### PR TITLE
DAH-1924 - Sort ls by download speed by default

### DIFF
--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -11,7 +11,7 @@ from . import validation, display
 from .actions import GetExecutorsAction
 
 
-def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "price_gpu") -> List[ExecutorInfo]:
+def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download") -> List[ExecutorInfo]:
     """Load and store executors without displaying them."""
     lium = Lium()
     executors = lium.ls(gpu_type=gpu_type)
@@ -24,7 +24,7 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "price_gpu"
 
     executors_with_pareto = sorted(
         executors_with_pareto,
-        key=lambda x: (not x[1], x[0].price_per_gpu_hour or 0.0)  # TODO: DAH-1874 - deprecated
+        key=lambda x: (not x[1], -(x[0].specs.get("network", {}).get("ema_verifyx_download_speed") or 0))
     )
 
     sorted_executors = [e for e, _ in executors_with_pareto]
@@ -42,8 +42,8 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "price_gpu"
 @click.option(
     "--sort",
     "sort_by",
-    type=click.Choice(["price_gpu", "price_total", "loc", "id", "gpu"]),
-    default="price_gpu",
+    type=click.Choice(["download", "price_gpu", "price_total", "loc", "id", "gpu"]),
+    default="download",
     help="Sort result by the chosen field.",
 )
 @click.option("--limit", type=int, default=None, help="Limit number of rows shown.")

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -24,7 +24,7 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download")
 
     executors_with_pareto = sorted(
         executors_with_pareto,
-        key=lambda x: (not x[1], -(x[0].specs.get("network", {}).get("ema_verifyx_download_speed") or 0))
+        key=lambda x: (not x[1], -x[0].download_speed)
     )
 
     sorted_executors = [e for e, _ in executors_with_pareto]

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -97,7 +97,7 @@ def _specs_row(specs: Optional[Dict]) -> Dict[str, str]:
         "Country": _country_name(specs.get("location")),
         "PCIe": _maybe_int(d.get("pcie_speed")),
         "Upload": _maybe_int(net.get("upload_speed")),
-        "Download": _maybe_int(net.get("download_speed")),
+        "Download": _maybe_int(net.get("ema_verifyx_download_speed") or net.get("download_speed")),
         "Ports": _maybe_int(specs.get("available_port_count")),
     }
 
@@ -105,13 +105,14 @@ def _specs_row(specs: Optional[Dict]) -> Dict[str, str]:
 def _sort_key_factory(name: str) -> Callable[[ExecutorInfo], Any]:
     """Get sort key function by name."""
     mapping = {
+        "download": lambda e: -(e.specs.get("network", {}).get("ema_verifyx_download_speed") or 0),
         "price_gpu": lambda e: e.price_per_gpu_hour or 0.0,  # TODO: DAH-1874 - deprecated
         "price_total": lambda e: e.price_per_hour or 0.0,
         "loc": lambda e: _country_name(e.location),
         "id": lambda e: e.huid,
         "gpu": lambda e: (e.gpu_type, e.gpu_count),
     }
-    return mapping.get(name, mapping["price_gpu"])
+    return mapping.get(name, mapping["download"])
 
 
 def _add_table_columns(t: Table) -> None:
@@ -144,7 +145,7 @@ def format_tip() -> str:
 
 def build_executors_table(
     executors: List[ExecutorInfo],
-    sort_by: str = "price_gpu",
+    sort_by: str = "download",
     limit: Optional[int] = None,
     show_pareto: bool = True
 ) -> tuple[Table, List[ExecutorInfo], str, str]:

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -105,7 +105,7 @@ def _specs_row(specs: Optional[Dict]) -> Dict[str, str]:
 def _sort_key_factory(name: str) -> Callable[[ExecutorInfo], Any]:
     """Get sort key function by name."""
     mapping = {
-        "download": lambda e: -(e.specs.get("network", {}).get("ema_verifyx_download_speed") or 0),
+        "download": lambda e: -e.download_speed,
         "price_gpu": lambda e: e.price_per_gpu_hour or 0.0,  # TODO: DAH-1874 - deprecated
         "price_total": lambda e: e.price_per_hour or 0.0,
         "loc": lambda e: _country_name(e.location),

--- a/lium/cli/ls/validation.py
+++ b/lium/cli/ls/validation.py
@@ -11,7 +11,7 @@ def validate(
     """Validate ls command options, returns (is_valid, error_message)."""
 
     # Validate sort_by
-    valid_sort_options = ["price_gpu", "price_total", "loc", "id", "gpu"]
+    valid_sort_options = ["download", "price_gpu", "price_total", "loc", "id", "gpu"]
     if sort_by not in valid_sort_options:
         return False, f"Invalid sort option: {sort_by}"
 

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -292,97 +292,113 @@ def extract_executor_metrics(executor: ExecutorInfo) -> Dict[str, float]:
         'memory_bandwidth': gpu_details.get("memory_speed") or 0,
         'tflops': gpu_details.get("graphics_speed") or 0,
         'net_up': network.get("upload_speed") or 0,
-        'net_down': network.get("download_speed") or 0,
+        'net_down': network.get("ema_verifyx_download_speed") or network.get("download_speed") or 0,
         'location_score': 1.0 if is_us else 0.0,  # US locations get higher score
-        'total_bandwidth': (network.get("upload_speed") or 0) + (network.get("download_speed") or 0),  # Combined bandwidth
+        'total_bandwidth': (network.get("upload_speed") or 0) + (network.get("ema_verifyx_download_speed") or network.get("download_speed") or 0),  # Combined bandwidth
     }
 
 
 def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
-    """Check if executor A dominates executor B in Pareto sense."""
+    """Check if executor A dominates executor B in Pareto sense.
+
+    Download speed is always evaluated first: if A is >10% faster than B, A
+    dominates immediately. If B is >10% faster, A cannot dominate. Only when
+    speeds are within 10% of each other does the rest of the comparison run.
+    """
     # Metrics to minimize (lower is better)
-    minimize_metrics = {'price_per_gpu_hour'}  # TODO: DAH-1874 - deprecated
-    
-    # Priority metrics when prices are equal
-    priority_metrics = ['total_bandwidth', 'location_score', 'net_down', 'net_up']
-    
-    price_a = (v := metrics_a.get('price_per_gpu_hour')) if v is not None else float('inf')  # TODO: DAH-1874 - deprecated
-    price_b = (v := metrics_b.get('price_per_gpu_hour')) if v is not None else float('inf')  # TODO: DAH-1874 - deprecated
-    
-    # Special handling when prices are equal (common with GPU filtering)
+    minimize_metrics = {'price_per_gpu_hour', 'price_per_gpu'}  # TODO: DAH-1874 - deprecated price_per_gpu_hour
+
+    # --- Download speed: unconditional first priority ---
+    net_down_a = metrics_a.get('net_down', 0) or 0
+    net_down_b = metrics_b.get('net_down', 0) or 0
+    dl_threshold = 0.1 * max(net_down_a, net_down_b)
+
+    if net_down_a > net_down_b + dl_threshold:
+        return True   # A is significantly faster — A dominates
+    if net_down_b > net_down_a + dl_threshold:
+        return False  # B is significantly faster — A cannot dominate
+
+    # --- Download speeds are similar; fall back to price-based logic ---
+    secondary_metrics = ['total_bandwidth', 'location_score', 'net_up']
+
+    price_a = metrics_a.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
+    price_b = metrics_b.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
+
     if abs(price_a - price_b) < 0.01:  # Prices are effectively equal
-        # Compare based on priority metrics
-        for metric in priority_metrics:
+        for metric in secondary_metrics:
             val_a = metrics_a.get(metric, 0) or 0
             val_b = metrics_b.get(metric, 0) or 0
-            
-            # Significant difference threshold (10% for bandwidth, any diff for location)
             threshold = 0.1 * max(val_a, val_b) if metric != 'location_score' else 0
-            
+
             if val_a > val_b + threshold:
-                # A is significantly better in this priority metric
                 return True
             elif val_b > val_a + threshold:
-                # B is significantly better in this priority metric
                 return False
-        
-        # If all priority metrics are similar, compare all metrics
+
+        # All secondary metrics similar — compare everything else
         at_least_one_better = False
+        skip = {'net_down'} | set(secondary_metrics)
         for metric in metrics_a:
-            if metric in priority_metrics:
-                continue  # Already checked
-            
+            if metric in skip:
+                continue
             val_a = metrics_a[metric] or 0
             val_b = metrics_b.get(metric, 0) or 0
-            
             if val_a > val_b:
                 at_least_one_better = True
             elif val_a < val_b:
                 return False
-        
         return at_least_one_better
-    
+
     # Standard Pareto domination when prices differ
+    # Use a 0.1% relative tolerance to absorb floating-point noise from unit
+    # conversions (e.g. KB→GB for RAM), so a 7 MB difference on a 1.5 TB node
+    # doesn't block a genuine domination.
     at_least_one_better = False
-    
     for metric in metrics_a:
+        if metric == 'net_down':
+            continue  # already decided above
         val_a = metrics_a[metric] or 0
         val_b = metrics_b.get(metric, 0) or 0
+        eps = 0.001 * max(abs(val_a), abs(val_b))
 
         if metric in minimize_metrics:
-            # For minimize metrics, A is better if it's lower
-            if val_a < val_b:
+            if val_a < val_b - eps:
                 at_least_one_better = True
-            elif val_a > val_b:
-                return False  # B is better in this metric
+            elif val_a > val_b + eps:
+                return False
         else:
-            # For maximize metrics, A is better if it's higher
-            if val_a > val_b:
+            if val_a > val_b + eps:
                 at_least_one_better = True
-            elif val_a < val_b:
-                return False  # B is better in this metric
-    
+            elif val_a < val_b - eps:
+                return False
+
     return at_least_one_better
+
+
+MIN_DOWNLOAD_MBPS = 100.0  # mirrors MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS in the validator
 
 
 def calculate_pareto_frontier(executors: List[ExecutorInfo]) -> List[bool]:
     """Calculate which executors are on the Pareto frontier.
-    
+
     Returns a list of booleans indicating if each executor is Pareto-optimal.
+    Executors below MIN_DOWNLOAD_MBPS are disqualified before domination checks.
     """
-    # Extract metrics for all executors
     metrics_list = [extract_executor_metrics(e) for e in executors]
-    
-    # Mark each executor as Pareto-optimal or not
+
     is_pareto = []
     for i, metrics_i in enumerate(metrics_list):
+        if (metrics_i.get('net_down') or 0) < MIN_DOWNLOAD_MBPS:
+            is_pareto.append(False)
+            continue
+
         dominated = False
         for j, metrics_j in enumerate(metrics_list):
             if i != j and dominates(metrics_j, metrics_i):
                 dominated = True
                 break
         is_pareto.append(not dominated)
-    
+
     return is_pareto
 
 

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -292,10 +292,17 @@ def extract_executor_metrics(executor: ExecutorInfo) -> Dict[str, float]:
         'memory_bandwidth': gpu_details.get("memory_speed") or 0,
         'tflops': gpu_details.get("graphics_speed") or 0,
         'net_up': network.get("upload_speed") or 0,
-        'net_down': network.get("ema_verifyx_download_speed") or network.get("download_speed") or 0,
+        'net_down': executor.download_speed,
         'location_score': 1.0 if is_us else 0.0,  # US locations get higher score
-        'total_bandwidth': (network.get("upload_speed") or 0) + (network.get("ema_verifyx_download_speed") or network.get("download_speed") or 0),  # Combined bandwidth
+        'total_bandwidth': (network.get("upload_speed") or 0) + executor.download_speed,  # Combined bandwidth
     }
+
+
+_MINIMIZE_METRICS = frozenset({'price_per_gpu_hour', 'price_per_gpu'})  # TODO: DAH-1874 - deprecated price_per_gpu_hour
+_SECONDARY_METRICS = ('total_bandwidth', 'location_score', 'net_up')
+# Metrics excluded from the equal-price residual sweep: already handled above, or
+# minimize-metrics whose direction the residual loop does not account for.
+_EQUAL_PRICE_SKIP = frozenset({'net_down'} | set(_SECONDARY_METRICS) | _MINIMIZE_METRICS)
 
 
 def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
@@ -305,12 +312,9 @@ def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
     dominates immediately. If B is >10% faster, A cannot dominate. Only when
     speeds are within 10% of each other does the rest of the comparison run.
     """
-    # Metrics to minimize (lower is better)
-    minimize_metrics = {'price_per_gpu_hour', 'price_per_gpu'}  # TODO: DAH-1874 - deprecated price_per_gpu_hour
-
     # --- Download speed: unconditional first priority ---
-    net_down_a = metrics_a.get('net_down', 0) or 0
-    net_down_b = metrics_b.get('net_down', 0) or 0
+    net_down_a = metrics_a.get('net_down') or 0
+    net_down_b = metrics_b.get('net_down') or 0
     dl_threshold = 0.1 * max(net_down_a, net_down_b)
 
     if net_down_a > net_down_b + dl_threshold:
@@ -319,27 +323,29 @@ def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
         return False  # B is significantly faster — A cannot dominate
 
     # --- Download speeds are similar; fall back to price-based logic ---
-    secondary_metrics = ['total_bandwidth', 'location_score', 'net_up']
-
     price_a = metrics_a.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
     price_b = metrics_b.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
 
     if abs(price_a - price_b) < 0.01:  # Prices are effectively equal
-        for metric in secondary_metrics:
+        # Check secondary metrics in priority order; both A and B must be
+        # compared across ALL of them before declaring domination.
+        at_least_one_better = False
+        for metric in _SECONDARY_METRICS:
             val_a = metrics_a.get(metric, 0) or 0
             val_b = metrics_b.get(metric, 0) or 0
             threshold = 0.1 * max(val_a, val_b) if metric != 'location_score' else 0
 
             if val_a > val_b + threshold:
-                return True
+                at_least_one_better = True
             elif val_b > val_a + threshold:
                 return False
 
-        # All secondary metrics similar — compare everything else
-        at_least_one_better = False
-        skip = {'net_down'} | set(secondary_metrics)
+        if at_least_one_better:
+            return True
+
+        # All secondary metrics similar — compare remaining maximize-metrics
         for metric in metrics_a:
-            if metric in skip:
+            if metric in _EQUAL_PRICE_SKIP:
                 continue
             val_a = metrics_a[metric] or 0
             val_b = metrics_b.get(metric, 0) or 0
@@ -349,7 +355,7 @@ def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
                 return False
         return at_least_one_better
 
-    # Standard Pareto domination when prices differ
+    # Standard Pareto domination when prices differ.
     # Use a 0.1% relative tolerance to absorb floating-point noise from unit
     # conversions (e.g. KB→GB for RAM), so a 7 MB difference on a 1.5 TB node
     # doesn't block a genuine domination.
@@ -361,7 +367,7 @@ def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
         val_b = metrics_b.get(metric, 0) or 0
         eps = 0.001 * max(abs(val_a), abs(val_b))
 
-        if metric in minimize_metrics:
+        if metric in _MINIMIZE_METRICS:
             if val_a < val_b - eps:
                 at_least_one_better = True
             elif val_a > val_b + eps:

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -33,6 +33,12 @@ class ExecutorInfo:
         gpu_details = self.specs.get('gpu', {}).get('details', [])
         return gpu_details[0].get('name', '') if gpu_details else ''
 
+    @property
+    def download_speed(self) -> float:
+        """Verified EMA download speed in Mbps, falling back to raw download_speed."""
+        net = self.specs.get("network", {})
+        return net.get("ema_verifyx_download_speed") or net.get("download_speed") or 0.0
+
 
 @dataclass
 class PodInfo:


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1924](https://www.notion.so/DAH-1924)

## Problem

The `lium ls` command sorted executors by `price_gpu` by default, which did not reflect network performance. Download speed (`ema_verifyx_download_speed`) was not exposed as a sort option and was not used in the Pareto frontier calculation.

## Solution

- Add `download` as a sort option and make it the new default for `lium ls`.
- Use `ema_verifyx_download_speed` (verified EMA value) instead of the raw `download_speed` for display, sorting, and Pareto metrics.
- Refactor `dominates()` so download speed is the unconditional first priority: if one executor is >10% faster it immediately dominates (or cannot dominate), falling back to price-based logic only when speeds are within 10%.

## Changes

- `lium/sdk/models.py` — added `ExecutorInfo.download_speed` property that resolves `ema_verifyx_download_speed` with fallback to `download_speed`; eliminates duplicated resolution logic across call sites.
- `lium/cli/ls/command.py` — default `sort_by` changed from `price_gpu` to `download`; sort key in `ls_store_executor` uses `executor.download_speed`.
- `lium/cli/ls/display.py` — added `download` sort key using `executor.download_speed`; updated `build_executors_table` default; Download column uses `ema_verifyx_download_speed` with fallback.
- `lium/cli/ls/validation.py` — added `download` to `valid_sort_options`.
- `lium/cli/utils.py` — `extract_executor_metrics` uses `executor.download_speed`; `dominates()` rewritten (see below); `_MINIMIZE_METRICS`, `_SECONDARY_METRICS`, `_EQUAL_PRICE_SKIP` hoisted to module-level constants.

## `dominates()` Logic

The function determines whether executor A Pareto-dominates executor B. The rewrite introduces a strict priority order:

**1. Download speed gate (unconditional)**
Compare `net_down` with a 10% relative threshold:
- A is >10% faster → A dominates immediately (`return True`)
- B is >10% faster → A cannot dominate (`return False`)
- Within 10% → fall through to price comparison

This replaces the old approach where download speed was just one of several equal-priority metrics.

**2. Equal-price branch (`|price_a − price_b| < $0.01`)**
When prices are effectively the same, secondary metrics are compared in priority order: `total_bandwidth` → `location_score` → `net_up`. Previously, a single win on any secondary metric caused an early `return True` without checking whether B wins on a later metric — a Pareto correctness bug. Now all three are evaluated before declaring domination.

Price metrics (`price_per_gpu_hour`, `price_per_gpu`) are excluded from the residual sweep via `_EQUAL_PRICE_SKIP`. Previously they leaked into the residual loop where the direction (lower = better) was not respected, causing incorrect `return False` for sub-cent price differences.

**3. Standard Pareto (prices differ)**
Full metric sweep with a 0.1% relative epsilon to absorb floating-point noise from unit conversions (MiB→GB for VRAM, KB→GB for RAM/disk). `net_down` is skipped here since it was already decided in step 1.

## Deployment Steps

Use GitHub Action.

## Review Request

- [ ] Just code review
- [ ] QA – local test on reviewer side

## Other PRs

## Risks

- Executors without `ema_verifyx_download_speed` (older agents) fall back to `download_speed`, so display and sorting remain functional.
- Changing the default sort order changes what users see first — intended behavior per the task.
- `dominates()` behaviour changes may shift which executors appear as Pareto-optimal. Executors below `MIN_DOWNLOAD_MBPS` (100 Mbps) are now always excluded from the frontier.

## Test Cases

### Test Case 1

**Actions**
Run `lium ls` without any `--sort` flag.

**Expected Output**
Executors are ordered by `ema_verifyx_download_speed` descending. The Download column reflects the EMA-verified value.

### Test Case 2

**Actions**
Run `lium ls --sort price_gpu`.

**Expected Output**
Executors are sorted by price per GPU hour as before.

### Test Case 3

**Actions**
Compare the Pareto frontier result for two executors with equal price but different secondary metrics (e.g. same download speed, A has higher upload, B has better location).

**Expected Output**
All secondary metrics are considered before domination is declared — no early exit on the first win.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [ ] PR description is clear and complete
- [ ] Risks are documented
- [ ] Tests are described