### PR TITLE
DAH-1924 - Add effective speed fields and unify upload/download speed access

### DIFF
--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -80,15 +80,15 @@ def _first_gpu_detail(specs: Optional[Dict]) -> Dict:
     return details[0] if details else {}
 
 
-def _specs_row(specs: Optional[Dict]) -> Dict[str, str]:
-    """Extract display fields from specs."""
+def _specs_row(executor: ExecutorInfo) -> Dict[str, str]:
+    """Extract display fields from an executor."""
+    specs = executor.specs
     if not specs:
         return {k: "—" for k in ["VRAM", "RAM", "Disk", "PCIe", "Mem", "TFLOPs", "Upload", "Download", "Ports"]}
 
     d = _first_gpu_detail(specs)
     ram = specs.get("ram", {})
     disk = specs.get("hard_disk", {})
-    net = specs.get("network", {})
 
     return {
         "VRAM": _maybe_gi_from_capacity(d.get("capacity")),
@@ -96,8 +96,8 @@ def _specs_row(specs: Optional[Dict]) -> Dict[str, str]:
         "Disk": _maybe_gi_from_big_number(disk.get("total")),
         "Country": _country_name(specs.get("location")),
         "PCIe": _maybe_int(d.get("pcie_speed")),
-        "Upload": _maybe_int(net.get("upload_speed")),
-        "Download": _maybe_int(net.get("ema_verifyx_download_speed") or net.get("download_speed")),
+        "Upload": _maybe_int(executor.upload_speed or None),
+        "Download": _maybe_int(executor.download_speed or None),
         "Ports": _maybe_int(specs.get("available_port_count")),
     }
 
@@ -196,7 +196,7 @@ def build_executors_table(
 
     # Add rows
     for idx, (exe, is_pareto) in enumerate(zip(sorted_executors, pareto_flags), 1):
-        s = _specs_row(exe.specs)
+        s = _specs_row(exe)
 
         # Format HUID with Pareto star
         huid = _mid_ellipsize(exe.huid)

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -185,9 +185,7 @@ def up_command(
                 estimate = lium.get_deployment_estimate(executor.id, template.id)
                 est_secs = estimate.get("estimated_seconds")
                 if est_secs:
-                    specs = executor.specs or {}
-                    network = specs.get("network", {}) or {}
-                    dl_speed = network.get("download_speed") or 0
+                    dl_speed = executor.download_speed
                     raw_bytes = estimate.get("docker_image_size")
                     img_gb = raw_bytes / 1e9 if raw_bytes is not None else None
                     _show_estimate(

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -274,14 +274,16 @@ def extract_executor_metrics(executor: ExecutorInfo) -> Dict[str, float]:
     # System metrics
     ram_data = specs.get("ram", {})
     disk_data = specs.get("hard_disk", {})
-    network = specs.get("network", {})
-    
+
     # Location preference (US gets a bonus)
     location = executor.location or {}
     country = location.get("country", "").upper()
     country_code = location.get("country_code", "").upper()
     is_us = country == "UNITED STATES" or country_code == "US"
-    
+
+    net_up = executor.upload_speed
+    net_down = executor.download_speed
+
     return {
         'price_per_gpu_hour': executor.price_per_gpu_hour or float('inf'), # TODO: DAH-1874 - deprecated
         'price_per_gpu': executor.price_per_gpu,
@@ -291,10 +293,10 @@ def extract_executor_metrics(executor: ExecutorInfo) -> Dict[str, float]:
         'pcie_speed': gpu_details.get("pcie_speed") or 0,
         'memory_bandwidth': gpu_details.get("memory_speed") or 0,
         'tflops': gpu_details.get("graphics_speed") or 0,
-        'net_up': network.get("upload_speed") or 0,
-        'net_down': executor.download_speed,
+        'net_up': net_up,
+        'net_down': net_down,
         'location_score': 1.0 if is_us else 0.0,  # US locations get higher score
-        'total_bandwidth': (network.get("upload_speed") or 0) + executor.download_speed,  # Combined bandwidth
+        'total_bandwidth': net_up + net_down,  # Combined bandwidth
     }
 
 

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -153,6 +153,8 @@ class Lium:
             status=executor_dict.get("status", "unknown"),
             docker_in_docker=specs.get("sysbox_runtime", False),
             available_port_count=specs.get("available_port_count"),
+            effective_upload_speed_mbps=executor_dict.get("effective_upload_speed_mbps"),
+            effective_download_speed_mbps=executor_dict.get("effective_download_speed_mbps"),
         )
 
     def up(

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -38,31 +38,12 @@ class ExecutorInfo:
     @property
     def download_speed(self) -> float:
         """Effective download speed in Mbps (backend-authoritative; 0.0 if unknown)."""
-        if self.effective_download_speed_mbps:
-            return self.effective_download_speed_mbps
-        # Fallback chain mirrors backend priority for pre-effective-field deployments.
-        net = self.specs.get("network", {})
-        return (
-            net.get("ema_verifyx_download_speed")
-            or net.get("ema_download_speed")
-            or net.get("verifyx_download_speed")
-            or net.get("download_speed")
-            or 0.0
-        )
+        return self.effective_download_speed_mbps or 0.0
 
     @property
     def upload_speed(self) -> float:
         """Effective upload speed in Mbps (backend-authoritative; 0.0 if unknown)."""
-        if self.effective_upload_speed_mbps:
-            return self.effective_upload_speed_mbps
-        # Fallback chain mirrors backend priority for pre-effective-field deployments.
-        net = self.specs.get("network", {})
-        return (
-            net.get("ema_verifyx_upload_speed")
-            or net.get("ema_upload_speed")
-            or net.get("upload_speed")
-            or 0.0
-        )
+        return self.effective_upload_speed_mbps or 0.0
 
 
 @dataclass

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -21,6 +21,8 @@ class ExecutorInfo:
     docker_in_docker: bool
     ip: str
     available_port_count: Optional[int] = None
+    effective_upload_speed_mbps: Optional[float] = None
+    effective_download_speed_mbps: Optional[float] = None
 
     @property
     def driver_version(self) -> str:
@@ -35,9 +37,32 @@ class ExecutorInfo:
 
     @property
     def download_speed(self) -> float:
-        """Verified EMA download speed in Mbps, falling back to raw download_speed."""
+        """Effective download speed in Mbps (backend-authoritative; 0.0 if unknown)."""
+        if self.effective_download_speed_mbps:
+            return self.effective_download_speed_mbps
+        # Fallback chain mirrors backend priority for pre-effective-field deployments.
         net = self.specs.get("network", {})
-        return net.get("ema_verifyx_download_speed") or net.get("download_speed") or 0.0
+        return (
+            net.get("ema_verifyx_download_speed")
+            or net.get("ema_download_speed")
+            or net.get("verifyx_download_speed")
+            or net.get("download_speed")
+            or 0.0
+        )
+
+    @property
+    def upload_speed(self) -> float:
+        """Effective upload speed in Mbps (backend-authoritative; 0.0 if unknown)."""
+        if self.effective_upload_speed_mbps:
+            return self.effective_upload_speed_mbps
+        # Fallback chain mirrors backend priority for pre-effective-field deployments.
+        net = self.specs.get("network", {})
+        return (
+            net.get("ema_verifyx_upload_speed")
+            or net.get("ema_upload_speed")
+            or net.get("upload_speed")
+            or 0.0
+        )
 
 
 @dataclass

--- a/uv.lock
+++ b/uv.lock
@@ -1017,7 +1017,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.3"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1924](https://www.notion.so/DAH-1924)

## Problem

Upload and download speed lookups were scattered across the codebase, each directly accessing `specs["network"]` with inconsistent fallback chains. The backend now exposes authoritative `effective_upload_speed_mbps` / `effective_download_speed_mbps` fields that should be preferred over raw spec values.

## Solution

Added `effective_upload_speed_mbps` and `effective_download_speed_mbps` to `ExecutorInfo`, mapped from the backend API response. Added an `upload_speed` property (mirroring the existing `download_speed` property) and extended the `download_speed` fallback chain to cover all verified EMA variants. All call sites in `display.py`, `up/command.py`, and `utils.py` now use these properties instead of reaching into `specs["network"]` directly.

## Changes

- `lium/sdk/models.py` — add `effective_upload_speed_mbps` / `effective_download_speed_mbps` fields; add `upload_speed` property with full fallback chain; extend `download_speed` fallback chain with `ema_download_speed` and `verifyx_download_speed`
- `lium/sdk/client.py` — map the two new backend fields when constructing `ExecutorInfo`
- `lium/cli/ls/display.py` — use `executor.upload_speed` / `executor.download_speed` instead of raw `net.get(...)` calls
- `lium/cli/up/command.py` — use `executor.download_speed` instead of raw `specs["network"]` lookup
- `lium/cli/utils.py` — use `executor.upload_speed` / `executor.download_speed`; fix `total_bandwidth` calculation which previously used inconsistent sources for up vs down
- `uv.lock` — bump `lium-io` version to `0.0.7`

## Deployment Steps

Use GitHub Action.

## Review Request

- [ ] Just code review
- [ ] QA – local test on reviewer side

## Other PRs

Follows #54 (feat/1924-sort-ls-by-download-speed).

## Risks

- Low. Changes consolidate existing logic into properties already exercised by the sort/display path merged in #54. The fallback chain preserves backward compatibility with older API responses that lack `effective_*` fields.

## Test Cases

### Test Case 1

**Actions**

Run `lium ls` against a live endpoint and verify Upload/Download columns show values.

**Expected Output**

Columns populated from `effective_*` fields when present; fallback to `ema_verifyx_*` / `download_speed` otherwise.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [ ] PR description is clear and complete
- [ ] Risks are documented
- [ ] Tests are described