### PR TITLE
feat: add ensure_config function to initialize API and SSH keys if no…

### DIFF
--- a/cli/commands/ps.py
+++ b/cli/commands/ps.py
@@ -12,7 +12,7 @@ from rich.text import Text
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from lium_sdk import Lium, PodInfo
-from ..utils import console, handle_errors, loading_status
+from ..utils import console, handle_errors, loading_status, ensure_config
 
 
 
@@ -162,6 +162,8 @@ def ps_command(pod_id: Optional[str]):
       lium ps                # Show all active pods
       lium ps eager-wolf-aa  # Show specific pod details
     """
+    ensure_config()
+
     with loading_status("Loading pods", ""):
         pods = Lium().ps()
     

--- a/cli/commands/up.py
+++ b/cli/commands/up.py
@@ -20,6 +20,7 @@ from ..utils import (
     resolve_executor_indices,
     timed_step_status,
     wait_ready_no_timeout,
+    ensure_config
 )
 from .ssh import get_ssh_method_and_pod, ssh_to_pod
 
@@ -306,6 +307,7 @@ def up_command(
       lium up --country US          # Filter by country code
       lium up --gpu H200 --country FR  # Combine multiple filters
     """
+    ensure_config()
     lium = Lium()
     
     # Resolve executor

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -409,3 +409,16 @@ def get_pytorch_template_id() -> Optional[str]:
     # Get the template with highest version
     newest_template = max(pytorch_templates, key=extract_pytorch_version)
     return newest_template.id
+
+
+def ensure_config():
+    from .commands.init import setup_api_key, setup_ssh_key
+    from .config import config
+
+    if not config.get('api.api_key'):
+        # Setup API key
+        setup_api_key()
+
+    if not config.get('ssh.key_path'):
+        # Setup SSH key
+        setup_ssh_key()


### PR DESCRIPTION
If a user runs lium up without an API key or SSH key, we will run the initialization logic first and then proceed with the up command.

https://www.loom.com/share/6cc54fe0c24b4215b45ae740e895c9c7 - demonstration