### PR TITLE
Fix UnboundLocalError in lium ls command

### DIFF
--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -306,8 +306,8 @@ def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
     # Priority metrics when prices are equal
     priority_metrics = ['total_bandwidth', 'location_score', 'net_down', 'net_up']
     
-    price_a = (v := metrics_a.get('price_per_gpu_hour')) if v is not None else float('inf')  # TODO: DAH-1874 - deprecated
-    price_b = (v := metrics_b.get('price_per_gpu_hour')) if v is not None else float('inf')  # TODO: DAH-1874 - deprecated
+    price_a = metrics_a.get('price_per_gpu_hour') or float('inf')  # TODO: DAH-1874 - deprecated
+    price_b = metrics_b.get('price_per_gpu_hour') or float('inf')  # TODO: DAH-1874 - deprecated
     
     # Special handling when prices are equal (common with GPU filtering)
     if abs(price_a - price_b) < 0.01:  # Prices are effectively equal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.7"
+version = "0.0.8"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

### Task Link

N/A — bug fix discovered in production

---

## Problem

`lium ls` crashes with `Unexpected error: local variable 'v' referenced before assignment`.

The walrus operator (`:=`) was used inside a ternary expression incorrectly:
```python
price_a = (v := metrics_a.get('price_per_gpu_hour')) if v is not None else float('inf')
```
Python evaluates the condition (`v is not None`) **before** the true-branch where `v` gets assigned, causing `UnboundLocalError`.

## Solution

Replaced the broken walrus operator pattern with a simple `or` fallback:
```python
price_a = metrics_a.get('price_per_gpu_hour') or float('inf')
```

## Changes

- Fix two lines in `lium/cli/utils.py` in the `dominates()` function

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Risks

- Minimal — the fix is a 2-line change that replaces broken code with a simpler equivalent

## Test Cases

### Test Case 1

**Actions**
Run `lium ls` on a machine with valid API key.

**Expected Output**
Executor list displays correctly instead of crashing with UnboundLocalError.

## Checklist

- [ ] Proper labels added
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described