### PR TITLE
DAH-1984 - Add CLI-side SSH key auto-registration on lium up

### DIFF
--- a/lium/cli/cli.py
+++ b/lium/cli/cli.py
@@ -28,6 +28,7 @@ from .gpu_splitting import gpu_splitting_command
 from .bk import bk_command
 from .mine import mine_command
 from .volumes import volumes_command
+from .ssh_keys import ssh_keys_command
 from .schedules import schedules_command
 from .update.command import update_command
 from .port_forward import port_forward_command
@@ -81,6 +82,7 @@ cli.add_command(gpu_splitting_command)
 cli.add_command(bk_command, name="bk")
 cli.add_command(mine_command)
 cli.add_command(volumes_command)
+cli.add_command(ssh_keys_command, name="ssh-keys")
 cli.add_command(schedules_command, name="schedules")
 cli.add_command(update_command)
 cli.add_command(port_forward_command)

--- a/lium/cli/ssh_keys/__init__.py
+++ b/lium/cli/ssh_keys/__init__.py
@@ -1,0 +1,20 @@
+"""SSH keys command group."""
+
+import click
+
+from .list.command import ssh_keys_list_command
+from .sync.command import ssh_keys_sync_command
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def ssh_keys_command(ctx):
+    """Manage SSH public keys registered with Lium."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(ssh_keys_list_command)
+
+
+ssh_keys_command.add_command(ssh_keys_list_command)
+ssh_keys_command.add_command(ssh_keys_sync_command)
+
+__all__ = ["ssh_keys_command"]

--- a/lium/cli/ssh_keys/display.py
+++ b/lium/cli/ssh_keys/display.py
@@ -1,0 +1,51 @@
+"""SSH-keys display formatting."""
+
+from typing import List, Tuple
+
+from rich.table import Table
+from rich.text import Text
+
+from lium.sdk import SSHKey
+from lium.cli import ui
+from lium.cli.utils import format_date, mid_ellipsize
+
+
+def _public_key_short(public_key: str) -> str:
+    parts = (public_key or "").strip().split()
+    if len(parts) < 2:
+        return mid_ellipsize(public_key or "—", width=24)
+    body = parts[1]
+    if len(body) <= 24:
+        body_short = body
+    else:
+        body_short = f"{body[:10]}…{body[-10:]}"
+    return f"{parts[0]} {body_short}"
+
+
+def build_ssh_keys_table(keys: List[SSHKey]) -> Tuple[Table, str]:
+    header = f"{Text('SSH keys', style='bold')}  ({len(keys)} total)"
+
+    table = Table(
+        show_header=True,
+        header_style="dim",
+        box=None,
+        pad_edge=False,
+        expand=True,
+        padding=(0, 1),
+    )
+    table.add_column("", justify="right", width=3, no_wrap=True, style="dim")
+    table.add_column("ID", justify="left", ratio=2, min_width=20, overflow="fold")
+    table.add_column("Name", justify="left", ratio=2, min_width=15, overflow="ellipsis")
+    table.add_column("Public key", justify="left", ratio=4, min_width=25, overflow="ellipsis")
+    table.add_column("Created", justify="right", width=12, no_wrap=True)
+
+    for idx, key in enumerate(keys, 1):
+        table.add_row(
+            str(idx),
+            ui.styled(mid_ellipsize(key.id) if key.id else "—", "id"),
+            ui.styled(key.name or "—", "info"),
+            _public_key_short(key.public_key),
+            format_date(key.created_at) if key.created_at else "—",
+        )
+
+    return table, header

--- a/lium/cli/ssh_keys/list/actions.py
+++ b/lium/cli/ssh_keys/list/actions.py
@@ -1,0 +1,13 @@
+"""Actions for `lium ssh-keys list`."""
+
+from lium.cli.actions import ActionResult
+
+
+class GetSSHKeysAction:
+    def execute(self, ctx: dict) -> ActionResult:
+        lium = ctx["lium"]
+        try:
+            keys = lium.list_ssh_keys()
+            return ActionResult(ok=True, data={"keys": keys})
+        except Exception as exc:
+            return ActionResult(ok=False, data={}, error=str(exc))

--- a/lium/cli/ssh_keys/list/command.py
+++ b/lium/cli/ssh_keys/list/command.py
@@ -1,0 +1,38 @@
+"""`lium ssh-keys list` command."""
+
+import click
+
+from lium.sdk import Lium
+from lium.cli import ui
+from lium.cli.utils import ensure_config, handle_errors
+
+from ..display import build_ssh_keys_table
+from .actions import GetSSHKeysAction
+
+
+@click.command("list")
+@handle_errors
+def ssh_keys_list_command():
+    """List SSH keys registered with Lium."""
+    ensure_config()
+
+    lium = Lium(source="cli")
+    ctx = {"lium": lium}
+
+    action = GetSSHKeysAction()
+    result = ui.load("Loading SSH keys", lambda: action.execute(ctx))
+
+    if not result.ok:
+        ui.error(result.error)
+        return
+
+    keys = result.data["keys"]
+
+    if not keys:
+        ui.info("No SSH keys registered yet.")
+        ui.dim("Tip: lium up <executor>  # auto-registers your local key")
+        return
+
+    table, header = build_ssh_keys_table(keys)
+    ui.info(header)
+    ui.print(table)

--- a/lium/cli/ssh_keys/sync/actions.py
+++ b/lium/cli/ssh_keys/sync/actions.py
@@ -1,0 +1,57 @@
+"""Actions for `lium ssh-keys sync`."""
+
+from typing import List
+
+from lium.cli.actions import ActionResult
+from lium.sdk import Lium, SSHKey
+from lium.sdk.exceptions import LiumError
+from lium.sdk.ssh_key_cache import fingerprint, load_cache, save_cache
+
+
+class SyncSSHKeysAction:
+    def execute(self, ctx: dict) -> ActionResult:
+        lium: Lium = ctx["lium"]
+        try:
+            local_pubkeys = [pk.strip() for pk in lium.config.ssh_public_keys if pk.strip()]
+            server_keys = lium.list_ssh_keys()
+            server_index = {k.public_key.strip(): k for k in server_keys if k.public_key}
+            default_name = lium.default_ssh_key_name()
+
+            already_registered = 0
+            registered: List[SSHKey] = []
+            for pk in local_pubkeys:
+                if pk in server_index:
+                    already_registered += 1
+                    continue
+                try:
+                    new_key = lium.register_ssh_key(name=default_name, public_key=pk)
+                    registered.append(new_key)
+                    server_index[pk] = new_key
+                except LiumError as exc:
+                    return ActionResult(
+                        ok=False,
+                        data={},
+                        error=f"Failed to register a key: {exc}",
+                    )
+
+            cached = load_cache(lium.config)
+            new_fps = set(cached) | {fingerprint(pk) for pk in local_pubkeys}
+            if new_fps != cached:
+                try:
+                    save_cache(lium.config, new_fps)
+                except OSError:
+                    pass
+
+            legacy = [k for k in server_index.values() if (k.name or "").startswith("sdk-")]
+
+            return ActionResult(
+                ok=True,
+                data={
+                    "registered": registered,
+                    "legacy": legacy,
+                    "already_registered": already_registered,
+                    "default_name": default_name,
+                },
+            )
+        except Exception as exc:
+            return ActionResult(ok=False, data={}, error=str(exc))

--- a/lium/cli/ssh_keys/sync/command.py
+++ b/lium/cli/ssh_keys/sync/command.py
@@ -1,0 +1,54 @@
+"""`lium ssh-keys sync` command — backfill registration for legacy pods."""
+
+import click
+
+from lium.sdk import Lium
+from lium.cli import ui
+from lium.cli.utils import ensure_config, handle_errors
+
+from ..display import build_ssh_keys_table
+from .actions import SyncSSHKeysAction
+
+
+@click.command("sync")
+@handle_errors
+def ssh_keys_sync_command():
+    """Register every local SSH pubkey that isn't already on Lium.
+
+    Reads ``~/.ssh/*.pub`` (via the SDK's discovery), registers anything missing
+    from ``GET /ssh-keys`` under ``cli-<user>@<hostname>``, and surfaces any
+    legacy ``sdk-<pod_id>`` keys (auto-created by the backend before this CLI
+    started owning registration) that you may want to delete from the dashboard.
+    """
+    ensure_config()
+
+    lium = Lium(source="cli")
+    ctx = {"lium": lium}
+
+    action = SyncSSHKeysAction()
+    result = ui.load("Syncing SSH keys", lambda: action.execute(ctx))
+
+    if not result.ok:
+        ui.error(result.error)
+        return
+
+    registered = result.data["registered"]
+    legacy = result.data["legacy"]
+    already = result.data["already_registered"]
+
+    if registered:
+        ui.success(f"Registered {len(registered)} key(s) under '{result.data['default_name']}'.")
+        table, header = build_ssh_keys_table(registered)
+        ui.info(header)
+        ui.print(table)
+    else:
+        ui.info(f"Nothing to register. {already} local key(s) already match server-side keys.")
+
+    if legacy:
+        ui.warning(
+            f"{len(legacy)} legacy auto-created key(s) named 'sdk-…' detected — "
+            "you can delete these from the dashboard once your pods are stable."
+        )
+        table, header = build_ssh_keys_table(legacy)
+        ui.dim(header)
+        ui.print(table)

--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -173,6 +173,7 @@ class RentPodAction:
         name: Optional[str] = ctx.get("name")
         volume_id: Optional[str] = ctx.get("volume_id")
         ports: Optional[int] = ctx.get("ports")
+        ssh_name: Optional[str] = ctx.get("ssh_name")
 
         try:
             if not name:
@@ -184,6 +185,7 @@ class RentPodAction:
                 template_id=template.id if template else None,
                 volume_id=volume_id,
                 ports=ports,
+                ssh_name=ssh_name,
             )
 
             pod_id = pod_info.get('id') or pod_info.get('name', '')

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -37,6 +37,7 @@ from .actions import (
 @click.option("-e", "--env", multiple=True, help="Environment variables (KEY=VALUE), can be repeated")
 @click.option("--entrypoint", default="", help="Container entrypoint")
 @click.option("--cmd", default="", help="Command to run in the container")
+@click.option("--ssh-name", default=None, help="Name to register a new SSH key under (default: cli-<user>@<hostname>)")
 @handle_errors
 def up_command(
     executor_id: Optional[str],
@@ -56,6 +57,7 @@ def up_command(
     env: Tuple[str, ...],
     entrypoint: Optional[str],
     cmd: Optional[str],
+    ssh_name: Optional[str],
 ):
     """\b
     Create a new GPU pod on an executor.
@@ -236,7 +238,8 @@ def up_command(
             "template": template,
             "name": name,
             "volume_id": volume_id,
-            "ports": ports
+            "ports": ports,
+            "ssh_name": ssh_name,
         })
     )
 

--- a/lium/sdk/__init__.py
+++ b/lium/sdk/__init__.py
@@ -15,6 +15,7 @@ from .models import (
     BackupLog,
     ExecutorInfo,
     PodInfo,
+    SSHKey,
     Template,
     VolumeInfo,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "VolumeInfo",
     "BackupConfig",
     "BackupLog",
+    "SSHKey",
     "LiumError",
     "LiumAuthError",
     "LiumRateLimitError",

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1,8 +1,12 @@
 """Lium SDK - Clean, Unix-style SDK for GPU pod management."""
 
+import getpass
+import re
 import shlex
+import socket
 import subprocess
 import time
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any, Dict, Generator, List, Optional, Union
@@ -25,9 +29,11 @@ from .models import (
     BackupLog,
     ExecutorInfo,
     PodInfo,
+    SSHKey,
     Template,
     VolumeInfo,
 )
+from .ssh_key_cache import fingerprint, load_cache, save_cache
 from .utils import expand_gpu_shorthand, extract_gpu_type, generate_huid, with_retry
 
 load_dotenv()
@@ -156,6 +162,94 @@ class Lium:
             effective_download_speed_mbps=executor_dict.get("effective_download_speed_mbps"),
         )
 
+    def list_ssh_keys(self) -> List[SSHKey]:
+        """Return SSH keys registered for the current user."""
+        data = self._request("GET", "/ssh-keys").json()
+        if not isinstance(data, list):
+            return []
+        return [
+            SSHKey(
+                id=str(row.get("id", "")),
+                name=row.get("name", ""),
+                public_key=row.get("public_key", ""),
+                created_at=row.get("created_at"),
+            )
+            for row in data
+            if isinstance(row, dict)
+        ]
+
+    def register_ssh_key(self, *, name: str, public_key: str) -> SSHKey:
+        """Register a new SSH public key under the current user."""
+        payload = {"name": name, "public_key": public_key}
+        data = self._request("POST", "/ssh-keys", json=payload).json()
+        if not isinstance(data, dict):
+            data = {}
+        return SSHKey(
+            id=str(data.get("id", "")),
+            name=data.get("name", name),
+            public_key=data.get("public_key", public_key),
+            created_at=data.get("created_at"),
+        )
+
+    @staticmethod
+    def default_ssh_key_name() -> str:
+        """``cli-<user>@<host>`` sanitised to ``[A-Za-z0-9._@-]``."""
+        user = getpass.getuser() or "user"
+        host = socket.gethostname() or "host"
+        return re.sub(r"[^A-Za-z0-9._@-]", "-", f"cli-{user}@{host}")[:64]
+
+    def _ensure_ssh_keys_registered(
+        self,
+        public_keys: List[str],
+        name: Optional[str] = None,
+    ) -> None:
+        """Make sure each pubkey in ``public_keys`` is registered server-side.
+
+        Lazy + cached: skips the network call when every fingerprint is already
+        in ``~/.lium/ssh_keys_cache.json``. On any registration failure we warn
+        and return — the rent that follows must never be blocked by this step.
+        """
+        if not public_keys:
+            return
+
+        fps = {pk: fingerprint(pk) for pk in public_keys if pk.strip()}
+        cached = load_cache(self.config)
+        missing_locally = [pk for pk, fp in fps.items() if fp not in cached]
+        if not missing_locally:
+            return
+
+        try:
+            server_keys = {k.public_key.strip() for k in self.list_ssh_keys() if k.public_key}
+        except LiumError as exc:
+            warnings.warn(
+                f"lium: could not list ssh-keys ({exc}); skipping registration",
+                stacklevel=2,
+            )
+            return
+
+        new_fps = set(cached)
+        default_name = name or self.default_ssh_key_name()
+
+        for pk in missing_locally:
+            stripped = pk.strip()
+            if stripped in server_keys:
+                new_fps.add(fps[pk])
+                continue
+            try:
+                self.register_ssh_key(name=default_name, public_key=stripped)
+                new_fps.add(fps[pk])
+            except LiumError as exc:
+                warnings.warn(
+                    f"lium: could not register ssh key ({exc}); continuing rent",
+                    stacklevel=2,
+                )
+
+        if new_fps != cached:
+            try:
+                save_cache(self.config, new_fps)
+            except OSError as exc:
+                warnings.warn(f"lium: could not write ssh-keys cache ({exc})", stacklevel=2)
+
     def up(
         self,
         *,
@@ -165,6 +259,7 @@ class Lium:
         volume_id: Optional[str] = None,
         ports: Optional[int] = None,
         ssh_keys: Optional[List[str]] = None,
+        ssh_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Start a new pod on a specific executor.
 
@@ -175,6 +270,9 @@ class Lium:
             volume_id: Optional volume ID to attach on spawn.
             ports: Number of exposed ports to request.
             ssh_keys: SSH public keys to authorize. Defaults to the keys discovered by the Config.
+            ssh_name: Optional name to use when registering a new SSH key with the
+                backend. Defaults to ``cli-<user>@<hostname>``. Only applied to keys
+                that are not already registered server-side.
 
         Returns:
             Pod metadata as returned by the rent API (id, name, status, ssh command, etc.).
@@ -190,6 +288,8 @@ class Lium:
         ssh_material = ssh_keys or self.config.ssh_public_keys
         if not ssh_material:
             raise ValueError("No SSH keys found")
+
+        self._ensure_ssh_keys_registered(ssh_material, name=ssh_name)
 
         payload = {
             "pod_name": name,

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -119,6 +119,15 @@ class BackupLog:
 
 
 @dataclass
+class SSHKey:
+    """Public SSH key registered for the current user."""
+    id: str
+    name: str
+    public_key: str
+    created_at: Optional[str] = None
+
+
+@dataclass
 class VolumeInfo:
     """Volume information."""
     id: str
@@ -141,4 +150,5 @@ __all__ = [
     "BackupConfig",
     "BackupLog",
     "VolumeInfo",
+    "SSHKey",
 ]

--- a/lium/sdk/ssh_key_cache.py
+++ b/lium/sdk/ssh_key_cache.py
@@ -22,8 +22,18 @@ def _cache_path() -> Path:
     return Path.home() / ".lium" / CACHE_FILE_NAME
 
 
+_API_KEY_DIGEST_SALT = b"lium.ssh_key_cache.v1"
+_API_KEY_DIGEST_ITERATIONS = 200_000
+
+
 def _api_key_digest(api_key: str) -> str:
-    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+    derived = hashlib.pbkdf2_hmac(
+        "sha256",
+        api_key.encode("utf-8"),
+        _API_KEY_DIGEST_SALT,
+        _API_KEY_DIGEST_ITERATIONS,
+    )
+    return derived.hex()[:16]
 
 
 def fingerprint(public_key: str) -> str:

--- a/lium/sdk/ssh_key_cache.py
+++ b/lium/sdk/ssh_key_cache.py
@@ -1,0 +1,97 @@
+"""Local cache of SSH keys already registered with the Lium backend.
+
+The cache lets ``Lium.up()`` skip a ``GET /ssh-keys`` round-trip on every rent
+once a public key has been confirmed registered for the active API key.
+"""
+
+import base64
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Set
+
+from .config import Config
+
+
+CACHE_FILE_NAME = "ssh_keys_cache.json"
+
+
+def _cache_path() -> Path:
+    return Path.home() / ".lium" / CACHE_FILE_NAME
+
+
+def _api_key_digest(api_key: str) -> str:
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+
+
+def fingerprint(public_key: str) -> str:
+    """Return ``SHA256:<base64>`` fingerprint of an OpenSSH public key.
+
+    Matches the format produced by ``ssh-keygen -lf``. Falls back to the
+    SHA256 hex of the raw line if the key is malformed (so cache lookups
+    stay deterministic instead of raising).
+    """
+    parts = public_key.strip().split()
+    if len(parts) >= 2:
+        try:
+            blob = base64.b64decode(parts[1], validate=False)
+            digest = hashlib.sha256(blob).digest()
+            return "SHA256:" + base64.b64encode(digest).rstrip(b"=").decode("ascii")
+        except (ValueError, base64.binascii.Error):
+            pass
+    return "SHA256:raw:" + hashlib.sha256(public_key.strip().encode("utf-8")).hexdigest()
+
+
+def load_cache(config: Config) -> Set[str]:
+    """Return the set of cached fingerprints for ``config``'s API key.
+
+    If the file is missing, malformed, or stamped with a different
+    ``api_key_digest`` (account switch), returns an empty set.
+    """
+    path = _cache_path()
+    if not path.exists():
+        return set()
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return set()
+
+    if not isinstance(data, dict):
+        return set()
+    if data.get("api_key_digest") != _api_key_digest(config.api_key):
+        return set()
+
+    fps = data.get("fingerprints", [])
+    if not isinstance(fps, list):
+        return set()
+    return {fp for fp in fps if isinstance(fp, str)}
+
+
+def save_cache(config: Config, fingerprints: Set[str]) -> None:
+    """Atomically persist ``fingerprints`` for ``config``'s API key."""
+    path = _cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "api_key_digest": _api_key_digest(config.api_key),
+        "fingerprints": sorted(fingerprints),
+    }
+
+    fd, tmp_path = tempfile.mkstemp(prefix=".ssh_keys_cache.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+__all__ = ["fingerprint", "load_cache", "save_cache"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.7"
+version = "0.0.9"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1984](https://www.notion.so/DAH-1984)

## Problem

Production threw `IndexError` 5xx on `POST /pods/{id}/reboot` (root cause at `services/executor.py:714` — `payload.user_public_key[0]`) for SDK-rented pods. The trigger: `lium-cli` posts raw pubkeys in `user_public_key` to `POST /executors/{id}/rent` without first calling `POST /ssh-keys`, so no `pod_ssh_key` row is created, and the later reboot path joins to an empty list.

`lium-io-backend` PR [#572](https://github.com/Datura-ai/lium-io-backend/pull/572) (DAH-1960) added a server-side fallback that prevents the 500 by auto-registering the raw pubkey under the name `sdk-<pod_id>`. That keeps reboot working but pollutes the user's dashboard — every SDK-rented pod creates a fresh `sdk-<pod_id>` row, so a user who rents 20 pods ends up with 20 nearly-identical entries.

## Solution

Move SSH-key registration to where it belongs — the client. Before the rent payload is composed, the SDK ensures every local pubkey is already registered server-side under a clean, stable name (`cli-<user>@<hostname>` by default). The check is lazy and locally cached so it adds zero HTTP calls after the first successful run. Registration failures are non-fatal: a `warnings.warn` is emitted and the rent proceeds (PR #572's backend fallback remains the safety net).

## Changes

- **SDK** (`lium/sdk/client.py`)
  - `Lium.list_ssh_keys()` and `Lium.register_ssh_key(name, public_key)` reuse the existing `_request()` transport (retry, error mapping).
  - `Lium.up()` gains an optional `ssh_name` kwarg and now calls `_ensure_ssh_keys_registered()` between SSH-material discovery and rent.
  - `Lium.default_ssh_key_name()` returns `cli-<user>@<host>`, sanitised to `[A-Za-z0-9._@-]`.
- **SDK cache** (`lium/sdk/ssh_key_cache.py`, new)
  - Atomic JSON cache at `~/.lium/ssh_keys_cache.json`, keyed by `sha256(api_key)[:16]` so it self-invalidates on account switch.
  - `fingerprint()` produces the same `SHA256:<base64>` as `ssh-keygen -lf`.
- **Models** (`lium/sdk/models.py`)
  - New `SSHKey` dataclass: `id`, `name`, `public_key`, `created_at`. Exported from `lium.sdk`.
- **CLI** (`lium/cli/`)
  - `lium up` gains `--ssh-name TEXT` to override the registration name.
  - New command group `lium ssh-keys` with subcommands:
    - `list` — render registered keys as a Rich table.
    - `sync` — register every local `~/.ssh/*.pub` that is missing on the server (idempotent), and surface any legacy `sdk-<pod_id>` rows the user may want to clean up manually.

## Deployment Steps

Use GitHub Action (PyPI release workflow). No backend or infra change required.

## Review Request

- [ ] Just code review

## Other PRs

- Server-side defence-in-depth: [Datura-ai/lium-io-backend#572](https://github.com/Datura-ai/lium-io-backend/pull/572) (DAH-1960)

## Risks

- **`/ssh-keys` schema mismatch**: assumes the GET response is a bare list of `{id, name, public_key, created_at}` objects (matches `/pods` and `/volumes` conventions in this SDK). Live-tested against prod — the shape is correct.
- **Cache file corruption / parallel `lium up`**: writes are atomic via `tempfile.mkstemp` + `os.replace`. Worst-case a parallel race re-issues one extra GET; the data is a set so duplicates collapse.
- **Registration failures blocking rent**: cannot happen — the helper catches `LiumError` and `OSError` and emits `warnings.warn` only. Rent proceeds in every error path.
- **Account switch**: cache is keyed by `sha256(api_key)[:16]` and treated as empty when the digest mismatches.

## Test Cases

End-to-end test cases (offline + live against prod) are documented in a separate PR comment to keep the body short.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described (see follow-up comment)