### PR TITLE
Bump version to 0.0.15

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.14"
+__version__ = "0.0.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.14"
+version = "0.0.15"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Cut release **0.0.15**, picking up everything merged into `main` since v0.0.14.

### Task Link

No ticket provided.

## Changes

- `lium/__about__.py`: `0.0.14` -> `0.0.15`
- `pyproject.toml`: `0.0.14` -> `0.0.15`

## Included since v0.0.14

- refactor(provider-cli): render output with Rich tables (3223e18)
- feat(provider-cli): allow group flags at leaf-command position (5b71712)
- fix(deps): make provider deps required, drop optional extra (94d1aa9)
- fix(build): include provider extra in binary builds (7a160d1)
- ci: add per-PR build verification workflow (ee39720)
- feat: DAH-2060 - complete lium provider CLI subgroup with price auto-fill (746b4d2)
- refactor: rename `lium miner` CLI group to `lium provider` (ab083fa)
- fix: make crypto funding failures visible to agents - DAH-2006 (5214aab)
- feat: DAH-2060 - add lium miner provider-portal CLI + SDK (f10014e)
- fix(release): publish lium-cli deprecation stub from trusted workflow (040ede8)
- feat: add NowPayments funding commands - DAH-2006 (f4015ce)

## Deployment Steps

Tag `v0.0.15` after merge and trigger the PyPI release workflow (`.github/workflows/release.yml`).

## Risks

- Version-only bump; no runtime code change. Risk is limited to release-pipeline misconfiguration.

## Test Cases

Not applicable for a version-only bump; the included commits were validated in their own PRs (#64, #66, #69).