### PR TITLE
DAH-1865 - Add deployment estimate and CLI source header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,4 +178,8 @@ notebooks/
 
 # Claude Code configuration
 CLAUDE.md
+AGENTS.md
 .python-version
+.cursor
+.codex
+.claude

--- a/docs/api/lium.sdk.ExecutorInfo.rst
+++ b/docs/api/lium.sdk.ExecutorInfo.rst
@@ -33,6 +33,7 @@
       ~ExecutorInfo.gpu_count
       ~ExecutorInfo.price_per_hour
       ~ExecutorInfo.price_per_gpu_hour
+      ~ExecutorInfo.price_per_gpu
       ~ExecutorInfo.location
       ~ExecutorInfo.specs
       ~ExecutorInfo.status

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -24,7 +24,7 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "price_gpu"
 
     executors_with_pareto = sorted(
         executors_with_pareto,
-        key=lambda x: (not x[1], x[0].price_per_gpu_hour or 0.0)
+        key=lambda x: (not x[1], x[0].price_per_gpu_hour or 0.0)  # TODO: DAH-1874 - deprecated
     )
 
     sorted_executors = [e for e, _ in executors_with_pareto]

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -202,6 +202,14 @@ def build_executors_table(
         huid += " (DinD)" if exe.docker_in_docker else ""
         huid_display = f"{console.get_styled('★', 'success')} {console.get_styled(huid, 'id')}" if is_pareto else f"  {console.get_styled(huid, 'id')}"
 
+        # Style download speed in yellow when below 100 Mbps
+        dl_val = _intish(s["Download"])
+        dl_display = (
+            console.get_styled(s["Download"], "warning")
+            if dl_val is not None and dl_val < 100
+            else s["Download"]
+        )
+
         table.add_row(
             str(idx),
             huid_display,
@@ -212,7 +220,7 @@ def build_executors_table(
             s["RAM"],
             s["Disk"],
             s["Upload"],
-            s["Download"],
+            dl_display,
             s["Ports"]
         )
 

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -105,7 +105,7 @@ def _specs_row(specs: Optional[Dict]) -> Dict[str, str]:
 def _sort_key_factory(name: str) -> Callable[[ExecutorInfo], Any]:
     """Get sort key function by name."""
     mapping = {
-        "price_gpu": lambda e: e.price_per_gpu_hour or 0.0,
+        "price_gpu": lambda e: e.price_per_gpu_hour or 0.0,  # TODO: DAH-1874 - deprecated
         "price_total": lambda e: e.price_per_hour or 0.0,
         "loc": lambda e: _country_name(e.location),
         "id": lambda e: e.huid,
@@ -214,7 +214,7 @@ def build_executors_table(
             str(idx),
             huid_display,
             _cfg(exe),
-            console.get_styled(_money(exe.price_per_gpu_hour), 'success'),
+            console.get_styled(_money(exe.price_per_gpu_hour), 'success'),  # TODO: DAH-1874 - deprecated
             _country_name(exe.location),
             s["VRAM"],
             s["RAM"],

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -115,7 +115,7 @@ def up_command(
     volume_id = parsed.get("volume_id")
     volume_create_params = parsed.get("volume_create_params")
 
-    lium = Lium()
+    lium = Lium(source="cli")
 
     action = ResolveExecutorAction()
     result = ui.load(
@@ -136,14 +136,13 @@ def up_command(
 
     executor = result.data["executor"]
 
-    if not yes:
-        confirm_msg = (
-            f"Acquire pod on {executor.huid} "
-            f"({executor.gpu_count}×{executor.gpu_type}) "
-            f"at ${executor.price_per_hour:.2f}/h?"
-        )
-        if not ui.confirm(confirm_msg):
-            return
+    def _show_estimate(est_secs, dl_speed, img_gb, is_slow, warning_msg):
+        est_min, est_sec = divmod(est_secs, 60)
+        est_str = f"{est_min}m {est_sec}s" if est_min else f"{est_sec}s"
+        img_str = f"image: ~{img_gb:.1f} GB, " if img_gb is not None else ""
+        ui.dim(f"Est. deploy time: ~{est_str} ({img_str}download: {int(dl_speed)} Mbps)")
+        if is_slow and warning_msg:
+            ui.warning(f"Warning: {warning_msg}")
 
     # Resolve or create template
     if docker_run_mode:
@@ -179,9 +178,38 @@ def up_command(
             "executor": executor
         })
 
+        if result.ok:
+            template = result.data["template"]
+            # API-based estimate using resolved template ID
+            try:
+                estimate = lium.get_deployment_estimate(executor.id, template.id)
+                est_secs = estimate.get("estimated_seconds")
+                if est_secs:
+                    specs = executor.specs or {}
+                    network = specs.get("network", {}) or {}
+                    dl_speed = network.get("download_speed") or 0
+                    raw_bytes = estimate.get("docker_image_size")
+                    img_gb = raw_bytes / 1e9 if raw_bytes is not None else None
+                    _show_estimate(
+                        est_secs, dl_speed, img_gb,
+                        estimate.get("is_slow_machine", False),
+                        estimate.get("warning_message"),
+                    )
+            except Exception:
+                pass
+
     if not result.ok:
         ui.error(result.error)
         return
+
+    if not yes:
+        confirm_msg = (
+            f"Acquire pod on {executor.huid} "
+            f"({executor.gpu_count}×{executor.gpu_type}) "
+            f"at ${executor.price_per_hour:.2f}/h?"
+        )
+        if not ui.confirm(confirm_msg):
+            return
 
     template = result.data["template"]
 

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -285,12 +285,12 @@ def extract_executor_metrics(executor: ExecutorInfo) -> Dict[str, float]:
     return {
         'price_per_gpu_hour': executor.price_per_gpu_hour or float('inf'), # TODO: DAH-1874 - deprecated
         'price_per_gpu': executor.price_per_gpu,
-        'vram_gb': (gpu_details.get("capacity", 0) / 1024) if gpu_details else 0,  # MiB to GB
-        'ram_gb': (ram_data.get("total", 0) / (1024 * 1024)) if ram_data else 0,  # KB to GB
-        'disk_gb': (disk_data.get("total", 0) / (1024 * 1024)) if disk_data else 0,  # KB to GB
-        'pcie_speed': gpu_details.get("pcie_speed", 0),
-        'memory_bandwidth': gpu_details.get("memory_speed", 0),
-        'tflops': gpu_details.get("graphics_speed", 0),
+        'vram_gb': ((gpu_details.get("capacity") or 0) / 1024) if gpu_details else 0,  # MiB to GB
+        'ram_gb': ((ram_data.get("total") or 0) / (1024 * 1024)) if ram_data else 0,  # KB to GB
+        'disk_gb': ((disk_data.get("total") or 0) / (1024 * 1024)) if disk_data else 0,  # KB to GB
+        'pcie_speed': gpu_details.get("pcie_speed") or 0,
+        'memory_bandwidth': gpu_details.get("memory_speed") or 0,
+        'tflops': gpu_details.get("graphics_speed") or 0,
         'net_up': network.get("upload_speed") or 0,
         'net_down': network.get("download_speed") or 0,
         'location_score': 1.0 if is_us else 0.0,  # US locations get higher score
@@ -306,8 +306,8 @@ def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
     # Priority metrics when prices are equal
     priority_metrics = ['total_bandwidth', 'location_score', 'net_down', 'net_up']
     
-    price_a = metrics_a.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
-    price_b = metrics_b.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
+    price_a = (v := metrics_a.get('price_per_gpu_hour')) if v is not None else float('inf')  # TODO: DAH-1874 - deprecated
+    price_b = (v := metrics_b.get('price_per_gpu_hour')) if v is not None else float('inf')  # TODO: DAH-1874 - deprecated
     
     # Special handling when prices are equal (common with GPU filtering)
     if abs(price_a - price_b) < 0.01:  # Prices are effectively equal

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -283,7 +283,8 @@ def extract_executor_metrics(executor: ExecutorInfo) -> Dict[str, float]:
     is_us = country == "UNITED STATES" or country_code == "US"
     
     return {
-        'price_per_gpu_hour': executor.price_per_gpu_hour or float('inf'),
+        'price_per_gpu_hour': executor.price_per_gpu_hour or float('inf'), # TODO: DAH-1874 - deprecated
+        'price_per_gpu': executor.price_per_gpu,
         'vram_gb': (gpu_details.get("capacity", 0) / 1024) if gpu_details else 0,  # MiB to GB
         'ram_gb': (ram_data.get("total", 0) / (1024 * 1024)) if ram_data else 0,  # KB to GB
         'disk_gb': (disk_data.get("total", 0) / (1024 * 1024)) if disk_data else 0,  # KB to GB
@@ -300,13 +301,13 @@ def extract_executor_metrics(executor: ExecutorInfo) -> Dict[str, float]:
 def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
     """Check if executor A dominates executor B in Pareto sense."""
     # Metrics to minimize (lower is better)
-    minimize_metrics = {'price_per_gpu_hour'}
+    minimize_metrics = {'price_per_gpu_hour'}  # TODO: DAH-1874 - deprecated
     
     # Priority metrics when prices are equal
     priority_metrics = ['total_bandwidth', 'location_score', 'net_down', 'net_up']
     
-    price_a = metrics_a.get('price_per_gpu_hour', float('inf'))
-    price_b = metrics_b.get('price_per_gpu_hour', float('inf'))
+    price_a = metrics_a.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
+    price_b = metrics_b.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
     
     # Special handling when prices are equal (common with GPU filtering)
     if abs(price_a - price_b) < 0.01:  # Prices are effectively equal

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -36,9 +36,9 @@ load_dotenv()
 class Lium:
     """Clean Unix-style SDK for Lium."""
 
-    def __init__(self, config: Optional[Config] = None):
+    def __init__(self, config: Optional[Config] = None, source: str = "sdk"):
         self.config = config or Config.load()
-        self.headers = {"X-API-KEY": self.config.api_key}
+        self.headers = {"X-API-KEY": self.config.api_key, "X-Source": source}
 
     @with_retry()
     def _request(
@@ -1291,6 +1291,24 @@ class Lium:
         }
         
         return self._request("POST", f"/pods/{pod.id}/restore", json=payload).json()
+
+    def get_deployment_estimate(self, executor_id: str, template_id: str) -> dict:
+        """Estimate deployment time for a template on an executor.
+
+        Args:
+            executor_id: Executor UUID.
+            template_id: Template UUID.
+
+        Returns:
+            Dict with ``estimated_seconds``, ``is_slow_machine``, ``warning_message``, ``is_cached_template``,
+            and ``docker_image_size`` (image size in bytes, or ``None`` if unknown).
+        """
+        resp = self._request(
+            "GET",
+            "/executors/deployment-estimate",
+            params={"executor_id": executor_id, "template_id": template_id},
+        )
+        return resp.json()
 
     def balance(self) -> float:
         """Get current account balance.

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -135,7 +135,7 @@ class Lium:
                 if gpu_name:
                     gpu_type = extract_gpu_type(gpu_name)
 
-        price_per_gpu = executor_dict.get("price_per_gpu", 0)
+        price_per_gpu = executor_dict.get("price_per_gpu") or 0
         price_per_hour = price_per_gpu * gpu_count
 
         return ExecutorInfo(

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -135,7 +135,8 @@ class Lium:
                 if gpu_name:
                     gpu_type = extract_gpu_type(gpu_name)
 
-        price_per_hour = executor_dict.get("price_per_hour", 0)
+        price_per_gpu = executor_dict.get("price_per_gpu", 0)
+        price_per_hour = price_per_gpu * gpu_count
 
         return ExecutorInfo(
             id=executor_dict.get("id", ""),
@@ -145,7 +146,8 @@ class Lium:
             gpu_type=gpu_type,
             gpu_count=gpu_count,
             price_per_hour=price_per_hour,
-            price_per_gpu_hour=price_per_hour / max(1, gpu_count),
+            price_per_gpu_hour=price_per_hour / max(1, gpu_count), # deprecated field
+            price_per_gpu=price_per_gpu,
             location=executor_dict.get("location", {}),
             specs=specs,
             status=executor_dict.get("status", "unknown"),
@@ -911,7 +913,8 @@ class Lium:
                 gpu_type=response.get("gpu_name", ""),
                 gpu_count=int(response.get("gpu_count", 0) or 0),
                 price_per_hour=0.0,
-                price_per_gpu_hour=0.0,
+                price_per_gpu_hour=0.0,  # TODO: DAH-1874 - deprecated
+                price_per_gpu=0.0,
                 location={},
                 specs={},
                 status="",

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1319,7 +1319,7 @@ class Lium:
         Returns:
             Floating-point balance value reported by ``/users/me``.
         """
-        return float(self._request("GET", "/users/me").json().get("balance", 0))
+        return float(self._request("GET", "/users/me").json().get("balance") or 0)
 
     def volumes(self) -> List[VolumeInfo]:
         """List all volumes for the current user.

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -13,7 +13,8 @@ class ExecutorInfo:
     gpu_type: str
     gpu_count: int
     price_per_hour: float
-    price_per_gpu_hour: float
+    price_per_gpu: float
+    price_per_gpu_hour: float # TODO: DAH-1874 - deprecated field
     location: Dict
     specs: Dict
     status: str


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1865](https://www.notion.so/DAH-1865)

## Problem

Users launching pods via `lium up` currently do not get an estimate of how long the deployment is likely to take, especially when the executor has slow download bandwidth or when the Docker image is large. The backend also does not receive structured information about which client (SDK vs CLI) is calling, which makes observability and rollout coordination harder.

Additionally, `ExecutorInfo` was previously computing `price_per_gpu_hour` by dividing `price_per_hour` from the API, when the API now provides `price_per_gpu` as the canonical per-GPU field. This made pricing logic brittle and inconsistent with the backend source of truth.

## Solution

- Add `price_per_gpu` as the canonical price field in `ExecutorInfo`, deriving `price_per_hour` from it (`price_per_gpu * gpu_count`). Mark `price_per_gpu_hour` as deprecated (tracked by DAH-1874).
- Add an SDK method to request a deployment-time estimate from the API for a given executor + template pair.
- Use this estimate in the `up` CLI flow (after template resolution, before final confirmation) to display a human-readable estimate and contextual warning when the machine is slow.
- Tag SDK / CLI calls with a simple `X-Source` header so the backend can distinguish request sources.
- Improve CLI listing UX by visually flagging executors with low download bandwidth.
- Extend `.gitignore` for local AI tooling config files.

## Changes

- **SDK models (`lium/sdk/models.py`)**
  - Add `price_per_gpu: float` field to `ExecutorInfo`.
  - Mark `price_per_gpu_hour` with a `# TODO: DAH-1874 - deprecated` comment; it remains for now to avoid breaking callsites.

- **SDK client (`lium/sdk/client.py`)**
  - Switch `price_per_hour` computation to `price_per_gpu * gpu_count` (using the new `price_per_gpu` field from the API response) instead of reading a raw `price_per_hour` value directly.
  - Populate `price_per_gpu` on all `ExecutorInfo` construction sites.
  - Extend `Lium.__init__` to accept a `source` argument (default `"sdk"`); add `X-Source` to the default request headers.
  - Introduce `get_deployment_estimate(executor_id, template_id)` which calls `GET /executors/deployment-estimate` and returns a dict containing `estimated_seconds`, `is_slow_machine`, `warning_message`, `is_cached_template`, and `docker_image_size`.

- **CLI `up` command (`lium/cli/up/command.py`)**
  - Construct the SDK client as `Lium(source="cli")`.
  - After template resolution, call `get_deployment_estimate`; render a dimmed estimate line and optional warning before the confirmation prompt.
  - Move the confirmation prompt to run after the estimate so the user has full context before committing.

- **CLI `ls` display (`lium/cli/ls/display.py`)**
  - Render the `Download` column in yellow (warning style) when below 100 Mbps.
  - Flag `price_per_gpu_hour` sort-key usages with `# TODO: DAH-1874` deprecation notes.

- **CLI utils (`lium/cli/utils.py`)**
  - Expose `price_per_gpu` in `extract_executor_metrics` alongside the deprecated `price_per_gpu_hour`.
  - Flag all `price_per_gpu_hour` Pareto-comparison references with deprecation TODO comments.

- **Docs (`docs/api/lium.sdk.ExecutorInfo.rst`)**
  - Add `price_per_gpu` to the `ExecutorInfo` autoclass member list.

- **Housekeeping (`.gitignore`)**
  - Ignore `AGENTS.md`, `.cursor`, `.codex`, and `.claude`.

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA – local test on reviewer side

## Other PRs

None.

## Risks

- `price_per_hour` is now derived as `price_per_gpu * gpu_count`. If the API returns `price_per_gpu = 0` (e.g. for executors without pricing data), `price_per_hour` will be 0. This was previously masked by reading `price_per_hour` from the API directly — validate the API consistently populates `price_per_gpu`.
- The new `/executors/deployment-estimate` call adds one extra API request in the `lium up` flow; failures are swallowed in a `try/except` and will not block pod creation.
- The `X-Source` header is a new contract; keep it stable if the backend starts validating it.
- The download-speed styling threshold (100 Mbps) is heuristic and may need tuning.
- `price_per_gpu_hour` is deprecated but still active — callsites marked `TODO: DAH-1874` should be migrated in the follow-up ticket.

## Test Cases

### Test Case 1 – Pricing computation

**Actions**
- Run `lium ls` and inspect the per-GPU price column for executors.

**Expected Output**
- Prices reflect `price_per_gpu` from the API; `price_per_hour` equals `price_per_gpu * gpu_count`.

### Test Case 2 – Fast executor with estimate

**Actions**
- Run `lium up` against an executor with good download bandwidth and a commonly-used template where the backend can compute `estimated_seconds`.

**Expected Output**
- After template resolution and before the final confirmation, the CLI prints a dimmed line with an estimated deploy time and download speed, and no warning message.

### Test Case 3 – Slow executor with warning

**Actions**
- Run `lium up` against an executor that the backend classifies as `is_slow_machine=True` with a non-trivial image size.

**Expected Output**
- The CLI prints the estimated deploy time and then a warning line using the backend-provided `warning_message`.

### Test Case 4 – Estimate API unavailable

**Actions**
- Simulate the estimate endpoint being unavailable or returning an unexpected payload.

**Expected Output**
- `lium up` still proceeds to the confirmation prompt without raising an exception; no estimate/warning is shown.

### Test Case 5 – Executor list download styling

**Actions**
- Run `lium ls` and observe the download-speed column.

**Expected Output**
- Download speeds below 100 Mbps render in yellow; others keep the existing style.

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)