### PR TITLE
fix: build Linux binary on Debian bullseye (glibc 2.31)

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,11 +1,11 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bullseye
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     libglib2.0-dev \
     libssl-dev \
-    libwebkit2gtk-4.1-dev \
+    libwebkit2gtk-4.0-dev \
     pkg-config \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Switch `Dockerfile.build` base from `python:3.12-slim` (Debian 12, glibc 2.36) to `python:3.12-slim-bullseye` (Debian 11, glibc 2.31)
- Adjust `libwebkit2gtk-4.1-dev` → `libwebkit2gtk-4.0-dev` (bullseye only ships 4.0)

## Why
The Linux binary built on bookworm fails on Ubuntu 22.04 with `version GLIBC_2.36 not found`. Bullseye's glibc 2.31 covers Ubuntu 20.04, 22.04, 24.04 and current Debian/RHEL.

Stacked on top of #58.

## Test plan
- [ ] Workflow builds `lium-linux-amd64` successfully
- [ ] Binary runs on Ubuntu 22.04 (`./lium-linux-amd64 --version`)
- [ ] Binary runs on Ubuntu 24.04