### PR TITLE
DAH-2083 Fix backup pod ID lookups in CLI SDK

### DIFF
--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1324,10 +1324,8 @@ class Lium:
         Returns:
             :class:`BackupConfig` if present, otherwise ``None``.
         """
-        if not pod.executor:
-            raise ValueError(f"Pod {pod.name} has no executor information")
         try:
-            response = self._request("GET", f"/backup-configs/pod/{pod.executor.id}").json()
+            response = self._request("GET", f"/backup-configs/pod/{pod.id}").json()
             return self._dict_to_backup_config(response) if response else None
         except LiumNotFoundError:
             # No backup config exists for this pod
@@ -1351,11 +1349,8 @@ class Lium:
         Returns:
             List of :class:`BackupLog` entries (possibly empty).
         """
-        if not pod.executor:
-            raise ValueError(f"Pod {pod.name} has no executor information")
-        
         try:
-            response = self._request("GET", f"/backup-logs/pod/{pod.executor.id}").json()
+            response = self._request("GET", f"/backup-logs/pod/{pod.id}").json()
             
             # Handle paginated response - extract items from the response
             if isinstance(response, dict) and 'items' in response:


### PR DESCRIPTION
## Summary

Fixes SDK backup config/log lookup to use the pod UUID instead of the executor UUID.

This aligns lookup behavior with the rest of the backup flow:
- `backup_config_create()` sends `pod_id`
- `backup_now()` posts to `/pods/{pod.id}/backup`
- backend backup config/log lookup endpoints expect pod IDs

## Validation

- `python3 -m py_compile lium/sdk/client.py`
- Confirmed during staging backup investigation that the old lookup used `pod.executor.id` and caused CLI backup commands to miss existing backup configs.

## Notes

No CLI syntax changes. Users can keep using pod name/HUID/UUID; the SDK now resolves to the correct backend pod ID internally.