### PR TITLE
feat: release from GitHub tag (hatch-vcs, no manual version bumps)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,16 @@
 name: Build and Publish Python Package
-run-name: Release ${{ inputs.version }} (${{ inputs.release_mode }})
+run-name: >-
+  ${{ github.event_name == 'release'
+      && format('Release {0}', github.event.release.tag_name)
+      || format('Manual {0}', inputs.release_mode) }}
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version to release"
-        required: true
-        type: string
       release_mode:
-        description: "Which release path to run"
+        description: "Which release path to run (ignored for release events)"
         required: true
         type: choice
         default: build-only
@@ -19,8 +20,8 @@ on:
         - full-release
 
 env:
-  RELEASE_VERSION: ${{ inputs.version }}
-  RELEASE_TAG: v${{ inputs.version }}
+  RELEASE_TAG: >-
+    ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
 
 jobs:
   build-python:
@@ -30,29 +31,13 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-
-    - name: Validate requested version
-      run: |
-        python - <<'PY'
-        import tomllib
-        from pathlib import Path
-        import os
-
-        version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
-        about_ns = {}
-        exec(Path("lium/__about__.py").read_text(), about_ns)
-        module_version = about_ns["__version__"]
-        requested = os.environ["RELEASE_VERSION"]
-        if requested != version:
-            raise SystemExit(f"Requested version {requested!r} does not match pyproject version {version!r}")
-        if module_version != version:
-            raise SystemExit(f"lium.__about__.__version__ {module_version!r} does not match pyproject version {version!r}")
-        PY
 
     - name: Install dependencies
       run: |
@@ -104,6 +89,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Build Linux binary in Docker
       run: |
@@ -150,6 +137,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -191,7 +180,9 @@ jobs:
 
   release-assets:
     name: Publish GitHub release assets
-    if: ${{ inputs.release_mode != 'build-only' }}
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && inputs.release_mode != 'build-only')
     needs:
     - build-python
     - validate-binary-targets
@@ -203,6 +194,20 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Resolve release tag
+      id: tag
+      run: |
+        if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+          TAG="${{ github.event.release.tag_name }}"
+        else
+          TAG="$(git describe --tags --abbrev=0)"
+        fi
+        VERSION="${TAG#v}"
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Download Python artifact
       uses: actions/download-artifact@v4
@@ -245,9 +250,11 @@ jobs:
           cat release-assets/darwin-arm64/lium-darwin-arm64.sha256
         } > release-assets/checksums.txt
 
-    - name: Create or update GitHub release
+    - name: Upload assets to GitHub release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        RELEASE_VERSION: ${{ steps.tag.outputs.version }}
       run: |
         gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
           gh release create "$RELEASE_TAG" \
@@ -270,7 +277,10 @@ jobs:
           --clobber
 
   approve-and-publish:
-    if: ${{ inputs.release_mode == 'full-release' }}
+    name: Publish Python package to PyPI
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && inputs.release_mode == 'full-release')
     needs: build-python
     runs-on: ubuntu-latest
     environment: release

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# hatch-vcs generated version file
+lium/_version.py
+
 # C extensions
 *.so
 

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,6 @@
 """Project version metadata."""
 
-__version__ = "0.0.7"
+try:
+    from lium._version import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.7"
+dynamic = ["version"]
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -57,6 +57,15 @@ docs = ["sphinx>=7.3", "sphinx-rtd-theme>=1.3"]
 
 [project.scripts]
 lium = "lium.cli.cli:main"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "lium/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["lium"]


### PR DESCRIPTION
## Summary
- Version sourced from git tags via `hatch-vcs`; no manual edits in `pyproject.toml` / `__about__.py` for releases
- Workflow triggers on `release: published` — **create a GitHub release in UI → everything builds and ships**
- `workflow_dispatch` kept as a fallback with `build-only` / `github-release` / `full-release` modes for ad-hoc runs (without a tag input)
- Removed version-validation step (no longer needed — tag is the source of truth)

## How a release works now
1. Open **Releases → Draft a new release** in GitHub.
2. Create tag `v0.0.8` on the target commit, write notes, click **Publish release**.
3. Workflow fires automatically and builds wheel + 4 binaries (linux-amd64/arm64, darwin-amd64/arm64) from the tagged sha.
4. Assets uploaded to the release; Python distributions published to PyPI.

Version `0.0.8` is baked into the wheel, `lium --version`, and asset names — no files edited.

## Implementation notes
- `pyproject.toml`: `dynamic = [\"version\"]` + `[tool.hatch.version] source = \"vcs\"` + `[tool.hatch.build.hooks.vcs] version-file = \"lium/_version.py\"`
- `local_scheme = \"no-local-version\"` so PyPI accepts dev builds when needed
- `lium/__about__.py` now re-exports from the generated `lium/_version.py` with a `0.0.0+unknown` fallback
- `lium/_version.py` added to `.gitignore` (written at build time by hatch-vcs)
- All `checkout@v4` steps now use `fetch-depth: 0` so hatch-vcs can see the tag/history inside Docker and macOS runners
- PyInstaller bundles `_version.py` as part of the `lium` package; `get_version()` fallback chain still honors `LIUM_BUILD_VERSION`

## Stacked on
#58 and #59. Merge order: #58 → #59 → this.

## Test plan
- [ ] `uv sync` locally populates `lium/_version.py` with a sensible dev version
- [ ] Manual `workflow_dispatch` with `build-only` passes (builds wheel + all binaries, no publish)
- [ ] Draft + publish `v0.0.X-test` on a throwaway commit → workflow publishes release assets + PyPI (TestPyPI if configured)
- [ ] `lium --version` of the freshly built binary shows `0.0.X-test`