### PR TITLE
Enable CLI binary releases - DAH-1873

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,21 +4,45 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release'
+        description: "Version to release"
         required: true
         type: string
 
+env:
+  RELEASE_VERSION: ${{ inputs.version }}
+  RELEASE_TAG: v${{ inputs.version }}
+
 jobs:
-  build:
+  build-python:
     name: Build Python distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: "3.12"
+
+    - name: Validate requested version
+      run: |
+        python - <<'PY'
+        import tomllib
+        from pathlib import Path
+        import os
+
+        version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+        about_ns = {}
+        exec(Path("lium/__about__.py").read_text(), about_ns)
+        module_version = about_ns["__version__"]
+        requested = os.environ["RELEASE_VERSION"]
+        if requested != version:
+            raise SystemExit(f"Requested version {requested!r} does not match pyproject version {version!r}")
+        if module_version != version:
+            raise SystemExit(f"lium.__about__.__version__ {module_version!r} does not match pyproject version {version!r}")
+        PY
 
     - name: Install dependencies
       run: |
@@ -28,14 +52,150 @@ jobs:
     - name: Build package
       run: python -m build --sdist --wheel --outdir dist/
 
-    - name: Upload artifact
+    - name: Upload Python artifact
       uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: python-dist
         path: dist/
 
+  build-linux-binary:
+    name: Build Linux binary
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build Linux binary in Docker
+      run: |
+        mkdir -p dist
+        docker build --platform linux/amd64 -f Dockerfile.build -t lium-build:${GITHUB_SHA} .
+        docker create --name lium-extract lium-build:${GITHUB_SHA} true
+        docker cp lium-extract:/app/dist/lium dist/lium-linux-amd64
+        docker rm -f lium-extract
+        chmod +x dist/lium-linux-amd64
+
+    - name: Smoke test Linux binary
+      run: |
+        ./dist/lium-linux-amd64 --version
+        ./dist/lium-linux-amd64 --help >/dev/null
+
+    - name: Generate Linux checksum
+      run: |
+        cd dist
+        sha256sum lium-linux-amd64 > lium-linux-amd64.sha256
+
+    - name: Upload Linux artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: lium-linux-amd64
+        path: |
+          dist/lium-linux-amd64
+          dist/lium-linux-amd64.sha256
+
+  build-macos-binary:
+    name: Build macOS binary
+    runs-on: macos-14
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install uv
+      run: python -m pip install --upgrade pip uv
+
+    - name: Build macOS binary
+      run: |
+        uv sync --frozen --extra dev
+        uv run pyinstaller lium.spec --clean
+        mv dist/lium dist/lium-darwin-arm64
+        chmod +x dist/lium-darwin-arm64
+
+    - name: Smoke test macOS binary
+      run: |
+        ./dist/lium-darwin-arm64 --version
+        ./dist/lium-darwin-arm64 --help >/dev/null
+
+    - name: Generate macOS checksum
+      run: |
+        cd dist
+        shasum -a 256 lium-darwin-arm64 > lium-darwin-arm64.sha256
+
+    - name: Upload macOS artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: lium-darwin-arm64
+        path: |
+          dist/lium-darwin-arm64
+          dist/lium-darwin-arm64.sha256
+
+  release-assets:
+    name: Publish GitHub release assets
+    needs:
+    - build-python
+    - build-linux-binary
+    - build-macos-binary
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download Python artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: python-dist
+        path: release-assets/python-dist
+
+    - name: Download Linux artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: lium-linux-amd64
+        path: release-assets/linux
+
+    - name: Download macOS artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: lium-darwin-arm64
+        path: release-assets/macos
+
+    - name: Assemble release assets
+      run: |
+        cp scripts/install.sh release-assets/install.sh
+        chmod +x release-assets/install.sh
+        {
+          cat release-assets/linux/lium-linux-amd64.sha256
+          cat release-assets/macos/lium-darwin-arm64.sha256
+        } > release-assets/checksums.txt
+
+    - name: Create or update GitHub release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
+          gh release create "$RELEASE_TAG" \
+            --target "$GITHUB_SHA" \
+            --title "Lium CLI ${RELEASE_VERSION}" \
+            --notes "Binary and Python package artifacts for ${RELEASE_VERSION}."
+
+        gh release upload "$RELEASE_TAG" \
+          release-assets/install.sh \
+          release-assets/checksums.txt \
+          release-assets/linux/lium-linux-amd64 \
+          release-assets/linux/lium-linux-amd64.sha256 \
+          release-assets/macos/lium-darwin-arm64 \
+          release-assets/macos/lium-darwin-arm64.sha256 \
+          release-assets/python-dist/* \
+          --clobber
+
   approve-and-publish:
-    needs: build
+    needs: build-python
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -46,7 +206,7 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v4
       with:
-        name: dist
+        name: python-dist
         path: dist/
 
     - name: Publish package distributions to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,38 @@ jobs:
         name: python-dist
         path: dist/
 
-  build-linux-binary:
-    name: Build Linux binary
+  validate-binary-targets:
+    name: Validate binary target matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install pytest
+      run: python -m pip install --upgrade pip pytest
+
+    - name: Verify installer and workflow target coverage
+      run: pytest test/test_release_binary_targets.py
+
+  build-linux-binary:
+    name: Build Linux binary (${{ matrix.asset_name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - runner: ubuntu-latest
+          platform: linux/amd64
+          asset_name: lium-linux-amd64
+        - runner: ubuntu-24.04-arm
+          platform: linux/arm64
+          asset_name: lium-linux-arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     steps:
@@ -69,33 +98,44 @@ jobs:
     - name: Build Linux binary in Docker
       run: |
         mkdir -p dist
-        docker build --platform linux/amd64 -f Dockerfile.build -t lium-build:${GITHUB_SHA} .
-        docker create --name lium-extract lium-build:${GITHUB_SHA} true
-        docker cp lium-extract:/app/dist/lium dist/lium-linux-amd64
+        docker rm -f lium-extract >/dev/null 2>&1 || true
+        docker build --platform ${{ matrix.platform }} -f Dockerfile.build -t lium-build:${GITHUB_SHA}-${{ matrix.asset_name }} .
+        docker create --name lium-extract lium-build:${GITHUB_SHA}-${{ matrix.asset_name }} true
+        docker cp lium-extract:/app/dist/lium dist/${{ matrix.asset_name }}
         docker rm -f lium-extract
-        chmod +x dist/lium-linux-amd64
+        chmod +x dist/${{ matrix.asset_name }}
 
     - name: Smoke test Linux binary
       run: |
-        ./dist/lium-linux-amd64 --version
-        ./dist/lium-linux-amd64 --help >/dev/null
+        ./dist/${{ matrix.asset_name }} --version
+        ./dist/${{ matrix.asset_name }} --help >/dev/null
 
     - name: Generate Linux checksum
       run: |
         cd dist
-        sha256sum lium-linux-amd64 > lium-linux-amd64.sha256
+        sha256sum ${{ matrix.asset_name }} > ${{ matrix.asset_name }}.sha256
 
     - name: Upload Linux artifact
       uses: actions/upload-artifact@v4
       with:
-        name: lium-linux-amd64
+        name: ${{ matrix.asset_name }}
         path: |
-          dist/lium-linux-amd64
-          dist/lium-linux-amd64.sha256
+          dist/${{ matrix.asset_name }}
+          dist/${{ matrix.asset_name }}.sha256
 
   build-macos-binary:
-    name: Build macOS binary
-    runs-on: macos-14
+    name: Build macOS binary (${{ matrix.asset_name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - runner: macos-14
+          asset_name: lium-darwin-arm64
+          expected_machine: arm64
+        - runner: macos-15-intel
+          asset_name: lium-darwin-amd64
+          expected_machine: x86_64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     steps:
@@ -111,33 +151,39 @@ jobs:
 
     - name: Build macOS binary
       run: |
+        actual_machine="$(uname -m)"
+        if [[ "$actual_machine" != "${{ matrix.expected_machine }}" ]]; then
+          echo "Expected macOS runner architecture ${{ matrix.expected_machine }}, got $actual_machine" >&2
+          exit 1
+        fi
         uv sync --frozen --extra dev
         uv run pyinstaller lium.spec --clean
-        mv dist/lium dist/lium-darwin-arm64
-        chmod +x dist/lium-darwin-arm64
+        mv dist/lium dist/${{ matrix.asset_name }}
+        chmod +x dist/${{ matrix.asset_name }}
 
     - name: Smoke test macOS binary
       run: |
-        ./dist/lium-darwin-arm64 --version
-        ./dist/lium-darwin-arm64 --help >/dev/null
+        ./dist/${{ matrix.asset_name }} --version
+        ./dist/${{ matrix.asset_name }} --help >/dev/null
 
     - name: Generate macOS checksum
       run: |
         cd dist
-        shasum -a 256 lium-darwin-arm64 > lium-darwin-arm64.sha256
+        shasum -a 256 ${{ matrix.asset_name }} > ${{ matrix.asset_name }}.sha256
 
     - name: Upload macOS artifact
       uses: actions/upload-artifact@v4
       with:
-        name: lium-darwin-arm64
+        name: ${{ matrix.asset_name }}
         path: |
-          dist/lium-darwin-arm64
-          dist/lium-darwin-arm64.sha256
+          dist/${{ matrix.asset_name }}
+          dist/${{ matrix.asset_name }}.sha256
 
   release-assets:
     name: Publish GitHub release assets
     needs:
     - build-python
+    - validate-binary-targets
     - build-linux-binary
     - build-macos-binary
     runs-on: ubuntu-latest
@@ -157,21 +203,35 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: lium-linux-amd64
-        path: release-assets/linux
+        path: release-assets/linux-amd64
 
-    - name: Download macOS artifact
+    - name: Download Linux ARM64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: lium-linux-arm64
+        path: release-assets/linux-arm64
+
+    - name: Download macOS ARM64 artifact
       uses: actions/download-artifact@v4
       with:
         name: lium-darwin-arm64
-        path: release-assets/macos
+        path: release-assets/darwin-arm64
+
+    - name: Download macOS AMD64 artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: lium-darwin-amd64
+        path: release-assets/darwin-amd64
 
     - name: Assemble release assets
       run: |
         cp scripts/install.sh release-assets/install.sh
         chmod +x release-assets/install.sh
         {
-          cat release-assets/linux/lium-linux-amd64.sha256
-          cat release-assets/macos/lium-darwin-arm64.sha256
+          cat release-assets/linux-amd64/lium-linux-amd64.sha256
+          cat release-assets/linux-arm64/lium-linux-arm64.sha256
+          cat release-assets/darwin-amd64/lium-darwin-amd64.sha256
+          cat release-assets/darwin-arm64/lium-darwin-arm64.sha256
         } > release-assets/checksums.txt
 
     - name: Create or update GitHub release
@@ -187,10 +247,14 @@ jobs:
         gh release upload "$RELEASE_TAG" \
           release-assets/install.sh \
           release-assets/checksums.txt \
-          release-assets/linux/lium-linux-amd64 \
-          release-assets/linux/lium-linux-amd64.sha256 \
-          release-assets/macos/lium-darwin-arm64 \
-          release-assets/macos/lium-darwin-arm64.sha256 \
+          release-assets/linux-amd64/lium-linux-amd64 \
+          release-assets/linux-amd64/lium-linux-amd64.sha256 \
+          release-assets/linux-arm64/lium-linux-arm64 \
+          release-assets/linux-arm64/lium-linux-arm64.sha256 \
+          release-assets/darwin-amd64/lium-darwin-amd64 \
+          release-assets/darwin-amd64/lium-darwin-amd64.sha256 \
+          release-assets/darwin-arm64/lium-darwin-arm64 \
+          release-assets/darwin-arm64/lium-darwin-arm64.sha256 \
           release-assets/python-dist/* \
           --clobber
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!lium.spec
 
 # Installer logs
 pip-log.txt
@@ -185,3 +186,4 @@ AGENTS.md
 .cursor
 .codex
 .claude
+.omx/

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    pkg-config \
+    libssl-dev \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+COPY . .
+
+RUN uv sync --frozen --extra dev
+RUN uv run pyinstaller lium.spec --clean

--- a/README.md
+++ b/README.md
@@ -24,8 +24,16 @@
 
 ## Installation
 
+### Python package
+
 ```bash
 pip install lium.io
+```
+
+### Binary install (macOS amd64/arm64 / Linux amd64/arm64)
+
+```bash
+curl -fsSL https://github.com/Datura-ai/lium-cli/releases/latest/download/install.sh | bash
 ```
 
 ## Quick Start
@@ -98,6 +106,12 @@ Full API reference: https://lium-docs.readthedocs.io/en/latest/index.html
 
 - **CLI docs:** https://docs.lium.io/category/cli
 - **SDK docs:** https://lium-docs.readthedocs.io/en/latest/index.html
+
+## Binary Releases
+
+- Supported binary targets: `darwin-amd64`, `darwin-arm64`, `linux-amd64`, `linux-arm64`
+- Maintainers can build locally with `bash scripts/build.sh [macos|linux|all]`
+- Release artifacts publish through GitHub Releases with matching checksums
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ pip install lium.io
 curl -fsSL https://github.com/Datura-ai/lium-cli/releases/latest/download/install.sh | bash
 ```
 
+Fresh binary installs place a managed symlink at `~/.lium/bin/lium` that points to a
+versioned binary under `~/.lium/versions/<version>/lium`.
+
 ## Quick Start
 
 ### CLI

--- a/docs/binary-builds.rst
+++ b/docs/binary-builds.rst
@@ -1,0 +1,45 @@
+Binary Builds
+=============
+
+The first official binary rollout targets:
+
+- ``darwin-arm64``
+- ``linux-amd64``
+
+Local maintainer builds
+-----------------------
+
+Build from the repository root:
+
+.. code-block:: bash
+
+   bash scripts/build.sh macos
+   bash scripts/build.sh linux
+   bash scripts/build.sh all
+
+The script writes platform binaries plus ``.sha256`` files into ``dist/`` and
+runs basic smoke tests on the host-supported artifacts.
+
+Release flow
+------------
+
+The manual GitHub Actions release workflow now builds:
+
+- Python sdist/wheel outputs
+- ``lium-darwin-arm64``
+- ``lium-linux-amd64``
+- ``install.sh``
+- ``checksums.txt``
+
+Binary assets are uploaded to GitHub Releases so the public installer can fetch
+``releases/latest/download/<asset>`` without relying on private infrastructure.
+
+Binary runtime notes
+--------------------
+
+- The frozen entrypoint uses ``multiprocessing.freeze_support()`` to avoid
+  child-process argument parsing issues under PyInstaller.
+- The CLI version falls back to in-repo version metadata when distribution
+  metadata is unavailable in a frozen build.
+- ``lium/cli/themes.json`` is bundled into the PyInstaller build and loaded from
+  the extracted bundle when needed.

--- a/docs/binary-builds.rst
+++ b/docs/binary-builds.rst
@@ -37,6 +37,8 @@ The manual GitHub Actions release workflow now builds:
 
 Binary assets are uploaded to GitHub Releases so the public installer can fetch
 ``releases/latest/download/<asset>`` without relying on private infrastructure.
+Fresh installs keep ``~/.lium/bin/lium`` on ``PATH`` as a symlink to the managed
+versioned binary stored in ``~/.lium/versions/<version>/lium``.
 
 Binary runtime notes
 --------------------

--- a/docs/binary-builds.rst
+++ b/docs/binary-builds.rst
@@ -1,9 +1,11 @@
 Binary Builds
 =============
 
-The first official binary rollout targets:
+Official binary releases target:
 
+- ``darwin-amd64``
 - ``darwin-arm64``
+- ``linux-arm64``
 - ``linux-amd64``
 
 Local maintainer builds
@@ -26,7 +28,9 @@ Release flow
 The manual GitHub Actions release workflow now builds:
 
 - Python sdist/wheel outputs
+- ``lium-darwin-amd64``
 - ``lium-darwin-arm64``
+- ``lium-linux-arm64``
 - ``lium-linux-amd64``
 - ``install.sh``
 - ``checksums.txt``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,14 +9,20 @@ PROJECT_ROOT = os.path.abspath("..")
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
+about_ns: dict[str, str] = {}
+with open(os.path.join(PROJECT_ROOT, "lium", "__about__.py"), encoding="utf-8") as about_file:
+    exec(about_file.read(), about_ns)
+
+fallback_version = about_ns["__version__"]
+
 project = "Lium SDK"
 author = "Lium"
 copyright = f"{datetime.now():%Y}, {author}"
 
 try:
-    release = importlib.metadata.version("lium")
+    release = importlib.metadata.version("lium.io")
 except importlib.metadata.PackageNotFoundError:
-    release = "0.0.0"
+    release = fallback_version
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -10,7 +10,7 @@ The SDK ships with the `lium.io` package on PyPI:
 
    pip install lium.io
 
-Managed binary installs are also available for macOS arm64 and Linux amd64:
+Managed binary installs are also available for macOS and Linux on amd64 and arm64:
 
 .. code-block:: bash
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -16,6 +16,9 @@ Managed binary installs are also available for macOS and Linux on amd64 and arm6
 
    curl -fsSL https://github.com/Datura-ai/lium-cli/releases/latest/download/install.sh | bash
 
+Fresh binary installs create ``~/.lium/bin/lium`` as a managed symlink pointing at a
+versioned binary under ``~/.lium/versions/<version>/lium``.
+
 Authentication requires an API key stored in ``~/.lium/config.ini`` or exported as
 ``LIUM_API_KEY``. The CLI (`lium init`) can bootstrap this for you.
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -10,6 +10,12 @@ The SDK ships with the `lium.io` package on PyPI:
 
    pip install lium.io
 
+Managed binary installs are also available for macOS arm64 and Linux amd64:
+
+.. code-block:: bash
+
+   curl -fsSL https://github.com/Datura-ai/lium-cli/releases/latest/download/install.sh | bash
+
 Authentication requires an API key stored in ``~/.lium/config.ini`` or exported as
 ``LIUM_API_KEY``. The CLI (`lium init`) can bootstrap this for you.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,4 +11,5 @@ with each release.
    :maxdepth: 2
 
    getting-started
+   binary-builds
    api

--- a/lium.spec
+++ b/lium.spec
@@ -1,0 +1,86 @@
+# PyInstaller spec for the Lium CLI binary.
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+block_cipher = None
+
+hiddenimports = [
+    *collect_submodules("lium"),
+    *collect_submodules("bittensor"),
+    *collect_submodules("bittensor_cli"),
+    *collect_submodules("async_substrate_interface"),
+    *collect_submodules("scalecodec"),
+    *collect_submodules("Crypto"),
+    "paramiko",
+    "requests",
+    "dotenv",
+    "pydantic",
+    "loguru",
+    "yaml",
+    "click",
+    "rich",
+    "fuzzywuzzy",
+    "Levenshtein",
+    "netaddr",
+    "aiohttp",
+    "docker",
+    "git",
+    "jinja2",
+    "plotly",
+    "plotille",
+    "backoff",
+    "importlib.metadata",
+]
+
+datas = [
+    ("lium/cli/themes.json", "lium/cli"),
+]
+datas += collect_data_files("bittensor", include_py_files=False)
+datas += collect_data_files("bittensor_cli", include_py_files=False)
+datas += collect_data_files("plotly", include_py_files=False)
+datas += collect_data_files("pywry", include_py_files=False)
+datas += collect_data_files("certifi", include_py_files=False)
+
+a = Analysis(
+    ["lium_entry.py"],
+    pathex=["."],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        "tkinter",
+        "matplotlib",
+        "scipy",
+        "numpy.tests",
+        "pytest",
+        "sphinx",
+    ],
+    noarchive=False,
+    optimize=0,
+    cipher=block_cipher,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="lium",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,0 +1,3 @@
+"""Project version metadata."""
+
+__version__ = "0.0.7"

--- a/lium/__init__.py
+++ b/lium/__init__.py
@@ -1,3 +1,4 @@
 """Convenient import alias for the Lium SDK."""
 
+from .__about__ import __version__
 from .sdk import *  # noqa: F401,F403

--- a/lium/cli/cli.py
+++ b/lium/cli/cli.py
@@ -2,6 +2,7 @@
 import click
 import os
 from importlib.metadata import version, PackageNotFoundError
+from lium.__about__ import __version__ as fallback_version
 from .themed_console import ThemedConsole
 from .init.command import init_command
 from .ls import ls_command
@@ -35,7 +36,7 @@ def get_version():
     try:
         return version("lium.io")
     except PackageNotFoundError:
-        return "unknown"
+        return os.environ.get("LIUM_BUILD_VERSION", fallback_version)
 
 
 @click.group(invoke_without_command=True)

--- a/lium/cli/themed_console.py
+++ b/lium/cli/themed_console.py
@@ -4,6 +4,7 @@ import json
 import os
 import platform
 import subprocess
+import sys
 from pathlib import Path
 from typing import Dict, Any
 from rich.console import Console as RichConsole
@@ -22,16 +23,39 @@ class ThemedConsole(RichConsole):
     
     def _load_themes(self) -> Dict[str, Dict[str, str]]:
         """Load themes from themes.json."""
-        themes_file = Path(__file__).parent / "themes.json"
-        try:
-            with open(themes_file) as f:
-                return json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError):
-            # Fallback to basic themes
-            return {
-                "dark": {"success": "green", "error": "red", "warning": "yellow", "info": "cyan", "dim": "dim"},
-                "light": {"success": "green", "error": "red", "warning": "yellow", "info": "blue", "dim": "dim"}
-            }
+        candidates = [Path(__file__).parent / "themes.json"]
+        meipass_root = getattr(sys, "_MEIPASS", None)
+        if meipass_root:
+            candidates.append(Path(meipass_root) / "lium" / "cli" / "themes.json")
+
+        for themes_file in candidates:
+            try:
+                with open(themes_file, encoding="utf-8") as f:
+                    return json.load(f)
+            except (FileNotFoundError, json.JSONDecodeError):
+                continue
+
+        # Fallback to basic themes
+        return {
+            "dark": {
+                "success": "green",
+                "error": "red",
+                "warning": "yellow",
+                "info": "cyan",
+                "pending": "cyan",
+                "id": "dim",
+                "dim": "dim",
+            },
+            "light": {
+                "success": "green",
+                "error": "red",
+                "warning": "yellow",
+                "info": "blue",
+                "pending": "blue",
+                "id": "dim",
+                "dim": "dim",
+            },
+        }
     
     
     def _resolve_theme(self) -> Dict[str, str]:

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -323,8 +323,10 @@ def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
         return False  # B is significantly faster — A cannot dominate
 
     # --- Download speeds are similar; fall back to price-based logic ---
-    price_a = metrics_a.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
-    price_b = metrics_b.get('price_per_gpu_hour', float('inf'))  # TODO: DAH-1874 - deprecated
+    price_a_value = metrics_a.get('price_per_gpu_hour')
+    price_b_value = metrics_b.get('price_per_gpu_hour')
+    price_a = price_a_value if price_a_value is not None else float('inf')  # TODO: DAH-1874 - deprecated
+    price_b = price_b_value if price_b_value is not None else float('inf')  # TODO: DAH-1874 - deprecated
 
     if abs(price_a - price_b) < 0.01:  # Prices are effectively equal
         # Check secondary metrics in priority order; both A and B must be

--- a/lium_entry.py
+++ b/lium_entry.py
@@ -1,0 +1,13 @@
+"""PyInstaller entry point for the Lium CLI."""
+
+import multiprocessing
+
+from lium.cli.cli import main
+
+# Prevent spawned helper processes from re-entering Click as if this binary were
+# a generic Python interpreter when running under PyInstaller.
+multiprocessing.freeze_support()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "black", "wheel"]
+dev = ["pytest", "black", "wheel", "pyinstaller>=6.0.0"]
 docs = ["sphinx>=7.3", "sphinx-rtd-theme>=1.3"]
 
 [project.scripts]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DIST_DIR="dist"
+mkdir -p "$DIST_DIR"
+
+sha256_file() {
+    local target="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$(basename "$target")" > "$(basename "$target").sha256"
+    else
+        shasum -a 256 "$(basename "$target")" > "$(basename "$target").sha256"
+    fi
+}
+
+smoke_test() {
+    local target="$1"
+    echo "Smoke testing $(basename "$target")"
+    "$target" --version
+    "$target" --help >/dev/null
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Error: required command '$1' is not installed." >&2
+        exit 1
+    fi
+}
+
+build_macos() {
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        echo "Skipping macOS build: host is not macOS."
+        return
+    fi
+
+    require_command uv
+
+    echo "=== Building macOS (arm64) binary ==="
+    uv sync --frozen --extra dev
+    uv run pyinstaller lium.spec --clean
+    mv "$DIST_DIR/lium" "$DIST_DIR/lium-darwin-arm64"
+
+    (
+        cd "$DIST_DIR"
+        sha256_file "lium-darwin-arm64"
+    )
+    smoke_test "$DIST_DIR/lium-darwin-arm64"
+    echo "✓ macOS binary: $DIST_DIR/lium-darwin-arm64"
+}
+
+build_linux() {
+    require_command docker
+
+    echo "=== Building Linux (amd64) binary via Docker ==="
+    docker build --platform linux/amd64 -f Dockerfile.build -t lium-build .
+
+    docker rm -f lium-extract >/dev/null 2>&1 || true
+    docker create --name lium-extract lium-build true >/dev/null
+    docker cp lium-extract:/app/dist/lium "$DIST_DIR/lium-linux-amd64"
+    docker rm -f lium-extract >/dev/null
+
+    chmod +x "$DIST_DIR/lium-linux-amd64"
+    (
+        cd "$DIST_DIR"
+        sha256_file "lium-linux-amd64"
+    )
+
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        smoke_test "$DIST_DIR/lium-linux-amd64"
+    fi
+
+    echo "✓ Linux binary: $DIST_DIR/lium-linux-amd64"
+}
+
+case "${1:-all}" in
+    macos) build_macos ;;
+    linux) build_linux ;;
+    all)
+        build_macos
+        echo
+        build_linux
+        ;;
+    *)
+        echo "Usage: $0 [macos|linux|all]" >&2
+        exit 1
+        ;;
+esac
+
+echo
+echo "=== Build results ==="
+ls -lh "$DIST_DIR"/lium-* "$DIST_DIR"/*.sha256 2>/dev/null || echo "No binaries found"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,6 +41,66 @@ detect_asset_name() {
     esac
 }
 
+normalize_version() {
+    local version="$1"
+
+    version="${version#v}"
+    if [[ -z "$version" ]]; then
+        echo "Error: release version could not be determined." >&2
+        exit 1
+    fi
+
+    printf '%s' "$version"
+}
+
+resolve_latest_release_url() {
+    local latest_url resolved_url
+
+    if [[ -n "${LIUM_INSTALLER_RELEASE_URL:-}" ]]; then
+        printf '%s' "${LIUM_INSTALLER_RELEASE_URL}"
+        return
+    fi
+
+    latest_url="${RELEASE_BASE}/latest"
+
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url"
+        return
+    fi
+
+    if command -v wget >/dev/null 2>&1; then
+        resolved_url="$(
+            wget -qO /dev/null --server-response "$latest_url" 2>&1 \
+                | awk '/^[[:space:]]*Location: / {print $2}' \
+                | tr -d '\r' \
+                | tail -n 1
+        )"
+        if [[ -n "$resolved_url" ]]; then
+            printf '%s' "$resolved_url"
+            return
+        fi
+    fi
+
+    echo "Error: could not determine the latest Lium release version." >&2
+    exit 1
+}
+
+resolve_version() {
+    local release_url version
+
+    if [[ -n "${LIUM_VERSION:-}" ]]; then
+        normalize_version "${LIUM_VERSION}"
+        return
+    fi
+
+    release_url="$(resolve_latest_release_url)"
+    version="${release_url%/}"
+    version="${version##*/}"
+    version="${version%%\?*}"
+    version="${version%%\#*}"
+    normalize_version "$version"
+}
+
 download() {
     local url="$1"
     local target="$2"
@@ -74,6 +134,17 @@ verify_checksum() {
     )
 }
 
+ensure_managed_cli_path() {
+    local cli_path="$1"
+
+    if [[ -e "$cli_path" && ! -L "$cli_path" ]]; then
+        echo "Error: ${cli_path} already exists as a regular file." >&2
+        echo "Managed symlink installs are only used for fresh installs." >&2
+        echo "Leave the current install as-is or remove it before reinstalling." >&2
+        exit 1
+    fi
+}
+
 add_to_path() {
     local shell_name shell_rc path_line
 
@@ -105,18 +176,22 @@ add_to_path() {
 }
 
 main() {
-    local asset_name release_path temp_dir binary_url checksum_url
+    local asset_name version release_path temp_dir binary_url checksum_url
+    local install_root version_dir cli_path versioned_binary
 
     asset_name="$(detect_asset_name)"
-    release_path="${RELEASE_BASE}/latest/download"
-    if [[ -n "${LIUM_VERSION:-}" ]]; then
-        release_path="${RELEASE_BASE}/download/v${LIUM_VERSION}"
-    fi
+    version="$(resolve_version)"
+    release_path="${RELEASE_BASE}/download/v${version}"
+    install_root="$(dirname "$INSTALL_DIR")"
+    version_dir="${install_root}/versions/${version}"
+    cli_path="${INSTALL_DIR}/lium"
+    versioned_binary="${version_dir}/lium"
 
     temp_dir="$(mktemp -d)"
-    trap 'rm -rf "$temp_dir"' EXIT
+    trap "rm -rf \"$temp_dir\"" EXIT
 
-    mkdir -p "$INSTALL_DIR"
+    mkdir -p "$INSTALL_DIR" "$version_dir"
+    ensure_managed_cli_path "$cli_path"
 
     binary_url="${release_path}/${asset_name}"
     checksum_url="${release_path}/checksums.txt"
@@ -126,11 +201,13 @@ main() {
     download "$checksum_url" "$temp_dir/checksums.txt"
     verify_checksum "$asset_name" "$temp_dir"
 
-    install -m 0755 "$temp_dir/${asset_name}" "${INSTALL_DIR}/lium"
+    install -m 0755 "$temp_dir/${asset_name}" "$versioned_binary"
+    ln -sfn "../versions/${version}/lium" "$cli_path"
     add_to_path
 
     echo
     echo "Lium CLI installed to ${INSTALL_DIR}/lium"
+    echo "Managed binary location: ${versioned_binary}"
     echo
     echo "Next steps:"
     echo "  1. Restart your shell or run: export PATH=\"${INSTALL_DIR}:\$PATH\""
@@ -138,7 +215,7 @@ main() {
     echo "  3. List GPUs:  lium ls"
     echo
 
-    "${INSTALL_DIR}/lium" --version || true
+    "$cli_path" --version || true
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${LIUM_INSTALL_DIR:-$HOME/.lium/bin}"
+REPO_SLUG="${LIUM_REPO_SLUG:-Datura-ai/lium-cli}"
+RELEASE_BASE="https://github.com/${REPO_SLUG}/releases"
+
+detect_asset_name() {
+    local os arch
+
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    arch="$(uname -m)"
+
+    case "$arch" in
+        x86_64|amd64) arch="amd64" ;;
+        arm64|aarch64) arch="arm64" ;;
+        *)
+            echo "Error: unsupported architecture: $arch" >&2
+            exit 1
+            ;;
+    esac
+
+    case "$os" in
+        linux|darwin)
+            printf 'lium-%s-%s' "$os" "$arch"
+            ;;
+        *)
+            echo "Error: unsupported OS: $os" >&2
+            exit 1
+            ;;
+    esac
+}
+
+download() {
+    local url="$1"
+    local target="$2"
+
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$target"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q "$url" -O "$target"
+    else
+        echo "Error: curl or wget is required." >&2
+        exit 1
+    fi
+}
+
+verify_checksum() {
+    local asset_name="$1"
+    local install_root="$2"
+
+    if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+        echo "Warning: sha256sum/shasum not available; skipping checksum verification." >&2
+        return
+    fi
+
+    (
+        cd "$install_root"
+        if command -v sha256sum >/dev/null 2>&1; then
+            grep " ${asset_name}\$" checksums.txt | sha256sum --check --status
+        else
+            grep " ${asset_name}\$" checksums.txt | shasum -a 256 --check --status
+        fi
+    )
+}
+
+add_to_path() {
+    local shell_name shell_rc path_line
+
+    if [[ ":$PATH:" == *":${INSTALL_DIR}:"* ]]; then
+        return
+    fi
+
+    shell_name="${SHELL##*/}"
+    case "$shell_name" in
+        bash) shell_rc="$HOME/.bashrc"; path_line="export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
+        zsh) shell_rc="$HOME/.zshrc"; path_line="export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
+        fish) shell_rc="$HOME/.config/fish/config.fish"; path_line="set -gx PATH ${INSTALL_DIR} \$PATH" ;;
+        *) shell_rc="" ;;
+    esac
+
+    if [[ -n "$shell_rc" ]]; then
+        mkdir -p "$(dirname "$shell_rc")"
+        if ! grep -qF "$INSTALL_DIR" "$shell_rc" 2>/dev/null; then
+            {
+                echo
+                echo "# Lium CLI"
+                echo "$path_line"
+            } >> "$shell_rc"
+            echo "Added ${INSTALL_DIR} to PATH in ${shell_rc}"
+        fi
+    fi
+
+    export PATH="${INSTALL_DIR}:$PATH"
+}
+
+main() {
+    local asset_name release_path temp_dir binary_url checksum_url
+
+    asset_name="$(detect_asset_name)"
+    release_path="${RELEASE_BASE}/latest/download"
+    if [[ -n "${LIUM_VERSION:-}" ]]; then
+        release_path="${RELEASE_BASE}/download/v${LIUM_VERSION}"
+    fi
+
+    temp_dir="$(mktemp -d)"
+    trap 'rm -rf "$temp_dir"' EXIT
+
+    mkdir -p "$INSTALL_DIR"
+
+    binary_url="${release_path}/${asset_name}"
+    checksum_url="${release_path}/checksums.txt"
+
+    echo "Downloading ${asset_name} from ${binary_url}"
+    download "$binary_url" "$temp_dir/${asset_name}"
+    download "$checksum_url" "$temp_dir/checksums.txt"
+    verify_checksum "$asset_name" "$temp_dir"
+
+    install -m 0755 "$temp_dir/${asset_name}" "${INSTALL_DIR}/lium"
+    add_to_path
+
+    echo
+    echo "Lium CLI installed to ${INSTALL_DIR}/lium"
+    echo
+    echo "Next steps:"
+    echo "  1. Restart your shell or run: export PATH=\"${INSTALL_DIR}:\$PATH\""
+    echo "  2. Initialize: lium init"
+    echo "  3. List GPUs:  lium ls"
+    echo
+
+    "${INSTALL_DIR}/lium" --version || true
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,27 +5,37 @@ INSTALL_DIR="${LIUM_INSTALL_DIR:-$HOME/.lium/bin}"
 REPO_SLUG="${LIUM_REPO_SLUG:-Datura-ai/lium-cli}"
 RELEASE_BASE="https://github.com/${REPO_SLUG}/releases"
 
-detect_asset_name() {
-    local os arch
+detect_os() {
+    printf '%s' "${LIUM_INSTALLER_UNAME_S:-$(uname -s)}" | tr '[:upper:]' '[:lower:]'
+}
 
-    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-    arch="$(uname -m)"
+detect_arch() {
+    local arch
+
+    arch="${LIUM_INSTALLER_UNAME_M:-$(uname -m)}"
 
     case "$arch" in
-        x86_64|amd64) arch="amd64" ;;
-        arm64|aarch64) arch="arm64" ;;
+        x86_64|amd64) printf 'amd64' ;;
+        arm64|aarch64) printf 'arm64' ;;
         *)
             echo "Error: unsupported architecture: $arch" >&2
             exit 1
             ;;
     esac
+}
 
-    case "$os" in
-        linux|darwin)
+detect_asset_name() {
+    local os arch
+
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+
+    case "$os/$arch" in
+        linux/amd64|linux/arm64|darwin/amd64|darwin/arm64)
             printf 'lium-%s-%s' "$os" "$arch"
             ;;
         *)
-            echo "Error: unsupported OS: $os" >&2
+            echo "Error: unsupported platform: ${os}-${arch}. Supported binaries: darwin-amd64, darwin-arm64, linux-amd64, linux-arm64." >&2
             exit 1
             ;;
     esac
@@ -131,4 +141,6 @@ main() {
     "${INSTALL_DIR}/lium" --version || true
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -218,6 +218,8 @@ main() {
     "$cli_path" --version || true
 }
 
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+if [[ -z "${BASH_SOURCE:-}" ]]; then
+    main "$@"
+elif [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     main "$@"
 fi

--- a/test/test_binary_build_runtime.py
+++ b/test/test_binary_build_runtime.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from lium.__about__ import __version__
+from lium.cli import cli as cli_module
+from lium.cli.themed_console import ThemedConsole
+from lium.cli.utils import dominates
+
+
+def test_get_version_falls_back_to_module_version(monkeypatch):
+    def raise_missing(_distribution_name: str):
+        raise cli_module.PackageNotFoundError
+
+    monkeypatch.setattr(cli_module, "version", raise_missing)
+    monkeypatch.delenv("LIUM_BUILD_VERSION", raising=False)
+
+    assert cli_module.get_version() == __version__
+
+
+def test_get_version_prefers_build_override(monkeypatch):
+    def raise_missing(_distribution_name: str):
+        raise cli_module.PackageNotFoundError
+
+    monkeypatch.setattr(cli_module, "version", raise_missing)
+    monkeypatch.setenv("LIUM_BUILD_VERSION", "9.9.9-binary")
+
+    assert cli_module.get_version() == "9.9.9-binary"
+
+
+def test_themed_console_loads_themes_from_meipass(monkeypatch, tmp_path):
+    extracted_root = tmp_path / "bundle"
+    themes_dir = extracted_root / "lium" / "cli"
+    themes_dir.mkdir(parents=True)
+    themes_file = themes_dir / "themes.json"
+    themes_file.write_text(
+        '{"dark":{"success":"green","error":"red","warning":"yellow","info":"cyan","pending":"cyan","id":"dim","dim":"dim"},'
+        '"light":{"success":"green","error":"red","warning":"yellow","info":"blue","pending":"blue","id":"dim","dim":"dim"}}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("lium.cli.themed_console.__file__", str(tmp_path / "missing.py"))
+    monkeypatch.setattr("lium.cli.themed_console.config.get", lambda *args, **kwargs: "dark")
+    monkeypatch.setattr("sys._MEIPASS", str(extracted_root), raising=False)
+
+    console = ThemedConsole()
+
+    assert console.themes["dark"]["success"] == "green"
+    assert Path(str(extracted_root)).exists()
+
+
+def test_dominates_handles_missing_price_without_unboundlocalerror():
+    better = {"price_per_gpu_hour": None, "total_bandwidth": 100, "location_score": 1.0, "net_down": 50, "net_up": 50}
+    worse = {"price_per_gpu_hour": 2.0, "total_bandwidth": 10, "location_score": 0.0, "net_down": 5, "net_up": 5}
+
+    assert isinstance(dominates(better, worse), bool)

--- a/test/test_release_binary_targets.py
+++ b/test/test_release_binary_targets.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import subprocess
 from pathlib import Path
@@ -13,6 +14,20 @@ SUPPORTED_TARGETS = {
     ("Darwin", "arm64"): "lium-darwin-arm64",
 }
 
+DEFAULT_PLATFORM = ("Linux", "x86_64")
+DEFAULT_ASSET = SUPPORTED_TARGETS[DEFAULT_PLATFORM]
+
+
+def run_bash(command: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-lc", command],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
 
 def run_detect_asset_name(uname_s: str, uname_m: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
@@ -22,14 +37,87 @@ def run_detect_asset_name(uname_s: str, uname_m: str) -> subprocess.CompletedPro
             "LIUM_INSTALLER_UNAME_M": uname_m,
         }
     )
-    return subprocess.run(
-        ["bash", "-lc", "source scripts/install.sh && detect_asset_name"],
-        cwd=REPO_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
+    return run_bash("source scripts/install.sh && detect_asset_name", env=env)
+
+
+def write_fake_curl(bin_dir: Path) -> None:
+    fake_curl = bin_dir / "curl"
+    fake_curl.write_text(
+        """#!/bin/sh
+set -eu
+
+output=""
+url=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            output="$2"
+            shift 2
+            ;;
+        -f|-s|-S|-L)
+            shift
+            ;;
+        *)
+            url="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$output" ] || [ -z "$url" ]; then
+    echo "unexpected curl invocation: $*" >&2
+    exit 1
+fi
+
+asset_name=$(basename "$url")
+cp "${LIUM_TEST_RELEASES}/${asset_name}" "$output"
+""",
+        encoding="utf-8",
     )
+    fake_curl.chmod(0o755)
+
+
+def make_fake_release(tmp_path: Path, version: str) -> Path:
+    release_dir = tmp_path / f"release-{version}"
+    release_dir.mkdir()
+
+    asset_path = release_dir / DEFAULT_ASSET
+    asset_body = (
+        "#!/bin/sh\n"
+        f"printf 'lium {version}\\n'\n"
+    )
+    asset_path.write_text(asset_body, encoding="utf-8")
+    asset_path.chmod(0o755)
+
+    digest = hashlib.sha256(asset_path.read_bytes()).hexdigest()
+    (release_dir / "checksums.txt").write_text(
+        f"{digest}  {DEFAULT_ASSET}\n",
+        encoding="utf-8",
+    )
+
+    return release_dir
+
+
+def make_install_env(home_dir: Path, release_dir: Path, version: str) -> dict[str, str]:
+    fake_bin = home_dir / "fake-bin"
+    fake_bin.mkdir(exist_ok=True)
+    write_fake_curl(fake_bin)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home_dir),
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "LIUM_INSTALL_DIR": str(home_dir / ".lium" / "bin"),
+            "LIUM_INSTALLER_UNAME_S": DEFAULT_PLATFORM[0],
+            "LIUM_INSTALLER_UNAME_M": DEFAULT_PLATFORM[1],
+            "LIUM_TEST_RELEASES": str(release_dir),
+            "LIUM_VERSION": version,
+            "SHELL": "/bin/bash",
+        }
+    )
+    return env
 
 
 def test_install_script_supports_every_released_binary_target():
@@ -47,6 +135,18 @@ def test_install_script_rejects_unsupported_targets():
     assert "unsupported architecture: riscv64" in result.stderr
 
 
+def test_install_script_resolves_version_from_release_url_override():
+    env = os.environ.copy()
+    env["LIUM_INSTALLER_RELEASE_URL"] = (
+        "https://github.com/Datura-ai/lium-cli/releases/tag/v0.1.3"
+    )
+
+    result = run_bash("source scripts/install.sh && resolve_version", env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "0.1.3"
+
+
 def test_release_workflow_mentions_every_supported_binary_target():
     workflow_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
@@ -54,3 +154,87 @@ def test_release_workflow_mentions_every_supported_binary_target():
         assert f"name: {asset_name}" in workflow_text
         assert f"{asset_name}.sha256" in workflow_text
         assert asset_name in workflow_text
+
+
+def test_install_script_fresh_install_uses_versioned_symlink_layout(tmp_path: Path):
+    version = "0.1.3"
+    release_dir = make_fake_release(tmp_path, version)
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    result = run_bash("bash scripts/install.sh", env=make_install_env(home_dir, release_dir, version))
+
+    cli_path = home_dir / ".lium" / "bin" / "lium"
+    versioned_binary = home_dir / ".lium" / "versions" / version / "lium"
+
+    assert result.returncode == 0, result.stderr
+    assert cli_path.is_symlink()
+    assert os.readlink(cli_path) == f"../versions/{version}/lium"
+    assert versioned_binary.exists()
+    assert versioned_binary.read_text(encoding="utf-8").startswith("#!/bin/sh")
+    assert f"Managed binary location: {versioned_binary}" in result.stdout
+
+
+def test_install_script_reinstall_same_version_is_idempotent(tmp_path: Path):
+    version = "0.1.3"
+    release_dir = make_fake_release(tmp_path, version)
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    env = make_install_env(home_dir, release_dir, version)
+
+    first = run_bash("bash scripts/install.sh", env=env)
+    second = run_bash("bash scripts/install.sh", env=env)
+
+    cli_path = home_dir / ".lium" / "bin" / "lium"
+    versioned_binary = home_dir / ".lium" / "versions" / version / "lium"
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert cli_path.is_symlink()
+    assert os.readlink(cli_path) == f"../versions/{version}/lium"
+    assert versioned_binary.exists()
+
+
+def test_install_script_updates_symlink_for_newer_versions(tmp_path: Path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    first_version = "0.1.3"
+    first_release = make_fake_release(tmp_path, first_version)
+    first_result = run_bash(
+        "bash scripts/install.sh",
+        env=make_install_env(home_dir, first_release, first_version),
+    )
+
+    second_version = "0.1.4"
+    second_release = make_fake_release(tmp_path, second_version)
+    second_result = run_bash(
+        "bash scripts/install.sh",
+        env=make_install_env(home_dir, second_release, second_version),
+    )
+
+    cli_path = home_dir / ".lium" / "bin" / "lium"
+
+    assert first_result.returncode == 0, first_result.stderr
+    assert second_result.returncode == 0, second_result.stderr
+    assert cli_path.is_symlink()
+    assert os.readlink(cli_path) == f"../versions/{second_version}/lium"
+    assert (home_dir / ".lium" / "versions" / first_version / "lium").exists()
+    assert (home_dir / ".lium" / "versions" / second_version / "lium").exists()
+
+
+def test_install_script_refuses_existing_regular_file_install(tmp_path: Path):
+    version = "0.1.3"
+    release_dir = make_fake_release(tmp_path, version)
+    home_dir = tmp_path / "home"
+    cli_path = home_dir / ".lium" / "bin" / "lium"
+    cli_path.parent.mkdir(parents=True)
+    cli_path.write_text("legacy-binary", encoding="utf-8")
+
+    result = run_bash("bash scripts/install.sh", env=make_install_env(home_dir, release_dir, version))
+
+    assert result.returncode != 0
+    assert "already exists as a regular file" in result.stderr
+    assert "Managed symlink installs are only used for fresh installs." in result.stderr
+    assert not cli_path.is_symlink()
+    assert cli_path.read_text(encoding="utf-8") == "legacy-binary"

--- a/test/test_release_binary_targets.py
+++ b/test/test_release_binary_targets.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+SUPPORTED_TARGETS = {
+    ("Linux", "x86_64"): "lium-linux-amd64",
+    ("Linux", "aarch64"): "lium-linux-arm64",
+    ("Darwin", "x86_64"): "lium-darwin-amd64",
+    ("Darwin", "arm64"): "lium-darwin-arm64",
+}
+
+
+def run_detect_asset_name(uname_s: str, uname_m: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "LIUM_INSTALLER_UNAME_S": uname_s,
+            "LIUM_INSTALLER_UNAME_M": uname_m,
+        }
+    )
+    return subprocess.run(
+        ["bash", "-lc", "source scripts/install.sh && detect_asset_name"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_install_script_supports_every_released_binary_target():
+    for detected_platform, expected_asset in SUPPORTED_TARGETS.items():
+        result = run_detect_asset_name(*detected_platform)
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == expected_asset
+
+
+def test_install_script_rejects_unsupported_targets():
+    result = run_detect_asset_name("Linux", "riscv64")
+
+    assert result.returncode != 0
+    assert "unsupported architecture: riscv64" in result.stderr
+
+
+def test_release_workflow_mentions_every_supported_binary_target():
+    workflow_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    for asset_name in SUPPORTED_TARGETS.values():
+        assert f"name: {asset_name}" in workflow_text
+        assert f"{asset_name}.sha256" in workflow_text
+        assert asset_name in workflow_text

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1017,7 +1026,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1519,7 +1528,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.3"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1558,6 +1567,7 @@ dependencies = [
 dev = [
     { name = "black", version = "25.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "black", version = "26.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyinstaller" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "wheel" },
@@ -1590,6 +1600,7 @@ requires-dist = [
     { name = "plotly", specifier = ">=6.0.0" },
     { name = "pycryptodome", specifier = ">=3.0.0,<4.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pyinstaller", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "python-levenshtein" },
@@ -1616,6 +1627,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
 ]
 
 [[package]]
@@ -2286,6 +2309,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2716,6 +2748,49 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/63/fd62472b6371d89dc138d40c36d87a50dc2de18a035803bbdc376b4ffac4/pyinstaller-6.19.0.tar.gz", hash = "sha256:ec73aeb8bd9b7f2f1240d328a4542e90b3c6e6fbc106014778431c616592a865", size = 4036072, upload-time = "2026-02-14T18:06:28.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/eb/23374721fecfa72677e79800921cb6aceefa6ba48574dc404f3f6c6c3be7/pyinstaller-6.19.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:4190e76b74f0c4b5c5f11ac360928cd2e36ec8e3194d437bf6b8648c7bc0c134", size = 1040563, upload-time = "2026-02-14T18:05:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7e/dfd724b0b533f5aaec0ee5df406fe2319987ed6964480a706f85478b12ea/pyinstaller-6.19.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8bd68abd812d8a6ba33b9f1810e91fee0f325969733721b78151f0065319ca11", size = 735477, upload-time = "2026-02-14T18:05:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c9/ee3a4101c31f26344e66896c73c1fd6ed8282bf871473365b7f8674af406/pyinstaller-6.19.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1ec54ef967996ca61dacba676227e2b23219878ccce5ee9d6f3aada7b8ed8abf", size = 747143, upload-time = "2026-02-14T18:05:31.488Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0a/fc77e9f861be8cf300ac37155f59cc92aff99b29f2ddd78546f563a5b5a6/pyinstaller-6.19.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4ab2bb52e58448e14ddf9450601bdedd66800465043501c1d8f1cab87b60b122", size = 744849, upload-time = "2026-02-14T18:05:35.492Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e3/6872e020ee758afe0b821663858492c10745608b07150e5e2c824a5b3e1c/pyinstaller-6.19.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:da6d5c6391ccefe73554b9fa29b86001c8e378e0f20c2a4004f836ba537eff63", size = 741590, upload-time = "2026-02-14T18:05:39.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/b8db5f1a4b0fb228175f2ea0aa33f949adcc097fbe981cc524f9faf85777/pyinstaller-6.19.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a0fc5f6b3c55aa54353f0c74ffa59b1115433c1850c6f655d62b461a2ed6cbbe", size = 741448, upload-time = "2026-02-14T18:05:45.636Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4d/63b0600f2694e9141b83129fbc1c488ec84d5a0770b1448ec154dcd0fee9/pyinstaller-6.19.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:e649ba6bd1b0b89b210ad92adb5fbdc8a42dd2c5ca4f72ef3a0bfec83a424b83", size = 740613, upload-time = "2026-02-14T18:05:49.726Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d4/e812ad36178093a0e9fd4b8127577748dd85b0cb71de912229dca21fd741/pyinstaller-6.19.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:481a909c8e60c8692fc60fcb1344d984b44b943f8bc9682f2fcdae305ad297e6", size = 740350, upload-time = "2026-02-14T18:05:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/52/03/b2c2ee41fb8e10fd2a45d21f5ec2ef25852cfb978dbf762972eed59e3d63/pyinstaller-6.19.0-py3-none-win32.whl", hash = "sha256:3c5c251054fe4cfaa04c34a363dcfbf811545438cb7198304cd444756bc2edd2", size = 1324317, upload-time = "2026-02-14T18:06:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d3/6d5e62b8270e2b53a6065e281b3a7785079b00e9019c8019952828dd1669/pyinstaller-6.19.0-py3-none-win_amd64.whl", hash = "sha256:b5bb6536c6560330d364d91522250f254b107cf69129d9cbcd0e6727c570be33", size = 1384894, upload-time = "2026-02-14T18:06:06.425Z" },
+    { url = "https://files.pythonhosted.org/packages/81/65/458cd523308a101a22fd2742893405030cc24994cc74b1b767cecf137160/pyinstaller-6.19.0-py3-none-win_arm64.whl", hash = "sha256:c2d5a539b0bfe6159d5522c8c70e1c0e487f22c2badae0f97d45246223b798ea", size = 1325374, upload-time = "2026-02-14T18:06:12.804Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/fe/9278c29394bf69169febc21f96b4252c3ee7c8ec22c2fc545004bed47e71/pyinstaller_hooks_contrib-2026.4.tar.gz", hash = "sha256:766c281acb1ecc32e21c8c667056d7ebf5da0aabd5e30c219f9c2a283620eeaa", size = 173050, upload-time = "2026-03-31T14:10:51.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/f4/035fb8c06deff827f540a9a4ed9122c54e5376fca3e42eddf0c263730775/pyinstaller_hooks_contrib-2026.4-py3-none-any.whl", hash = "sha256:1de1a5e49a878122010b88c7e295502bc69776c157c4a4dc78741a4e6178b00f", size = 455496, upload-time = "2026-03-31T14:10:49.867Z" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2928,6 +3003,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/59/42/b86689aac0cdaee7ae1c58d464b0ff04ca909c19bb6502d4973cdd9f9544/pywin32-311-cp39-cp39-win32.whl", hash = "sha256:aba8f82d551a942cb20d4a83413ccbac30790b50efb89a75e4f586ac0bb8056b", size = 8760837, upload-time = "2025-07-14T20:12:59.59Z" },
     { url = "https://files.pythonhosted.org/packages/9f/8a/1403d0353f8c5a2f0829d2b1c4becbf9da2f0a4d040886404fc4a5431e4d/pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91", size = 9590187, upload-time = "2025-07-14T20:13:01.419Z" },
     { url = "https://files.pythonhosted.org/packages/60/22/e0e8d802f124772cec9c75430b01a212f86f9de7546bda715e54140d5aeb/pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d", size = 8778162, upload-time = "2025-07-14T20:13:03.544Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

### Task Link

DAH-1873

## Problem

The CLI release flow only publishes the Python package today, so there is no managed binary distribution path for Linux/macOS users. The current code also needs frozen-build fallbacks for version metadata and bundled assets.

## Solution

Add binary build and release automation, ship an installer script plus PyInstaller config, and update runtime code paths so packaged binaries can resolve version and theme assets correctly.

## Changes

- add GitHub Actions jobs to build Python distributions plus Linux/macOS binaries and upload release assets
- add PyInstaller entrypoints/config plus local build/install scripts for binary packaging
- add version fallback metadata and PyInstaller-safe theme loading for packaged CLI binaries
- add a regression test module covering binary runtime fallbacks and the `dominates` missing-price case
- update package/dev tooling and docs for binary install/build flows

## Deployment Steps

Use GitHub Action.

## Review Request

- [ ] Just code review
- [ ] QA – local test on reviewer side

## Other PRs

None.

## Risks

- The installer default repo slug and uploaded release asset names need to stay aligned with the target GitHub repository.
- Binary publishing now depends on Docker/PyInstaller/GitHub release asset behavior across runners.

## Test Cases

### Test Case 1

**Actions**

- Review `test/test_binary_build_runtime.py`
- Run the release workflow or local binary build smoke checks when ready

**Expected Output**

- Binary builds expose `lium --version` and `lium --help`
- Frozen builds can load bundled theme assets and version metadata without the installed package metadata path

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [ ] PR description is clear and complete
- [ ] Risks are documented
- [ ] Tests are described
