### PR TITLE
DAH-2083 Fix backup CLI pod lookup, UX, and SSH handling

### DIFF
--- a/lium/cli/bk/logs/display.py
+++ b/lium/cli/bk/logs/display.py
@@ -14,8 +14,9 @@ def format_logs_table(logs: list) -> Table:
     table.add_column("#", style="dim")
     table.add_column("Backup ID", style="cyan")
     table.add_column("Status")
+    table.add_column("Progress", justify="right")
     table.add_column("Created")
-    table.add_column("Size", justify="right")
+    table.add_column("Error")
 
     for idx, log in enumerate(logs, 1):
         backup_id_full = getattr(log, 'id', 'unknown')
@@ -37,17 +38,17 @@ def format_logs_table(logs: list) -> Table:
             except:
                 pass
 
-        size = ""
-        if hasattr(log, 'size_bytes') and log.size_bytes:
-            size_mb = log.size_bytes / (1024 * 1024)
-            size = f"{size_mb:.1f} MB"
+        progress = getattr(log, 'progress', None)
+        progress_text = f"{progress:.0f}%" if progress is not None else ""
+        error = getattr(log, 'error_message', None) or ""
 
         table.add_row(
             str(idx),
             backup_id_full,
             status,
+            progress_text,
             created,
-            size
+            error
         )
 
     return table
@@ -57,6 +58,9 @@ def format_single_backup(pod_name: str, log) -> str:
     """Format single backup details."""
     lines = [f"Pod: {pod_name}"]
     lines.append(f"Status: {getattr(log, 'status', 'Unknown')}")
+    progress = getattr(log, 'progress', None)
+    if progress is not None:
+        lines.append(f"Progress: {progress:.0f}%")
     lines.append(f"Created: {getattr(log, 'created_at', 'Unknown')}")
 
     if hasattr(log, 'completed_at') and log.completed_at:
@@ -66,7 +70,7 @@ def format_single_backup(pod_name: str, log) -> str:
         size_mb = log.size_bytes / (1024 * 1024)
         lines.append(f"Size: {size_mb:.2f} MB")
 
-    if hasattr(log, 'error') and log.error:
-        lines.append(f"Error: {log.error}")
+    if hasattr(log, 'error_message') and log.error_message:
+        lines.append(f"Error: {log.error_message}")
 
     return "\n".join(lines)

--- a/lium/cli/bk/now/actions.py
+++ b/lium/cli/bk/now/actions.py
@@ -20,12 +20,12 @@ class TriggerBackupAction:
                 return ActionResult(ok=False, data={}, error="No backup configuration found")
 
             # Trigger backup
-            lium.backup_now(
+            backup_result = lium.backup_now(
                 pod=pod,
                 name=name,
                 description=description
             )
 
-            return ActionResult(ok=True, data={})
+            return ActionResult(ok=True, data={"backup": backup_result})
         except Exception as e:
             return ActionResult(ok=False, data={}, error=str(e))

--- a/lium/cli/bk/now/command.py
+++ b/lium/cli/bk/now/command.py
@@ -59,3 +59,11 @@ def bk_now_command(pod_id: str, name: Optional[str], description: Optional[str])
 
     if not result.ok:
         ui.error(result.error)
+        return
+
+    backup = result.data.get("backup") or {}
+    backup_log_id = backup.get("backup_log_id")
+    if backup_log_id:
+        ui.success(f"Backup started for {pod_name} (id={backup_log_id[:8]})")
+    else:
+        ui.success(f"Backup started for {pod_name}")

--- a/lium/cli/bk/restore/actions.py
+++ b/lium/cli/bk/restore/actions.py
@@ -13,8 +13,8 @@ class RestoreBackupAction:
         restore_path: str = ctx["restore_path"]
 
         try:
-            lium.restore(pod=pod, backup_id=backup_id, restore_path=restore_path)
+            restore_result = lium.restore(pod=pod, backup_id=backup_id, restore_path=restore_path)
 
-            return ActionResult(ok=True, data={})
+            return ActionResult(ok=True, data={"restore": restore_result})
         except Exception as e:
             return ActionResult(ok=False, data={}, error=str(e))

--- a/lium/cli/bk/restore/command.py
+++ b/lium/cli/bk/restore/command.py
@@ -59,3 +59,6 @@ def bk_restore_command(pod_id: str, backup_id: str, restore_path: str, yes: bool
 
     if not result.ok:
         ui.error(result.error)
+        return
+
+    ui.success(f"Restore started for {pod_name} at {restore_path}")

--- a/lium/cli/bk/rm/actions.py
+++ b/lium/cli/bk/rm/actions.py
@@ -18,6 +18,6 @@ class RemoveBackupAction:
 
             lium.backup_delete(backup_config.id)
 
-            return ActionResult(ok=True, data={})
+            return ActionResult(ok=True, data={"backup_config_id": backup_config.id})
         except Exception as e:
             return ActionResult(ok=False, data={}, error=str(e))

--- a/lium/cli/bk/rm/command.py
+++ b/lium/cli/bk/rm/command.py
@@ -65,3 +65,6 @@ def bk_rm_command(pod_id: str, yes: bool):
 
     if not result.ok:
         ui.error(result.error)
+        return
+
+    ui.success(f"Backup configuration removed for {pod_name}")

--- a/lium/cli/bk/set/actions.py
+++ b/lium/cli/bk/set/actions.py
@@ -21,13 +21,13 @@ class SetBackupAction:
                 lium.backup_delete(existing_config.id)
 
             # Create new backup config
-            lium.backup_create(
+            backup_config = lium.backup_create(
                 pod=pod,
                 path=path,
                 frequency_hours=frequency_hours,
                 retention_days=retention_days
             )
 
-            return ActionResult(ok=True, data={})
+            return ActionResult(ok=True, data={"backup_config": backup_config})
         except Exception as e:
             return ActionResult(ok=False, data={}, error=str(e))

--- a/lium/cli/bk/set/command.py
+++ b/lium/cli/bk/set/command.py
@@ -72,3 +72,9 @@ def bk_set_command(pod_id: str, path: str, every: str, keep: str, yes: bool):
 
     if not result.ok:
         ui.error(result.error)
+        return
+
+    ui.success(
+        f"Backup configured for {pod_name}: "
+        f"path={backup_path}, every={frequency_hours}h, keep={retention_days}d"
+    )

--- a/lium/cli/bk/show/command.py
+++ b/lium/cli/bk/show/command.py
@@ -62,6 +62,7 @@ def bk_show_command(pod_id: str):
         return
 
     if not result.data.get("has_config"):
+        ui.warning(f"No backup configuration found for {pod_name}")
         return
 
     # Display

--- a/lium/cli/settings.py
+++ b/lium/cli/settings.py
@@ -74,6 +74,10 @@ class ConfigManager:
         env_value = os.environ.get(env_key)
         if env_value is not None:
             return env_value
+        if key == "api.api_key":
+            env_value = os.environ.get("LIUM_API_KEY")
+            if env_value is not None:
+                return env_value
         
         try:
             return self._config.get(section, option)

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1324,10 +1324,8 @@ class Lium:
         Returns:
             :class:`BackupConfig` if present, otherwise ``None``.
         """
-        if not pod.executor:
-            raise ValueError(f"Pod {pod.name} has no executor information")
         try:
-            response = self._request("GET", f"/backup-configs/pod/{pod.executor.id}").json()
+            response = self._request("GET", f"/backup-configs/pod/{pod.id}").json()
             return self._dict_to_backup_config(response) if response else None
         except LiumNotFoundError:
             # No backup config exists for this pod
@@ -1351,11 +1349,8 @@ class Lium:
         Returns:
             List of :class:`BackupLog` entries (possibly empty).
         """
-        if not pod.executor:
-            raise ValueError(f"Pod {pod.name} has no executor information")
-        
         try:
-            response = self._request("GET", f"/backup-logs/pod/{pod.executor.id}").json()
+            response = self._request("GET", f"/backup-logs/pod/{pod.id}").json()
             
             # Handle paginated response - extract items from the response
             if isinstance(response, dict) and 'items' in response:

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -763,13 +763,25 @@ class Lium:
             except (paramiko.SSHException, FileNotFoundError, PermissionError):
                 continue
 
-        if not key:
-            raise ValueError("Could not load SSH key")
-
         # Connect
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(hostname=host, port=port, username=user, pkey=key, timeout=timeout)
+        connect_kwargs = {
+            "hostname": host,
+            "port": port,
+            "username": user,
+            "timeout": timeout,
+            "look_for_keys": False,
+        }
+        if key:
+            connect_kwargs["pkey"] = key
+            connect_kwargs["allow_agent"] = False
+        else:
+            # System ssh can still work for encrypted keys via ssh-agent even when
+            # Paramiko cannot parse the private key file directly.
+            connect_kwargs["key_filename"] = str(self.config.ssh_key_path)
+            connect_kwargs["allow_agent"] = True
+        client.connect(**connect_kwargs)
 
         try:
             yield client

--- a/test/test_backup_cli.py
+++ b/test/test_backup_cli.py
@@ -1,0 +1,177 @@
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from lium.cli.bk.now import command as now_command
+from lium.cli.bk.logs import command as logs_command
+from lium.cli.bk.restore import command as restore_command
+from lium.cli.bk.rm import command as rm_command
+from lium.cli.bk.set import command as set_command
+from lium.cli.bk.show import command as show_command
+from lium.cli.cli import cli
+
+
+def _pod():
+    return SimpleNamespace(
+        id="pod-123",
+        name="backup-test",
+        huid="eager-shark-01",
+        status="RUNNING",
+        ssh_cmd=None,
+        ports={},
+        created_at="2026-05-14T00:00:00Z",
+        updated_at="2026-05-14T00:00:00Z",
+        executor=None,
+        template={},
+        removal_scheduled_at=None,
+        jupyter_installation_status=None,
+        jupyter_url=None,
+    )
+
+
+def _patch_backup_command(monkeypatch, command_module, fake_lium_cls):
+    monkeypatch.setattr(command_module, "ensure_config", lambda: None)
+    monkeypatch.setattr(command_module, "Lium", fake_lium_cls)
+
+
+def test_bk_set_prints_success(monkeypatch):
+    class FakeLium:
+        def ps(self):
+            return [_pod()]
+
+        def backup_config(self, pod):
+            assert pod.id == "pod-123"
+            return None
+
+        def backup_create(self, *, pod, path, frequency_hours, retention_days):
+            assert pod.id == "pod-123"
+            assert path == "/root/data"
+            assert frequency_hours == 6
+            assert retention_days == 7
+            return SimpleNamespace(id="config-123")
+
+    _patch_backup_command(monkeypatch, set_command, FakeLium)
+
+    result = CliRunner().invoke(
+        cli,
+        ["bk", "set", "backup-test", "--path", "/root/data", "--every", "6h", "--keep", "7d"],
+    )
+
+    assert result.exit_code == 0
+    assert "Backup configured for backup-test" in result.output
+    assert "path=/root/data, every=6h, keep=7d" in result.output
+
+
+def test_bk_now_prints_backup_log_id(monkeypatch):
+    class FakeLium:
+        def ps(self):
+            return [_pod()]
+
+        def backup_config(self, pod):
+            assert pod.id == "pod-123"
+            return SimpleNamespace(id="config-123")
+
+        def backup_now(self, *, pod, name, description):
+            assert pod.id == "pod-123"
+            assert name == "pre-deploy"
+            assert description == "before release"
+            return {"backup_log_id": "8fbb30f6-6026-4043-98c7-c4189dc09bef"}
+
+    _patch_backup_command(monkeypatch, now_command, FakeLium)
+
+    result = CliRunner().invoke(
+        cli,
+        ["bk", "now", "backup-test", "--name", "pre-deploy", "--description", "before release"],
+    )
+
+    assert result.exit_code == 0
+    assert "Backup started for backup-test (id=8fbb30f6)" in result.output
+
+
+def test_bk_logs_by_id_prints_status_progress_and_error(monkeypatch):
+    backup_log = SimpleNamespace(
+        id="8fbb30f6-6026-4043-98c7-c4189dc09bef",
+        status="FAILED",
+        progress=30,
+        created_at="2026-05-14T12:00:00Z",
+        completed_at=None,
+        error_message="Backup upload failed",
+    )
+
+    class FakeLium:
+        def ps(self):
+            return [_pod()]
+
+        def backup_logs(self, pod):
+            assert pod.id == "pod-123"
+            return [backup_log]
+
+    _patch_backup_command(monkeypatch, logs_command, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "logs", "--id", "8fbb30f6"])
+
+    assert result.exit_code == 0
+    assert "Pod: backup-test" in result.output
+    assert "Status: FAILED" in result.output
+    assert "Progress: 30%" in result.output
+    assert "Error: Backup upload failed" in result.output
+
+
+def test_bk_rm_prints_success(monkeypatch):
+    class FakeLium:
+        def ps(self):
+            return [_pod()]
+
+        def backup_config(self, pod):
+            assert pod.id == "pod-123"
+            return SimpleNamespace(id="config-123")
+
+        def backup_delete(self, config_id):
+            assert config_id == "config-123"
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, rm_command, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "rm", "backup-test", "--yes"])
+
+    assert result.exit_code == 0
+    assert "Backup configuration removed for backup-test" in result.output
+
+
+def test_bk_restore_prints_success(monkeypatch):
+    class FakeLium:
+        def ps(self):
+            return [_pod()]
+
+        def restore(self, *, pod, backup_id, restore_path):
+            assert pod.id == "pod-123"
+            assert backup_id == "backup-123"
+            assert restore_path == "/root/restore"
+            return {"restore_log_id": "restore-123"}
+
+    _patch_backup_command(monkeypatch, restore_command, FakeLium)
+
+    result = CliRunner().invoke(
+        cli,
+        ["bk", "restore", "backup-test", "--id", "backup-123", "--to", "/root/restore", "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert "Restore started for backup-test at /root/restore" in result.output
+
+
+def test_bk_show_warns_when_config_missing(monkeypatch):
+    class FakeLium:
+        def ps(self):
+            return [_pod()]
+
+        def backup_config(self, pod):
+            assert pod.id == "pod-123"
+            return None
+
+    _patch_backup_command(monkeypatch, show_command, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "show", "backup-test"])
+
+    assert result.exit_code == 0
+    assert "No backup configuration found for backup-test" in result.output

--- a/test/test_cli_settings.py
+++ b/test/test_cli_settings.py
@@ -1,0 +1,21 @@
+from lium.cli.settings import ConfigManager
+
+
+def test_api_api_key_reads_standard_sdk_env_alias(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LIUM_API_KEY", "sdk-env-key")
+    monkeypatch.delenv("LIUM_API_API_KEY", raising=False)
+
+    config = ConfigManager()
+
+    assert config.get("api.api_key") == "sdk-env-key"
+
+
+def test_generated_env_key_takes_precedence_over_api_key_alias(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LIUM_API_KEY", "sdk-env-key")
+    monkeypatch.setenv("LIUM_API_API_KEY", "cli-env-key")
+
+    config = ConfigManager()
+
+    assert config.get("api.api_key") == "cli-env-key"

--- a/test/test_sdk_ssh.py
+++ b/test/test_sdk_ssh.py
@@ -1,0 +1,63 @@
+from lium.sdk import Config, Lium, PodInfo
+from lium.sdk import client as sdk_client
+
+
+def _pod():
+    return PodInfo(
+        id="pod-123",
+        name="backup-test",
+        huid="swift-fox-c8",
+        status="RUNNING",
+        ssh_cmd="ssh root@38.80.122.244 -p 20299",
+        ports={},
+        created_at="2026-05-14T00:00:00Z",
+        updated_at="2026-05-14T00:00:00Z",
+        executor=None,
+        template={},
+        removal_scheduled_at=None,
+        jupyter_installation_status=None,
+        jupyter_url=None,
+    )
+
+
+def test_ssh_connection_falls_back_to_agent_when_key_file_cannot_be_loaded(monkeypatch, tmp_path):
+    key_path = tmp_path / "id_ed25519"
+    key_path.write_text("encrypted-key")
+    connect_calls = []
+
+    def raise_ssh_exception(*args, **kwargs):
+        raise sdk_client.paramiko.SSHException("encrypted key")
+
+    monkeypatch.setattr(sdk_client.paramiko.Ed25519Key, "from_private_key_file", raise_ssh_exception)
+    monkeypatch.setattr(sdk_client.paramiko.RSAKey, "from_private_key_file", raise_ssh_exception)
+    monkeypatch.setattr(sdk_client.paramiko.ECDSAKey, "from_private_key_file", raise_ssh_exception)
+
+    class FakeSSHClient:
+        def set_missing_host_key_policy(self, policy):
+            self.policy = policy
+
+        def connect(self, **kwargs):
+            connect_calls.append(kwargs)
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(sdk_client.paramiko, "SSHClient", FakeSSHClient)
+    monkeypatch.setattr(sdk_client.paramiko, "AutoAddPolicy", lambda: object())
+
+    client = Lium(Config(api_key="test", ssh_key_path=key_path))
+
+    with client.ssh_connection(_pod()) as ssh_client:
+        assert isinstance(ssh_client, FakeSSHClient)
+
+    assert connect_calls == [
+        {
+            "hostname": "38.80.122.244",
+            "port": 20299,
+            "username": "root",
+            "timeout": 30,
+            "look_for_keys": False,
+            "key_filename": str(key_path),
+            "allow_agent": True,
+        }
+    ]


### PR DESCRIPTION
## Summary

Makes the backup CLI/SDK changes standalone for DAH-2083. This PR now also includes the pod-id lookup fix that was previously opened separately in #72, so reviewers can review the CLI/SDK backup changes in one place.

## Changes

- Resolve backup pod arguments by pod id/HUID/name so `bk set`, `bk now`, `bk rm`, `bk logs`, and `bk restore` work with the human-readable pod ids shown by the CLI.
- Print success output for `lium bk set`, `bk now`, `bk rm`, and `bk restore`.
- Include backup status progress and backend `error_message` in `lium bk logs` output.
- Show a warning when `lium bk show` finds no config instead of returning silently.
- Let CLI config accept `LIUM_API_KEY` for `api.api_key`, matching the SDK env var.
- Fall back to `ssh-agent` for SDK SSH connections when Paramiko cannot parse the configured private key directly.
- Add focused tests for backup CLI output, config env alias behavior, and SSH agent fallback.

## Testing

- `uv run pytest test/test_cli_settings.py test/test_backup_cli.py test/test_sdk_ssh.py`
- Staging smoke using local source CLI only:
  - rented pod
  - configured backup for a subpath
  - triggered backup with `bk now`
  - checked status with `bk logs --id`
  - restored backup
  - verified restored checksums and subpath scope
