### PR TITLE
fix botched refactor (it's lium.io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,8 @@ The CLI stores configuration in `~/.lium/config.yaml`. Key settings include:
 
 - `api_key`: Your Lium API key
 - `docker_username`/`docker_password`: Docker Hub credentials
-- `server_url`: "https://liumcompute.ai"
-- `tao_pay_url`: "https://pay-api.liumcompute.ai"
+- `server_url`: "https://lium.io"
+- `tao_pay_url`: "https://pay-api.lium.io"
 - `network`: Bittensor network ("finney" or "testnet")
 
 **Manual Configuration:**
@@ -344,8 +344,8 @@ The CLI stores configuration in `~/.lium/config.yaml`. Key settings include:
 api_key: "your-api-key-here"
 docker_username: "your-docker-username" 
 docker_password: "your-docker-password"
-server_url: "https://liumcompute.ai"
-tao_pay_url: "https://pay-api.liumcompute.ai"
+server_url: "https://lium.io"
+tao_pay_url: "https://pay-api.lium.io"
 network: "finney"
 ```
 

--- a/lium_cli/src/apps/config.py
+++ b/lium_cli/src/apps/config.py
@@ -64,8 +64,8 @@ class ConfigApp(BaseApp):
         self.config = {
             "docker_username": None,
             "docker_password": None,
-            "server_url": "https://liumcompute.ai",
-            "tao_pay_url": "https://pay-api.liumcompute.ai",
+            "server_url": "https://lium.io",
+            "tao_pay_url": "https://pay-api.lium.io",
             "api_key": None,
             "network": "finney",
         }

--- a/lium_cli/src/config.py
+++ b/lium_cli/src/config.py
@@ -6,8 +6,8 @@ class Defaults:
             "docker_username": None,
             "docker_password": None,
             "api_key": None,
-            "server_url": "https://liumcompute.ai",
-            "tao_pay_url": "https://pay-api.liumcompute.ai",
+            "server_url": "https://lium.io",
+            "tao_pay_url": "https://pay-api.lium.io",
             "network": "finney",
         }
 


### PR DESCRIPTION
it seems when ai was prompted "rename celium to lium" it turned celiumcompute.ai to liumcompute.ai instead of the proper lium.io. this pr fixes that.