### PR TITLE
chore: add deprecation stubs for lium-cli and lium packages

### DIFF
--- a/.github/workflows/release-deprecate-lium-cli.yml
+++ b/.github/workflows/release-deprecate-lium-cli.yml
@@ -1,0 +1,35 @@
+name: Publish Deprecated lium-cli Stub
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: Build and publish lium-cli deprecation stub
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install build dependencies
+      run: pip install build
+
+    - name: Build stub package
+      working-directory: stubs/lium-cli
+      run: python -m build --sdist --wheel --outdir dist/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: stubs/lium-cli/dist/
+        verbose: true
+        print-hash: true

--- a/.github/workflows/release-lium-alias.yml
+++ b/.github/workflows/release-lium-alias.yml
@@ -1,0 +1,35 @@
+name: Publish lium Alias Stub
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: Build and publish lium alias stub
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install build dependencies
+      run: pip install build
+
+    - name: Build stub package
+      working-directory: stubs/lium
+      run: python -m build --sdist --wheel --outdir dist/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: stubs/lium/dist/
+        verbose: true
+        print-hash: true

--- a/stubs/lium-cli/README.md
+++ b/stubs/lium-cli/README.md
@@ -1,0 +1,11 @@
+# lium-cli (DEPRECATED)
+
+> **This package has been renamed to [`lium.io`](https://pypi.org/project/lium.io/).**
+
+Install the new package:
+
+```bash
+pip install lium.io
+```
+
+This package exists only as a redirect and will install `lium.io` automatically.

--- a/stubs/lium-cli/pyproject.toml
+++ b/stubs/lium-cli/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lium-cli"
+version = "0.7.0"
+description = "DEPRECATED: This package has been renamed to lium.io. Install lium.io instead."
+authors = [{ name = "Lium", email = "support@lium.io" }]
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 7 - Inactive",
+]
+dependencies = [
+    "lium.io",
+]
+
+[project.urls]
+homepage = "https://pypi.org/project/lium.io/"
+Repository = "https://github.com/Datura-ai/lium-io"

--- a/stubs/lium/README.md
+++ b/stubs/lium/README.md
@@ -1,0 +1,17 @@
+# lium
+
+> This is an alias package for [`lium.io`](https://pypi.org/project/lium.io/) — the Lium CLI.
+
+Install directly:
+
+```bash
+pip install lium.io
+```
+
+Or simply:
+
+```bash
+pip install lium
+```
+
+Both commands install the same CLI tool, available as the `lium` command.

--- a/stubs/lium/pyproject.toml
+++ b/stubs/lium/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lium"
+version = "0.1.0"
+description = "Alias package for lium.io — the Lium CLI. Install lium.io for the full package."
+authors = [{ name = "Lium", email = "support@lium.io" }]
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 4 - Beta",
+]
+dependencies = [
+    "lium.io",
+]
+
+[project.urls]
+homepage = "https://pypi.org/project/lium.io/"
+Repository = "https://github.com/Datura-ai/lium-io"


### PR DESCRIPTION
## Summary

- Add `lium-cli` deprecation stub that redirects `pip install lium-cli` to `lium.io`
- Add `lium` alias stub that redirects `pip install lium` to `lium.io`
- Add GitHub Actions workflows for publishing both stubs to PyPI (manual trigger)

After publishing, users can install the CLI via any of:
- `pip install lium.io` (canonical)
- `pip install lium` (alias)
- `pip install lium-cli` (deprecated, redirect)

## Test plan

- [ ] Verify `stubs/lium-cli` builds locally: `cd stubs/lium-cli && python -m build`
- [ ] Verify `stubs/lium` builds locally: `cd stubs/lium && python -m build`
- [ ] Publish `lium-cli` stub via workflow dispatch
- [ ] Publish `lium` stub via workflow dispatch
- [ ] Confirm `pip install lium` installs `lium.io` and `lium` command works