### PR TITLE
Feature/autocomplete

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -1,5 +1,6 @@
 """Main CLI entry point for Lium."""
 import click
+import os
 from importlib.metadata import version, PackageNotFoundError
 from .themed_console import ThemedConsole
 from .commands.init import init_command
@@ -71,6 +72,10 @@ load_plugins(cli)
 
 def main():
     """Main entry point for the CLI."""
+    if not os.environ.get('_LIUM_COMPLETE'):
+        from .completion import ensure_completion
+        ensure_completion()
+    
     cli()
 
 

--- a/cli/commands/ls.py
+++ b/cli/commands/ls.py
@@ -102,6 +102,7 @@ def _specs_row(specs: Optional[Dict]) -> Dict[str, str]:
         "VRAM": _maybe_gi_from_capacity(d.get("capacity")),
         "RAM": _maybe_gi_from_big_number(ram.get("total")),
         "Disk": _maybe_gi_from_big_number(disk.get("total")),
+        "Country": _country_name(specs.get("location")),
         "PCIe": _maybe_int(d.get("pcie_speed")),
         "Mem": _maybe_int(d.get("memory_speed")),
         "TFLOPs": _maybe_int(d.get("graphics_speed")),
@@ -137,17 +138,14 @@ def _add_long_columns(t: Table) -> None:
 
     # fixed widths for numerics
     t.add_column("$/GPU·h", justify="right", width=8, no_wrap=True)
+    t.add_column("Location", justify="left", ratio=4, min_width=10, overflow="fold")
     t.add_column("VRAM",    justify="right", width=8, no_wrap=True)
     t.add_column("RAM",     justify="right", width=8, no_wrap=True)
     t.add_column("Disk",    justify="right", width=8, no_wrap=True)
-    t.add_column("PCIe",    justify="right", width=8, no_wrap=True)
     t.add_column("Mem",     justify="right", width=8, no_wrap=True)
-    t.add_column("TFLOPs",  justify="right", width=8, no_wrap=True)
     t.add_column("Net ↑",   justify="right", width=8, no_wrap=True)  # note the space
     t.add_column("Net ↓",   justify="right", width=8, no_wrap=True)
 
-    # absorb remaining width on the right with Location
-    t.add_column("Location", justify="left", ratio=4, min_width=10, overflow="fold")
 
 
 # Display Functions
@@ -222,15 +220,13 @@ def show_executors(
             huid_display,
             _cfg(exe),
             console.get_styled(_money(exe.price_per_gpu_hour), 'success'),
+            _country_name(exe.location),
             s["VRAM"],
             s["RAM"],
             s["Disk"],
-            s["PCIe"],
             s["Mem"],
-            s["TFLOPs"],
             s["NetUp"],
             s["NetDn"],
-            _country_name(exe.location),
         )
 
     console.info(table)

--- a/cli/completion.py
+++ b/cli/completion.py
@@ -1,0 +1,56 @@
+"""Shell completion setup for Lium CLI."""
+
+import os
+from pathlib import Path
+from typing import Dict, Tuple
+
+
+# Shell configurations: (config_file, completion_script)
+SHELLS: Dict[str, Tuple[str, str]] = {
+    "bash": ("~/.bashrc", 'eval "$(_LIUM_COMPLETE=bash_source lium)"'),
+    "zsh": ("~/.zshrc", 'eval "$(_LIUM_COMPLETE=zsh_source lium)"'),
+    "fish": ("~/.config/fish/config.fish", "_LIUM_COMPLETE=fish_source lium | source")
+}
+
+
+def ensure_completion() -> None:
+    """Silently ensure shell completion is installed."""
+    # Check if already processed this installation
+    marker_file = Path.home() / ".lium_completion_installed"
+    if marker_file.exists():
+        return
+    
+    shell = os.path.basename(os.environ.get("SHELL", "bash"))
+    if shell not in SHELLS:
+        return
+    
+    config_file, script = SHELLS[shell]
+    config_path = Path(config_file).expanduser()
+    
+    # Check if already installed in shell config
+    try:
+        if config_path.exists() and "_LIUM_COMPLETE" in config_path.read_text():
+            # Mark as installed to avoid future checks
+            marker_file.touch()
+            return
+    except IOError:
+        return
+    
+    # Install completion and notify user
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with config_path.open("a") as f:
+            f.write(f"\n# Lium CLI completion\n{script}\n")
+        # Mark as installed
+        marker_file.touch()
+        
+        # Show success message using ThemedConsole
+        from .themed_console import ThemedConsole
+        console = ThemedConsole()
+        console.success("✓ Shell completions have been configured for tab support")
+        console.info("✓ Please restart your terminal or run:")
+        console.info(f"  source {config_file}")
+        console.print()
+        
+    except IOError:
+        pass  # Silent fail


### PR DESCRIPTION
`lum up` -> Removed columns `tflops` and `net`, move location closer to the beginning.
`lium rm` -> add interactive choosing pod to rm.
<img width="1302" height="941" alt="lium_up, lium_rm" src="https://github.com/user-attachments/assets/9d6545b4-afd7-4c70-9b07-475d2a0ea9a9" />

completions:
- On first run, it will do silent setup completions to the console and suggest updating the console.
![completions](https://github.com/user-attachments/assets/9efc86c9-ad9f-4142-b26a-a5f3fb7010e1)
