### PR TITLE
use default docker template on automatic up flow

### DIFF
--- a/cli/commands/up.py
+++ b/cli/commands/up.py
@@ -263,7 +263,9 @@ def _create_and_connect_pod(
     else:
         # Auto mode with timed steps
         with timed_step_status(1, 3, "Renting machine"):
-            template = lium.get_template(get_pytorch_template_id())
+            template = lium.default_docker_template(executor)
+            if not template:
+                template = lium.get_template(get_pytorch_template_id())
             pod_info = lium.up(executor_id=executor.id, pod_name=name, template_id=template.id)
         
         with timed_step_status(2, 3, "Loading image"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "paramiko>=3.5.1",
     "docker>=7.1.0",
     "bittensor>=9.8.3",
-    "lium-sdk>=0.2.7",
+    "lium-sdk>=0.2.9",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
deploy only after this https://github.com/Datura-ai/lium-sdk/pull/9

will use existing backend endpoint https://lium.io/api/executors/default-docker-image?gpu_model=NVIDIA%20RTX%20A6000&driver_version=570.133.20 to choose default cuda template for the choosen executor.