### PR TITLE
fix: use correct price field from API

### DIFF
--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -135,7 +135,8 @@ class Lium:
                 if gpu_name:
                     gpu_type = extract_gpu_type(gpu_name)
 
-        price_per_hour = executor_dict.get("price_per_hour", 0)
+        price_per_gpu = executor_dict.get("price_per_gpu", 0) or 0
+        price_per_hour = price_per_gpu * gpu_count
 
         return ExecutorInfo(
             id=executor_dict.get("id", ""),
@@ -145,7 +146,7 @@ class Lium:
             gpu_type=gpu_type,
             gpu_count=gpu_count,
             price_per_hour=price_per_hour,
-            price_per_gpu_hour=price_per_hour / max(1, gpu_count),
+            price_per_gpu_hour=price_per_gpu,
             location=executor_dict.get("location", {}),
             specs=specs,
             status=executor_dict.get("status", "unknown"),


### PR DESCRIPTION
## Summary

Fix executor price display showing 0.00 $/GPU·h for all executors.

---

## Problem

`lium ls` displayed `0.00` for all executor prices. The API returns pricing in the `price_per_gpu` field, but the CLI was reading a non-existent `price_per_hour` field, which defaulted to `0`.

## Solution

Read `price_per_gpu` from the API response and compute `price_per_hour` as `price_per_gpu * gpu_count`.

## Changes

- Read `price_per_gpu` instead of `price_per_hour` from executor API response
- Compute `price_per_hour` from `price_per_gpu * gpu_count`
- Use `price_per_gpu` directly for `price_per_gpu_hour` instead of dividing back

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Risks

- Low risk. Only affects display of pricing data in `lium ls`.

## Test Cases
### Test Case 1

**Actions**
Run `lium ls --limit 5`

**Expected Output**
Prices should show actual values (e.g., 0.05, 0.10, 0.18) instead of 0.00.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described