### PR TITLE
Fix: update pay API URL to pay-api.lium.io

### DIFF
--- a/lium/sdk/config.py
+++ b/lium/sdk/config.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 class Config:
     api_key: str
     base_url: str = "https://lium.io/api"
-    base_pay_url: str = "https://pay-api.celiumcompute.ai"
+    base_pay_url: str = "https://pay-api.lium.io"
     ssh_key_path: Optional[Path] = None
 
     @classmethod
@@ -39,7 +39,7 @@ class Config:
         return cls(
             api_key=api_key,
             base_url=os.getenv("LIUM_BASE_URL", "https://lium.io/api"),
-            base_pay_url=os.getenv("LIUM_PAY_URL", "https://pay-api.celiumcompute.ai"),
+            base_pay_url=os.getenv("LIUM_PAY_URL", "https://pay-api.lium.io"),
             ssh_key_path=ssh_key
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.6"
+version = "0.0.7"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

### Task Link

N/A — hotfix

---

## Problem

The pay API URL `pay-api.celiumcompute.ai` returns 502 errors, causing `lium fund` command to fail during wallet registration.

## Solution

Updated the pay API base URL from `https://pay-api.celiumcompute.ai` to `https://pay-api.lium.io` in both the default value and the env fallback.

## Changes

- Updated `base_pay_url` default in `Config` dataclass
- Updated `LIUM_PAY_URL` env var fallback in `Config.load()`

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None

## Risks

- If `pay-api.lium.io` is not yet configured or DNS is not propagated, the fund command will fail similarly
- Users with `LIUM_PAY_URL` env var set will not be affected (their override takes precedence)

## Test Cases

### Test Case 1

**Actions**
Run `lium fund` and verify wallet registration step reaches the pay API without 502 errors.

**Expected Output**
Wallet registration proceeds normally (or fails with auth/wallet errors, not 502).

## Checklist

- [ ] Proper labels added
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described