### PR TITLE
DAH-1874 - Drop deprecated price_per_gpu_hour and fix pod $/h display

### DIFF
--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -106,7 +106,7 @@ def _sort_key_factory(name: str) -> Callable[[ExecutorInfo], Any]:
     """Get sort key function by name."""
     mapping = {
         "download": lambda e: -e.download_speed,
-        "price_gpu": lambda e: e.price_per_gpu_hour or 0.0,  # TODO: DAH-1874 - deprecated
+        "price_gpu": lambda e: e.price_per_gpu or 0.0,
         "price_total": lambda e: e.price_per_hour or 0.0,
         "loc": lambda e: _country_name(e.location),
         "id": lambda e: e.huid,
@@ -215,7 +215,7 @@ def build_executors_table(
             str(idx),
             huid_display,
             _cfg(exe),
-            console.get_styled(_money(exe.price_per_gpu_hour), 'success'),  # TODO: DAH-1874 - deprecated
+            console.get_styled(_money(exe.price_per_gpu), 'success'),
             _country_name(exe.location),
             s["VRAM"],
             s["RAM"],

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -285,8 +285,7 @@ def extract_executor_metrics(executor: ExecutorInfo) -> Dict[str, float]:
     net_down = executor.download_speed
 
     return {
-        'price_per_gpu_hour': executor.price_per_gpu_hour or float('inf'), # TODO: DAH-1874 - deprecated
-        'price_per_gpu': executor.price_per_gpu,
+        'price_per_gpu': executor.price_per_gpu or float('inf'),
         'vram_gb': ((gpu_details.get("capacity") or 0) / 1024) if gpu_details else 0,  # MiB to GB
         'ram_gb': ((ram_data.get("total") or 0) / (1024 * 1024)) if ram_data else 0,  # KB to GB
         'disk_gb': ((disk_data.get("total") or 0) / (1024 * 1024)) if disk_data else 0,  # KB to GB
@@ -300,7 +299,7 @@ def extract_executor_metrics(executor: ExecutorInfo) -> Dict[str, float]:
     }
 
 
-_MINIMIZE_METRICS = frozenset({'price_per_gpu_hour', 'price_per_gpu'})  # TODO: DAH-1874 - deprecated price_per_gpu_hour
+_MINIMIZE_METRICS = frozenset({'price_per_gpu'})
 _SECONDARY_METRICS = ('total_bandwidth', 'location_score', 'net_up')
 # Metrics excluded from the equal-price residual sweep: already handled above, or
 # minimize-metrics whose direction the residual loop does not account for.
@@ -325,10 +324,10 @@ def dominates(metrics_a: Dict[str, float], metrics_b: Dict[str, float]) -> bool:
         return False  # B is significantly faster — A cannot dominate
 
     # --- Download speeds are similar; fall back to price-based logic ---
-    price_a_value = metrics_a.get('price_per_gpu_hour')
-    price_b_value = metrics_b.get('price_per_gpu_hour')
-    price_a = price_a_value if price_a_value is not None else float('inf')  # TODO: DAH-1874 - deprecated
-    price_b = price_b_value if price_b_value is not None else float('inf')  # TODO: DAH-1874 - deprecated
+    price_a_value = metrics_a.get('price_per_gpu')
+    price_b_value = metrics_b.get('price_per_gpu')
+    price_a = price_a_value if price_a_value is not None else float('inf')
+    price_b = price_b_value if price_b_value is not None else float('inf')
 
     if abs(price_a - price_b) < 0.01:  # Prices are effectively equal
         # Check secondary metrics in priority order; both A and B must be

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -146,7 +146,6 @@ class Lium:
             gpu_type=gpu_type,
             gpu_count=gpu_count,
             price_per_hour=price_per_hour,
-            price_per_gpu_hour=price_per_hour / max(1, gpu_count), # deprecated field
             price_per_gpu=price_per_gpu,
             location=executor_dict.get("location", {}),
             specs=specs,
@@ -363,8 +362,17 @@ class Lium:
         """
         data = self._request("GET", "/pods").json()
 
-        pods = [
-            PodInfo(
+        pods = []
+        for d in data:
+            executor = self._dict_to_executor_info(d.get("executor") or {}) if d.get("executor") else None
+            # The /pods endpoint returns the authoritative total $/h as pod.price; the
+            # nested executor.price_per_gpu is not populated in this payload. Anchor
+            # executor.price_per_hour on pod.price and derive per-GPU from it.
+            pod_price = d.get("price")
+            if executor is not None and pod_price is not None:
+                executor.price_per_hour = float(pod_price)
+                executor.price_per_gpu = float(pod_price) / max(1, executor.gpu_count)
+            pods.append(PodInfo(
                 id=d.get("id", ""),
                 name=d.get("pod_name", ""),
                 status=d.get("status", "unknown"),
@@ -373,14 +381,12 @@ class Lium:
                 ports=d.get("ports_mapping", {}),
                 created_at=d.get("created_at", ""),
                 updated_at=d.get("updated_at", ""),
-                executor=self._dict_to_executor_info(d.get("executor", {})) if d.get("executor") else None,
+                executor=executor,
                 template=d.get("template", {}),
                 removal_scheduled_at=d.get("removal_scheduled_at"),
                 jupyter_installation_status=d.get("jupyter_installation_status"),
                 jupyter_url=d.get("jupyter_url")
-            )
-            for d in data
-        ]
+            ))
 
         return pods
 
@@ -915,7 +921,6 @@ class Lium:
                 gpu_type=response.get("gpu_name", ""),
                 gpu_count=int(response.get("gpu_count", 0) or 0),
                 price_per_hour=0.0,
-                price_per_gpu_hour=0.0,  # TODO: DAH-1874 - deprecated
                 price_per_gpu=0.0,
                 location={},
                 specs={},

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -14,7 +14,6 @@ class ExecutorInfo:
     gpu_count: int
     price_per_hour: float
     price_per_gpu: float
-    price_per_gpu_hour: float # TODO: DAH-1874 - deprecated field
     location: Dict
     specs: Dict
     status: str

--- a/test/test_binary_build_runtime.py
+++ b/test/test_binary_build_runtime.py
@@ -48,7 +48,7 @@ def test_themed_console_loads_themes_from_meipass(monkeypatch, tmp_path):
 
 
 def test_dominates_handles_missing_price_without_unboundlocalerror():
-    better = {"price_per_gpu_hour": None, "total_bandwidth": 100, "location_score": 1.0, "net_down": 50, "net_up": 50}
-    worse = {"price_per_gpu_hour": 2.0, "total_bandwidth": 10, "location_score": 0.0, "net_down": 5, "net_up": 5}
+    better = {"price_per_gpu": None, "total_bandwidth": 100, "location_score": 1.0, "net_down": 50, "net_up": 50}
+    worse = {"price_per_gpu": 2.0, "total_bandwidth": 10, "location_score": 0.0, "net_down": 5, "net_up": 5}
 
     assert isinstance(dominates(better, worse), bool)


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1874](https://www.notion.so/DAH-1874)

## Problem

The backend migration on 2025-11-05 made `executor.price_per_gpu` the authoritative per-GPU hourly price and added a top-level `pod.price` field for total pod hourly. The SDK still exposed a derived `ExecutorInfo.price_per_gpu_hour` (= `price_per_hour / gpu_count`) that round-tripped the backend's own `price_per_gpu` through `gpu_count` — a no-op on paper, a silent bug the moment the two gpu-count sources ever drift. The field was already marked for removal with `# TODO: DAH-1874` markers across the codebase.

Separately, `lium ps` displayed `$0.00/h` and `$0.00 spent` for every running pod. The `/pods` endpoint returns a populated top-level `pod.price` but leaves the nested `executor.price_per_gpu` as `None`, and the SDK was reading only the nested field.

## Solution

- Remove `ExecutorInfo.price_per_gpu_hour` and every call site.
- Route `lium ls` (sort key + `$/GPU·h` column) and the Pareto `dominates()` logic to the backend-authoritative `price_per_gpu`.
- In `ps()`, when `pod.price` is present, anchor `executor.price_per_hour = pod.price` and derive `executor.price_per_gpu = pod.price / gpu_count` so the embedded executor stays internally consistent.
- Keep the repo's defensive `.get(...)` + `None`-check pattern in `dominates()` (matches the CLAUDE.md none-safe numeric convention).

## Changes

- `lium/sdk/models.py`: drop `price_per_gpu_hour` field from `ExecutorInfo`.
- `lium/sdk/client.py`: stop deriving the deprecated field in `_dict_to_executor_info` and in the `switch-template` fallback path; anchor `ps()`-returned executor prices on `pod.price`.
- `lium/cli/ls/display.py`: sort key `price_gpu` and `$/GPU·h` column now read `price_per_gpu`.
- `lium/cli/utils.py`: `extract_executor_metrics` emits `price_per_gpu` only (with `float('inf')` guard); `_MINIMIZE_METRICS = {'price_per_gpu'}`; `dominates()` keys on `price_per_gpu`.
- `test/test_binary_build_runtime.py`: regression guard for `None`-price now uses the new key so it still exercises the actual branch in `dominates()`.

## Deployment Steps

Standard PyPI release via the existing release workflow; no infra steps.

## Review Request

- [ ] Just code review
- [ ] QA – local test on reviewer side

## Other PRs

None.

## Risks

- **Public SDK break**: removing `ExecutorInfo.price_per_gpu_hour` is a dataclass-field removal. Any third-party SDK user reading that attribute will raise `AttributeError`. The value it carried was always numerically equal to `price_per_gpu`, so the migration path is a straight rename.
- **Pod-price anchoring assumes `pod.price` from the backend**: if the backend ever stops populating `pod.price`, the fallback path (nested executor fields only) reverts to the previous `None`-derived behavior. Out-of-band monitoring of the `$/h` column in `lium ps` would catch this.

## Test Cases

### Test Case 1 — `lium ls` renders per-GPU price from the backend

**Actions**
1. `lium ls --sort price_gpu --limit 5`
2. For the top row, compare the displayed `$/GPU·h` against the backend's `executor.price_per_gpu` field.

**Expected Output**
Displayed value equals backend `price_per_gpu` exactly (no division artifact). Ascending order after the Pareto-starred row.

### Test Case 2 — `lium ps` shows non-zero hourly cost

**Actions**
1. With at least one running pod, run `lium ps`.
2. Confirm the `$/h` column is non-zero and `Spent` increments with uptime.

**Expected Output**
`$/h = pod.price` from the backend; `executor.price_per_hour == price_per_gpu × gpu_count`.

### Test Case 3 — Pareto logic unchanged

**Actions**
1. Run `pytest test/` — in particular `test_dominates_handles_missing_price_without_unboundlocalerror`.

**Expected Output**
40 tests pass. `dominates({'price_per_gpu': None, ...}, ...)` returns a bool without raising.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described