### PR TITLE
glibc fix, sudo-safe installer, cli-auth fix, JSON output for ls/ps

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bullseye
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"

--- a/lium/cli/init/auth.py
+++ b/lium/cli/init/auth.py
@@ -20,13 +20,10 @@ class quiet_fds:
 def init_auth() -> tuple[str, str]:
     """Request a new auth session. Returns (browser_url, session_id)."""
     url = "https://lium.io/api/cli-auth/init"
-    resp = requests.post(url,
-        json={"callback_url": "http://localhost:8080/auth/callback"},
-        headers={"Content-Type": "application/json"},
-        timeout=10
-    )
+    resp = requests.post(url, timeout=10)
     resp.raise_for_status()
-    return resp.json()["browser_url"], resp.json()["session_id"]
+    data = resp.json()
+    return data["browser_url"], data["session_id"]
 
 def poll_auth(session_id: str, max_attempts: int = 6, interval: int = 5) -> Optional[str]:
     """Poll for auth approval. Returns API key or None on timeout."""
@@ -49,15 +46,16 @@ def browser_auth() -> Optional[str]:
     """Open browser for authentication and poll for approval."""
     try:
         browser_url, session_id = init_auth()
-
-        ui.info("Browser opened, waiting for authentication...")
-
-        with quiet_fds():
-            result = webbrowser.open(browser_url)
-
-        if not result:
-            ui.info(f"Opening browser failed. Please, open the page for authentication: {browser_url}")
-
-        return poll_auth(session_id)
-    except Exception:
+    except Exception as e:
+        ui.error(f"Failed to request auth URL: {e}")
         return None
+
+    ui.info("Browser opened, waiting for authentication...")
+
+    with quiet_fds():
+        result = webbrowser.open(browser_url)
+
+    if not result:
+        ui.info(f"Opening browser failed. Please, open the page for authentication: {browser_url}")
+
+    return poll_auth(session_id)

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -1,7 +1,6 @@
 """List (ls) command implementation."""
 
 import json
-from dataclasses import asdict
 from typing import Optional, List
 import click
 
@@ -115,10 +114,10 @@ def ls_command(
             executors, sort_by=sort_by, limit=limit
         )
         payload = [
-            {**asdict(exe), "is_pareto": is_pareto}
-            for exe, is_pareto in zip(sorted_executors, pareto_flags)
+            display.compact_executor(exe, is_pareto, idx)
+            for idx, (exe, is_pareto) in enumerate(zip(sorted_executors, pareto_flags), 1)
         ]
-        click.echo(json.dumps(payload, indent=2, default=str))
+        click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
         store_executor_selection(sorted_executors)
         return
 

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -1,5 +1,7 @@
 """List (ls) command implementation."""
 
+import json
+from dataclasses import asdict
 from typing import Optional, List
 import click
 
@@ -47,6 +49,12 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download")
     help="Sort result by the chosen field.",
 )
 @click.option("--limit", type=int, default=None, help="Limit number of rows shown.")
+@click.option(
+    "--format", "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format. 'json' emits machine-readable JSON to stdout (suitable for piping to jq).",
+)
 @handle_errors
 def ls_command(
     gpu_type: Optional[str],
@@ -56,6 +64,7 @@ def ls_command(
     max_distance: Optional[int],
     sort_by: str,
     limit: Optional[int],
+    output_format: str,
 ):
     """List available GPU executors."""
 
@@ -77,7 +86,10 @@ def ls_command(
     }
 
     action = GetExecutorsAction()
-    result = ui.load("Loading executors", lambda: action.execute(ctx))
+    if output_format == "json":
+        result = action.execute(ctx)
+    else:
+        result = ui.load("Loading executors", lambda: action.execute(ctx))
 
     if not result.ok:
         ui.error(result.error)
@@ -87,12 +99,27 @@ def ls_command(
 
     # Check if empty
     if not executors:
+        if output_format == "json":
+            click.echo("[]")
+            return
         if gpu_type:
             ui.error(f"All {gpu_type} GPUs are currently rented out")
             ui.info(f"Tip: {ui.styled('lium ls', 'success')}")
         else:
             ui.error("All GPUs are currently rented out")
             ui.info("Check back later or contact support if this persists")
+        return
+
+    if output_format == "json":
+        sorted_executors, pareto_flags = display.sort_executors(
+            executors, sort_by=sort_by, limit=limit
+        )
+        payload = [
+            {**asdict(exe), "is_pareto": is_pareto}
+            for exe, is_pareto in zip(sorted_executors, pareto_flags)
+        ]
+        click.echo(json.dumps(payload, indent=2, default=str))
+        store_executor_selection(sorted_executors)
         return
 
     # Build table

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -145,6 +145,30 @@ def format_tip() -> str:
     return f"Tip: {console.get_styled('lium up <index>', 'success')} {console.get_styled('# e.g. lium up 1', 'dim')}"
 
 
+def sort_executors(
+    executors: List[ExecutorInfo],
+    sort_by: str = "download",
+    limit: Optional[int] = None,
+    show_pareto: bool = True,
+) -> tuple[List[ExecutorInfo], List[bool]]:
+    """Apply Pareto-aware sort and limit. Returns (sorted_executors, pareto_flags)."""
+    if not executors:
+        return [], []
+
+    pareto_flags = calculate_pareto_frontier(executors) if show_pareto else [False] * len(executors)
+    pairs = list(zip(executors, pareto_flags))
+
+    if show_pareto:
+        pairs.sort(key=lambda x: (not x[1], _sort_key_factory(sort_by)(x[0])))
+    else:
+        pairs.sort(key=lambda x: _sort_key_factory(sort_by)(x[0]))
+
+    if isinstance(limit, int) and limit > 0:
+        pairs = pairs[:limit]
+
+    return [e for e, _ in pairs], [p for _, p in pairs]
+
+
 def build_executors_table(
     executors: List[ExecutorInfo],
     sort_by: str = "download",
@@ -156,31 +180,9 @@ def build_executors_table(
     if not executors:
         return None, [], "", ""
 
-    # Calculate Pareto frontier before sorting/limiting
-    pareto_flags = calculate_pareto_frontier(executors) if show_pareto else [False] * len(executors)
-
-    # Combine executors with their Pareto status for sorting
-    executors_with_pareto = list(zip(executors, pareto_flags))
-
-    # Sort with Pareto-optimal first, then by chosen criteria
-    if show_pareto:
-        executors_with_pareto = sorted(
-            executors_with_pareto,
-            key=lambda x: (not x[1], _sort_key_factory(sort_by)(x[0]))
-        )
-    else:
-        executors_with_pareto = sorted(
-            executors_with_pareto,
-            key=lambda x: _sort_key_factory(sort_by)(x[0])
-        )
-
-    # Apply limit
-    if isinstance(limit, int) and limit > 0:
-        executors_with_pareto = executors_with_pareto[:limit]
-
-    # Extract sorted executors and their Pareto flags
-    sorted_executors = [e for e, _ in executors_with_pareto]
-    pareto_flags = [p for _, p in executors_with_pareto]
+    sorted_executors, pareto_flags = sort_executors(
+        executors, sort_by=sort_by, limit=limit, show_pareto=show_pareto
+    )
 
     # Count Pareto-optimal in shown results
     pareto_count = sum(pareto_flags)

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -145,6 +145,30 @@ def format_tip() -> str:
     return f"Tip: {console.get_styled('lium up <index>', 'success')} {console.get_styled('# e.g. lium up 1', 'dim')}"
 
 
+def compact_executor(exe: ExecutorInfo, is_pareto: bool, index: int) -> Dict[str, Any]:
+    """Slim, table-equivalent JSON view of an executor."""
+    s = _specs_row(exe)
+    return {
+        "index": index,
+        "id": exe.id,
+        "huid": exe.huid,
+        "config": _cfg(exe),
+        "gpu_type": exe.gpu_type,
+        "gpu_count": exe.gpu_count,
+        "price_per_gpu_hour": exe.price_per_gpu,
+        "price_per_hour": exe.price_per_hour,
+        "country": _country_name(exe.location),
+        "vram_gb": _intish(s["VRAM"]),
+        "ram_gb": _intish(s["RAM"]),
+        "disk_gb": _intish(s["Disk"]),
+        "upload_mbps": _intish(s["Upload"]),
+        "download_mbps": _intish(s["Download"]),
+        "available_ports": _intish(s["Ports"]),
+        "docker_in_docker": exe.docker_in_docker,
+        "is_pareto": is_pareto,
+    }
+
+
 def sort_executors(
     executors: List[ExecutorInfo],
     sort_by: str = "download",

--- a/lium/cli/ps/command.py
+++ b/lium/cli/ps/command.py
@@ -1,7 +1,6 @@
 """Pods (ps) command implementation."""
 
 import json
-from dataclasses import asdict
 from typing import Optional
 import click
 
@@ -63,7 +62,7 @@ def ps_command(pod_id: Optional[str], output_format: str):
         return
 
     if output_format == "json":
-        click.echo(json.dumps([asdict(p) for p in pods], indent=2, default=str))
+        click.echo(json.dumps([display.compact_pod(p) for p in pods], indent=2, ensure_ascii=False))
         return
 
     # Build table

--- a/lium/cli/ps/command.py
+++ b/lium/cli/ps/command.py
@@ -1,5 +1,7 @@
 """Pods (ps) command implementation."""
 
+import json
+from dataclasses import asdict
 from typing import Optional
 import click
 
@@ -12,8 +14,14 @@ from .actions import GetPodsAction
 
 @click.command("ps")
 @click.argument("pod_id", required=False)
+@click.option(
+    "--format", "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format. 'json' emits machine-readable JSON to stdout (suitable for piping to jq).",
+)
 @handle_errors
-def ps_command(pod_id: Optional[str]):
+def ps_command(pod_id: Optional[str], output_format: str):
     """List active GPU pods."""
 
     ensure_config()
@@ -23,7 +31,10 @@ def ps_command(pod_id: Optional[str]):
     ctx = {"lium": lium}
 
     action = GetPodsAction()
-    result = ui.load("Loading pods", lambda: action.execute(ctx))
+    if output_format == "json":
+        result = action.execute(ctx)
+    else:
+        result = ui.load("Loading pods", lambda: action.execute(ctx))
 
     if not result.ok:
         ui.error(result.error)
@@ -31,19 +42,29 @@ def ps_command(pod_id: Optional[str]):
 
     pods = result.data["pods"]
 
-    # Check if empty
-    if not pods:
-        ui.warning("No active pods")
-        return
-
     # Filter by pod_id if provided
-    if pod_id:
+    if pod_id and pods:
         pod = next((p for p in pods if p.id == pod_id or p.huid == pod_id or p.name == pod_id), None)
         if pod:
             pods = [pod]
         else:
-            ui.error(f"Pod '{pod_id}' not found")
+            if output_format == "json":
+                click.echo("[]")
+            else:
+                ui.error(f"Pod '{pod_id}' not found")
             return
+
+    # Check if empty
+    if not pods:
+        if output_format == "json":
+            click.echo("[]")
+        else:
+            ui.warning("No active pods")
+        return
+
+    if output_format == "json":
+        click.echo(json.dumps([asdict(p) for p in pods], indent=2, default=str))
+        return
 
     # Build table
     table, header = display.build_pods_table(pods)

--- a/lium/cli/ps/display.py
+++ b/lium/cli/ps/display.py
@@ -76,6 +76,45 @@ def _format_ports(ports: dict) -> str:
     return ", ".join(port_pairs)
 
 
+def compact_pod(pod: PodInfo) -> dict:
+    """Slim, table-equivalent JSON view of a pod."""
+    executor = pod.executor
+    return {
+        "id": pod.id,
+        "huid": pod.huid,
+        "name": pod.name,
+        "status": pod.status.upper() if pod.status else None,
+        "gpu_type": executor.gpu_type if executor else None,
+        "gpu_count": executor.gpu_count if executor else None,
+        "config": (
+            f"{executor.gpu_count}×{executor.gpu_type}"
+            if executor and executor.gpu_count and executor.gpu_count > 1
+            else (executor.gpu_type if executor else None)
+        ),
+        "template": _format_template_name(pod.template) if pod.template else None,
+        "price_per_hour": executor.price_per_hour if executor else None,
+        "spent_usd": _spent_usd(pod.created_at, executor.price_per_hour if executor else None),
+        "uptime": _format_uptime(pod.created_at),
+        "created_at": pod.created_at,
+        "ip": executor.ip if executor else None,
+        "ports": pod.ports or {},
+        "ssh_cmd": pod.ssh_cmd,
+        "removal_scheduled_at": pod.removal_scheduled_at,
+        "jupyter_url": pod.jupyter_url,
+    }
+
+
+def _spent_usd(created_at: str, price_per_hour: Optional[float]) -> Optional[float]:
+    """Numeric counterpart of _format_cost; None when unknown."""
+    if not created_at or price_per_hour is None:
+        return None
+    dt_created = _parse_timestamp(created_at)
+    if not dt_created:
+        return None
+    hours = (datetime.now(timezone.utc) - dt_created).total_seconds() / 3600
+    return round(hours * price_per_hour, 2)
+
+
 def format_header(pod_count: int) -> str:
     """Format header text for pods list."""
     return f"Pods  ({pod_count} active)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.13"
+version = "0.0.14"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.10"
+version = "0.0.11"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.12"
+version = "0.0.13"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.11"
+version = "0.0.12"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -175,9 +175,37 @@ add_to_path() {
     export PATH="${INSTALL_DIR}:$PATH"
 }
 
+guard_against_sudo() {
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+        return
+    fi
+    if [[ -z "${SUDO_USER:-}" ]]; then
+        return
+    fi
+    if [[ -n "${LIUM_INSTALL_DIR:-}" ]]; then
+        return
+    fi
+
+    cat >&2 <<EOF
+Error: do not run the Lium installer with sudo.
+The CLI installs into your home directory and adds itself to your shell PATH;
+running under sudo installs into root's home and breaks the PATH update for
+your normal user.
+
+Re-run without sudo:
+  curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-cli/main/scripts/install.sh | bash
+
+If you really need a system-wide install, set LIUM_INSTALL_DIR explicitly,
+e.g.: sudo LIUM_INSTALL_DIR=/usr/local/bin bash install.sh
+EOF
+    exit 1
+}
+
 main() {
     local asset_name version release_path temp_dir binary_url checksum_url
     local install_root version_dir cli_path versioned_binary
+
+    guard_against_sudo
 
     asset_name="$(detect_asset_name)"
     version="$(resolve_version)"


### PR DESCRIPTION
## Summary

### Task Link

No Notion task — this is a release-stabilization PR bundling four GitHub-released fixes (v0.0.11 → v0.0.14) so `main` catches up with the latest published binary.

---

## Problem

Four independent issues found while installing and using the CLI on a fresh Shadeform Ubuntu 22.04 GPU box:

1. **`GLIBC_2.38 not found`** when running v0.0.10 binary. Linux binary was built on `python:3.12-slim` (Debian trixie, glibc 2.41); Ubuntu 22.04 ships glibc 2.35.
2. **`lium: command not found`** after `curl … | sudo bash`. The installer wrote to `/root/.lium/bin/lium` and updated `/root/.bashrc`, leaving the actual user with no PATH entry and no symlink in their home.
3. **`lium init` (browser and `--no-browser`) returned `403 Forbidden`** from `POST /api/cli-auth/init`. CLI was sending `{"callback_url": "http://localhost:8080/auth/callback"}`; CloudFront WAF blocks any POST whose body contains `http://localhost:…` (SSRF rule). The server stopped reading `callback_url` in compute-app commit `cfc36567` (Aug 2025), so the field is also dead. Browser flow swallowed the error in `except Exception` → users saw a generic "Authentication failed" with no diagnostics.
4. **No machine-readable output for agents.** `lium ls` and `lium ps` only emitted Rich tables. The first cut at `--format json` dumped raw `dataclasses.asdict()` (~270 lines per executor: 300+ verified_ports, docker container digests, md5 checksums, duplicated network metrics).

## Solution

1. Switch `Dockerfile.build` base image to `python:3.12-slim-bullseye` (glibc 2.31). Binary now runs on Ubuntu 22.04+ and any newer distro.
2. Add `guard_against_sudo()` to `scripts/install.sh` — refuse `sudo` invocations with a clear error and an escape hatch (`LIUM_INSTALL_DIR=/usr/local/bin sudo bash install.sh` for genuine system-wide installs).
3. In `lium/cli/init/auth.py`, drop the dead `callback_url` from the `init_auth()` POST body. Surface real HTTP errors via `ui.error()` in `browser_auth()` instead of silently returning `None`.
4. Add `--format table|json` to both `lium ls` and `lium ps`. JSON path skips the spinner, prints clean stdout via `click.echo` (suitable for `| jq`), uses identical sort/limit logic as the table view via a new `sort_executors()` helper. Compact output schema mirrors the table columns 1-for-1 plus `id` (UUID for `lium up <id>`) and `index` (for `lium up <N>` via stored selection) — ~20 lines per row instead of ~270.

## Changes

- `Dockerfile.build` — `python:3.12-slim` → `python:3.12-slim-bullseye`
- `scripts/install.sh` — `guard_against_sudo()` rejects sudo unless `LIUM_INSTALL_DIR` is set explicitly
- `lium/cli/init/auth.py` — drop dead `callback_url` field; show HTTP errors instead of swallowing
- `lium/cli/ls/{command,display}.py` — `--format json`, `sort_executors()` extracted from `build_executors_table`, `compact_executor()` returning the same 17 fields the table renders
- `lium/cli/ps/{command,display}.py` — `--format json`, `compact_pod()` mirroring table columns + computed `spent_usd` / `uptime`
- `pyproject.toml`, `lium/__about__.py` — version bumped 0.0.11 → 0.0.14 across four release commits

## Deployment Steps

Use GitHub Action — already done. Each commit was published to GitHub Releases as it landed:
- v0.0.11 — glibc fix + installer guard
- v0.0.12 — cli-auth callback fix
- v0.0.13 — `--format json` (raw asdict)
- v0.0.14 — compact JSON

Merging this PR brings `main` in sync with the v0.0.14 tag. PyPI publish (`full-release` mode) deliberately not run yet — recommend triggering it after merge.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None. Two follow-ups discussed but not in this PR:

- CLI: `lium up --gpu X -y` picks the first Pareto in backend order, not the displayed top by `--sort download`. Inconsistency with `lium ls`. Worth a separate PR.
- `lium-skill` repo: `llms-full.txt` still says `lium ps` has no `--format json`; should be updated and the recommended flow rewritten as `ls --sort download --format json` → `up <index>`.

## Risks

- **Linux binary `glibc` floor** raised from 2.31 (bullseye) — same as v0.0.11 release. Confirmed working on Ubuntu 22.04 (glibc 2.35) and macOS 14/15 native runners. Distros older than Debian 11 / Ubuntu 20.04 would break, but no deployment targets fall in that range.
- **`scripts/install.sh` rejects sudo by default.** Users who actually want a system-wide install must set `LIUM_INSTALL_DIR` explicitly; the error message documents this. Existing managed installs in `~/.lium` are not touched.
- **`lium init` request body changed.** Server already ignored `callback_url` (compute-app `cfc36567`, Aug 2025). No breakage expected.
- **JSON output schema is intentionally compact, not raw.** Anyone scripting against the previous `--format json` output (only existed for ~one release window between v0.0.13 and v0.0.14) would see fewer fields. The change is documented in commit message; field set is the table columns plus `id`/`index`.

## Test Cases

### Test Case 1: glibc fix on Ubuntu 22.04

**Actions**
- Clean Shadeform Ubuntu 22.04 box, glibc 2.35
- `curl -fsSL https://github.com/Datura-ai/lium-cli/releases/download/v0.0.14/install.sh | bash`
- `export PATH="$HOME/.lium/bin:$PATH" && lium --version`

**Expected Output**
- `lium, version 0.0.14`, no GLIBC error.

### Test Case 2: installer rejects sudo

**Actions**
- `curl -fsSL …/install.sh | sudo bash`

**Expected Output**
- Exit 1 with message "do not run the Lium installer with sudo" and the `LIUM_INSTALL_DIR` workaround.

### Test Case 3: `lium init --no-browser` succeeds

**Actions**
- Fresh install, no API key
- `lium init --no-browser`

**Expected Output**
- Prints `Open this URL to authenticate: https://lium.io/cli/approve/<session_id>` and `lium init --session <session_id>`. No 403.

### Test Case 4: `--format json` for ls

**Actions**
- `lium ls --gpu H100 --sort download --format json | jq '.[].huid'`

**Expected Output**
- Compact JSON array (~20 lines per executor), parses cleanly, sort respects `--sort`. Includes `id`, `index`, `is_pareto`, and the same fields rendered in the table.

### Test Case 5: `--format json` for ps

**Actions**
- `lium ps --format json | jq '.[].name'`

**Expected Output**
- Array of pods with `id`, `huid`, `name`, `status`, `gpu_type`, `config`, `template`, `price_per_hour`, `spent_usd`, `uptime`, `created_at`, `ip`, `ports`, `ssh_cmd`, `removal_scheduled_at`, `jupyter_url`.

### Test Case 6: self-update path

**Actions**
- Install v0.0.11 explicitly: `LIUM_VERSION=0.0.11 install.sh`
- Run `lium --version` once, then again

**Expected Output**
- First run: "Updated Lium CLI from 0.0.11 to 0.0.14; the new version will be used on the next launch", reports old version
- Second run: reports `0.0.14`, symlink switched, `~/.lium/self-update.json` recorded the upgrade

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
