### PR TITLE
fix: sync __about__.__version__ with pyproject (0.0.10)

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.7"
+__version__ = "0.0.10"


### PR DESCRIPTION
## Summary
- `lium/__about__.py` was stuck at `0.0.7` while `pyproject.toml` advanced to `0.0.10`, breaking the release CI consistency check (`__version__ does not match pyproject version`).
- Bump `__about__.__version__` to `0.0.10` so both sources agree.

## Test plan
- [x] CI: release pipeline version-check step should pass