### PR TITLE
feat: Browser-based authentication for CLI

### DIFF
--- a/cli/auth.py
+++ b/cli/auth.py
@@ -1,0 +1,52 @@
+import os, sys, time, requests, webbrowser
+
+class quiet_fds:
+    """Redirect stdout/stderr to /dev/null (silences child processes)."""
+    def __enter__(self):
+        self._null = open(os.devnull, 'w')
+        self._stdout, self._stderr = os.dup(1), os.dup(2)
+        os.dup2(self._null.fileno(), 1)
+        os.dup2(self._null.fileno(), 2)
+        return self
+    def __exit__(self, *_):
+        os.dup2(self._stdout, 1)
+        os.dup2(self._stderr, 2)
+        os.close(self._stdout); os.close(self._stderr)
+        self._null.close()
+
+def init_auth():
+    url = "https://lium.io/api/cli-auth/init"
+    resp = requests.post(url,
+        json={"callback_url": "http://localhost:8080/auth/callback"},
+        headers={"Content-Type": "application/json"},
+        timeout=10
+    )
+    resp.raise_for_status()
+    return resp.json()["browser_url"], resp.json()["session_id"]
+
+def poll_auth(session_id, max_attempts=6, interval=5):  # 30 seconds timeout (6 * 5)
+    url = f"https://lium.io/api/cli-auth/poll/{session_id}"
+    for _ in range(max_attempts):
+        try:
+            resp = requests.get(url, timeout=5)
+            if resp.status_code == 200:
+                data = resp.json()
+                print(f"Status: {data.get('status')}")  # Print status
+                if data.get("status") == "approved":
+                    return data.get("api_key")
+        except KeyboardInterrupt:
+            return None
+        except Exception:
+            pass
+        time.sleep(interval)
+    return None
+
+def browser_auth():
+    """Execute browser authentication flow and return API key or None."""
+    try:
+        browser_url, session_id = init_auth()
+        with quiet_fds():
+            webbrowser.open(browser_url)
+        return poll_auth(session_id)
+    except Exception:
+        return None

--- a/cli/commands/init.py
+++ b/cli/commands/init.py
@@ -1,74 +1,60 @@
 """Initialize Lium CLI configuration."""
 
-import os
 import subprocess
-import sys
 from pathlib import Path
 
 import click
 from rich.prompt import Prompt
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-
+from ..auth import browser_auth
 from ..config import config
 from ..utils import console, handle_errors
 
 
-
-
 def setup_api_key() -> None:
-    """Setup API key in config."""
-    # Check if already set
+    """Setup API key using browser authentication."""
+    # Check if already configured
     current_key = config.get('api.api_key')
     if current_key:
-        masked_key = current_key[:8] + '...' + current_key[-4:] if len(current_key) > 12 else '***'
-        console.success(f"✓ API key already configured: {masked_key}")
-        
-        if Prompt.ask("[yellow]Update API key?[/yellow]", choices=["y", "n"], default="n") == "n":
-            return
+        return  # Already configured, skip silently
     
-    # Prompt for new key
-    api_key = Prompt.ask(
-        "[cyan]Enter your Lium API key (get from https://lium.ai/api-keys)[/cyan]"
-    )
+    # Browser authentication flow
+    console.info("Opening browser for authentication...")
+    api_key = browser_auth()
     
-    if not api_key:
-        console.error("No API key provided")
-        return
-    
-    # Save to config
-    config.set('api.api_key', api_key)
-    console.success(f"✓ API key saved")
+    if api_key:
+        config.set('api.api_key', api_key)
+    else:
+        console.error("Authentication failed")
 
 
 def setup_ssh_key() -> None:
     """Setup SSH key path in config."""
-    # Find available SSH keys
-    ssh_dir = Path.home() / ".ssh"
-    available_keys = []
+    # Skip if already configured
+    if config.get('ssh.key_path'):
+        return
     
-    for key_name in ["id_ed25519", "id_rsa", "id_ecdsa"]:
-        key_path = ssh_dir / key_name
-        if key_path.exists():
-            available_keys.append(key_path)
+    ssh_dir = Path.home() / ".ssh"
+    available_keys = [
+        ssh_dir / key_name 
+        for key_name in ["id_ed25519", "id_rsa", "id_ecdsa"]
+        if (ssh_dir / key_name).exists()
+    ]
     
     if not available_keys:
-        console.warning("⚠ No SSH keys found. Generating new SSH key...")
+        # Generate new key silently
         key_path = ssh_dir / "id_ed25519"
-        
         try:
-            subprocess.run(["ssh-keygen", "-t", "ed25519", "-f", str(key_path), "-N", "", "-q"], check=True)
-            console.success(f"✓ SSH key generated: {key_path}")
-            config.set('ssh.key_path', str(key_path))
+            subprocess.run(
+                ["ssh-keygen", "-t", "ed25519", "-f", str(key_path), "-N", "", "-q"],
+                check=True, capture_output=True
+            )
+            selected_key = key_path
+        except Exception:
             return
-        except Exception as e:
-            console.error(f"Failed to generate SSH key: {e}")
-            return
-    
-    # Auto-select if only one
-    if len(available_keys) == 1:
+    elif len(available_keys) == 1:
+        # Auto-select single key
         selected_key = available_keys[0]
-        console.success(f"✓ Using SSH key: {selected_key}")
     else:
         # Let user choose
         console.info("Multiple SSH keys found:")
@@ -82,15 +68,7 @@ def setup_ssh_key() -> None:
         )
         selected_key = available_keys[int(choice) - 1]
     
-    # Save to config
     config.set('ssh.key_path', str(selected_key))
-    console.success(f"✓ SSH key configured")
-
-
-def show_config() -> None:
-    """Display current configuration."""
-    from ..commands.config import _config_show
-    _config_show()
 
 
 @click.command("init")
@@ -103,15 +81,8 @@ def init_command():
     Example:
       lium init    # Interactive setup wizard
     """
-    console.info("Lium CLI Setup\n")
-    
-    # Setup API key
     setup_api_key()
-    
-    # Setup SSH key
     setup_ssh_key()
     
-    # Show final config
-    show_config()
-    
-    console.dim("You can now use 'lium ls' to list available executors")
+    if config.get('api.api_key'):
+        console.success("✓ Lium configured successfully")


### PR DESCRIPTION
## Summary
- Implement browser-based authentication flow that opens user's browser automatically
- Eliminate manual API key copying by polling for authentication approval
- Streamline `lium init` with minimal output (2 lines total)

## Changes
- Add new `cli/auth.py` module with browser authentication logic
- Update `lium init` to use browser auth instead of manual key entry  
- Auto-configure SSH keys without prompts when possible
- Add 30-second timeout for authentication polling
- Suppress browser launch output for cleaner UX

## Testing
- Run `lium init` - browser should open automatically
- Approve in browser - API key saved to config
- Reject or timeout - shows authentication failed message