### PR TITLE
DAH-2084: sign bare Unix timestamp in provider login payload

### DIFF
--- a/lium/cli/provider/_render.py
+++ b/lium/cli/provider/_render.py
@@ -141,7 +141,7 @@ def emit_error(ctx: click.Context, err: ProviderError) -> int:
 
 
 def emit_warning(ctx: click.Context, code: str, message: str) -> None:
-    """Surface a non-fatal warning (e.g. PORTAL_LOGIN_REPLAY_DEBT)."""
+    """Surface a non-fatal warning code + message on stderr."""
     if _json_mode(ctx):
         # The status command surfaces warnings via ProviderStatus.warnings;
         # for one-shot warnings we deliberately keep stdout clean.

--- a/lium/provider/auth.py
+++ b/lium/provider/auth.py
@@ -6,39 +6,27 @@ This module implements:
   without touching ``ProviderClient`` call sites.
 - ``LocalKeypairSigner``, the default v1 implementation that wraps
   ``bittensor.Keypair``.
-- ``build_login_payload``, the *single* place that knows the wire format
-  (A2: mirrors ``AuthenticationPayload(timestamp, miner_hotkey).blob_for_signing()``
-  from ``lium-miner-portal/src/auth/signature_auth.py:30``).
+- ``build_login_payload``, the *single* place that knows the wire format.
 
-The portal's ``verify_miner_signature`` (``lium-miner-portal/src/common/subtensor.py``)
-currently accepts *any* signed string with no replay window. v1 ships
-interoperable; a NEEDS-PORTAL-CHANGE ticket is filed to enforce
-``AUTH_MESSAGE_MAX_AGE`` on ``/auth/login-flexible``. Until then this module
-emits a one-time ``PORTAL_LOGIN_REPLAY_DEBT`` warning per process so the
-SECURITY-DEBT marker is observable in stderr and structured logs.
+Wire format (DAH-2084)
+----------------------
+The portal's ``/auth/login-flexible`` endpoint authenticates the *signed
+message itself* as a freshness proof: the ``message`` field MUST be the
+current Unix timestamp as a decimal string, and the portal
+(``AuthService._verify_login_signature``) does ``int(message)`` and rejects
+anything outside ``LOGIN_SIGNATURE_MAX_AGE``, also burning a Redis nonce so a
+captured body cannot be replayed.
+
+Earlier revisions of this module signed a JSON blob
+(``{"miner_hotkey": ..., "timestamp": ...}``); that no longer parses as an
+int and is rejected by the hardened portal. ``build_login_payload`` now signs
+the bare timestamp string so the SDK stays interoperable with the fix.
 """
 
 from __future__ import annotations
 
-import json
-import logging
-import threading
 import time
 from typing import Any, Protocol, runtime_checkable
-
-logger = logging.getLogger("lium.provider.auth")
-
-# Module-level once-flag for the SECURITY-DEBT warning. Per-process, not per
-# call -- a follow-up issue tracks tuning the cadence.
-_REPLAY_DEBT_WARNED = False
-_REPLAY_DEBT_LOCK = threading.Lock()
-
-REPLAY_DEBT_MESSAGE = (
-    "[PORTAL_LOGIN_REPLAY_DEBT] portal /auth/login-flexible does not enforce "
-    "AUTH_MESSAGE_MAX_AGE; captured login bodies replay until the JWT expires. "
-    "Tracked as SECURITY-DEBT; see "
-    "https://github.com/Datura-ai/lium-miner-portal (NEEDS-PORTAL-CHANGE)."
-)
 
 
 @runtime_checkable
@@ -88,23 +76,6 @@ class LocalKeypairSigner:
         return self._kp.sign(message)
 
 
-def _build_blob(timestamp: int, hotkey_ss58: str) -> bytes:
-    """Compute ``AuthenticationPayload(...).blob_for_signing()`` exactly.
-
-    Mirrors the canonical serialisation used throughout lium-io:
-
-        json.dumps({"miner_hotkey": ..., "timestamp": ...}, sort_keys=True)
-
-    Bytes are UTF-8 encoded. The function is its own canonical form so unit
-    tests can assert against a known fixture.
-    """
-    payload: dict[str, Any] = {
-        "miner_hotkey": hotkey_ss58,
-        "timestamp": int(timestamp),
-    }
-    return json.dumps(payload, sort_keys=True).encode("utf-8")
-
-
 def build_login_payload(
     signer: Signer,
     *,
@@ -118,15 +89,15 @@ def build_login_payload(
         hotkey_ss58: hotkey to authenticate as. If ``None``, ``signer.ss58_address``
             is used. The two MUST agree if both supplied (defensive check).
         timestamp: explicit unix timestamp. ``None`` uses ``time.time()``.
+            Callers should leave this ``None`` outside of tests -- the portal
+            rejects stale timestamps (DAH-2084).
 
     Returns:
-        Dict with the three string fields the portal expects. ``signature``
-        is hex *without* the ``0x`` prefix; the portal adds the prefix
-        before calling ``verify_miner_signature`` (verified at
-        ``lium-miner-portal/src/services/auth_service.py``).
-
-    Side effect:
-        Emits ``REPLAY_DEBT_MESSAGE`` once per process via ``logger.warning``.
+        Dict with the three string fields the portal expects. ``message`` is
+        the current Unix timestamp as a decimal string -- the portal does
+        ``int(message)`` and enforces a freshness window. ``signature`` is hex
+        *without* the ``0x`` prefix; the portal adds the prefix before calling
+        ``verify_miner_signature``.
     """
     hotkey = hotkey_ss58 or signer.ss58_address
     if hotkey_ss58 is not None and hotkey_ss58 != signer.ss58_address:
@@ -136,45 +107,19 @@ def build_login_payload(
             f"hotkey mismatch: signer={signer.ss58_address!r} payload={hotkey_ss58!r}"
         )
     ts = int(timestamp) if timestamp is not None else int(time.time())
-    blob = _build_blob(ts, hotkey)
-    raw_sig = signer.sign(blob)
+    message = str(ts)
+    raw_sig = signer.sign(message.encode("utf-8"))
     if not isinstance(raw_sig, (bytes, bytearray)):
         raise TypeError(f"signer.sign must return bytes, got {type(raw_sig).__name__}")
-    _emit_replay_debt_warning_once()
     return {
         "miner_hotkey": hotkey,
-        "message": blob.decode("utf-8"),
+        "message": message,
         "signature": bytes(raw_sig).hex(),
     }
 
 
-def _emit_replay_debt_warning_once() -> None:
-    """Log the SECURITY-DEBT marker once per process.
-
-    Idempotent and thread-safe. ``ProviderClient`` consumers can suppress the
-    log by reconfiguring the ``lium.provider.auth`` logger.
-    """
-    global _REPLAY_DEBT_WARNED
-    if _REPLAY_DEBT_WARNED:
-        return
-    with _REPLAY_DEBT_LOCK:
-        if _REPLAY_DEBT_WARNED:
-            return
-        _REPLAY_DEBT_WARNED = True
-    logger.warning(REPLAY_DEBT_MESSAGE)
-
-
-def reset_replay_debt_warned() -> None:
-    """Test helper: reset the once-flag so warning re-emits."""
-    global _REPLAY_DEBT_WARNED
-    with _REPLAY_DEBT_LOCK:
-        _REPLAY_DEBT_WARNED = False
-
-
 __all__ = [
-    "REPLAY_DEBT_MESSAGE",
     "LocalKeypairSigner",
     "Signer",
     "build_login_payload",
-    "reset_replay_debt_warned",
 ]

--- a/lium/provider/errors.py
+++ b/lium/provider/errors.py
@@ -19,11 +19,6 @@ Each error code is exported as a string constant so callers can do::
     from lium.provider.errors import HOTKEY_NOT_REGISTERED
     if err.code == HOTKEY_NOT_REGISTERED:
         ...
-
-PORTAL_LOGIN_REPLAY_DEBT is a *warning* code, not an error: emitted to stderr
-and surfaced under ``warnings[]`` in ``lium provider status --json`` until the
-portal enforces ``AUTH_MESSAGE_MAX_AGE`` on ``/auth/login-flexible``
-(NEEDS-PORTAL-CHANGE filed).
 """
 
 from __future__ import annotations
@@ -57,9 +52,6 @@ PORTS_INVALID = "PORTS_INVALID"
 ARG_INVALID = "ARG_INVALID"
 CONFIG_MISSING = "CONFIG_MISSING"
 
-# Warnings (not raised; surfaced as info)
-PORTAL_LOGIN_REPLAY_DEBT = "PORTAL_LOGIN_REPLAY_DEBT"
-
 # Default hint table -- keep human and short. Empty string => no hint.
 _HINTS: dict[str, str] = {
     WALLET_NOT_FOUND: "Run `btcli wallet new_coldkey` then `btcli wallet new_hotkey`, or check --coldkey/--hotkey names.",
@@ -79,8 +71,6 @@ _HINTS: dict[str, str] = {
     PORTS_INVALID: "Use the form HTTP=8080,SSH=2200,RANGE=2000-2005 with positive integers.",
     ARG_INVALID: "Check the argument value and consult --help.",
     CONFIG_MISSING: "Run `lium init` or set the missing config value.",
-    PORTAL_LOGIN_REPLAY_DEBT: "Portal /auth/login-flexible does not enforce AUTH_MESSAGE_MAX_AGE; "
-    "captured login bodies replay until the JWT expires. Tracked as SECURITY-DEBT.",
 }
 
 
@@ -181,7 +171,6 @@ __all__ = [
     "PORTAL_AUTH_INVALID",
     "PORTAL_AUTH_REFRESH_RACE",
     "PORTAL_CONTRACT_DRIFT",
-    "PORTAL_LOGIN_REPLAY_DEBT",
     "PORTAL_NOT_FOUND",
     "PORTAL_RATE_LIMIT",
     "PORTAL_SERVER_ERROR",

--- a/test/provider/conftest.py
+++ b/test/provider/conftest.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import Any
 
 import pytest
 
-from lium.provider.auth import LocalKeypairSigner, reset_replay_debt_warned
+from lium.provider.auth import LocalKeypairSigner
 from lium.provider.token_store import TokenStore
 
 
@@ -44,14 +43,6 @@ def fake_signer(fake_keypair: FakeKeypair) -> LocalKeypairSigner:
 def tmp_token_store(tmp_path: Path) -> TokenStore:
     """A TokenStore rooted in a tmp dir so tests don't touch ~/.lium."""
     return TokenStore(path=tmp_path / "provider-portal-token.json")
-
-
-@pytest.fixture(autouse=True)
-def _reset_replay_debt_flag() -> Any:
-    """Reset the once-per-process replay-debt flag between tests."""
-    reset_replay_debt_warned()
-    yield
-    reset_replay_debt_warned()
 
 
 @pytest.fixture(autouse=True)

--- a/test/provider/test_auth.py
+++ b/test/provider/test_auth.py
@@ -1,19 +1,17 @@
-"""Tests for ``lium.provider.auth``: Signer Protocol + A2 wire format."""
+"""Tests for ``lium.provider.auth``: Signer Protocol + login wire format."""
 
 from __future__ import annotations
 
-import json
-import logging
+import time
 
 import pytest
 
 from lium.provider.auth import (
-    REPLAY_DEBT_MESSAGE,
     LocalKeypairSigner,
     Signer,
-    _build_blob,
     build_login_payload,
 )
+
 from .conftest import FakeKeypair
 
 
@@ -34,26 +32,26 @@ def test_local_keypair_signer_rejects_non_keypair() -> None:
         LocalKeypairSigner(NotAKeypair())
 
 
-def test_build_blob_canonical_form() -> None:
-    blob = _build_blob(timestamp=1_700_000_000, hotkey_ss58="5HK")
-    decoded = json.loads(blob.decode())
-    assert decoded == {"miner_hotkey": "5HK", "timestamp": 1_700_000_000}
-    # Keys must be sort_keys=True so the wire is canonical.
-    assert blob == b'{"miner_hotkey": "5HK", "timestamp": 1700000000}'
-
-
 def test_build_login_payload_shape(fake_signer: LocalKeypairSigner) -> None:
     payload = build_login_payload(fake_signer, timestamp=1_700_000_000)
     assert set(payload.keys()) == {"miner_hotkey", "message", "signature"}
     assert payload["miner_hotkey"] == fake_signer.ss58_address
-    decoded = json.loads(payload["message"])
-    assert decoded == {
-        "miner_hotkey": fake_signer.ss58_address,
-        "timestamp": 1_700_000_000,
-    }
+    # DAH-2084: message is the bare Unix timestamp string; the portal does
+    # ``int(message)`` and enforces a freshness window.
+    assert payload["message"] == "1700000000"
+    assert int(payload["message"]) == 1_700_000_000
     # Hex sig with no 0x prefix; portal adds the prefix server-side.
     assert payload["signature"] == fake_signer.sign(payload["message"].encode()).hex()
     assert not payload["signature"].startswith("0x")
+
+
+def test_build_login_payload_defaults_to_current_time(
+    fake_signer: LocalKeypairSigner,
+) -> None:
+    before = int(time.time())
+    payload = build_login_payload(fake_signer)
+    after = int(time.time())
+    assert before <= int(payload["message"]) <= after
 
 
 def test_build_login_payload_uses_signer_address_when_hotkey_omitted(
@@ -68,20 +66,6 @@ def test_build_login_payload_rejects_hotkey_mismatch(
 ) -> None:
     with pytest.raises(ValueError, match="hotkey mismatch"):
         build_login_payload(fake_signer, hotkey_ss58="5OtherHotkey")
-
-
-def test_replay_debt_warning_emitted_once(
-    fake_signer: LocalKeypairSigner, caplog: pytest.LogCaptureFixture
-) -> None:
-    caplog.set_level(logging.WARNING, logger="lium.provider.auth")
-    build_login_payload(fake_signer)
-    build_login_payload(fake_signer)
-    build_login_payload(fake_signer)
-    debt_records = [
-        r for r in caplog.records if "PORTAL_LOGIN_REPLAY_DEBT" in r.getMessage()
-    ]
-    assert len(debt_records) == 1
-    assert REPLAY_DEBT_MESSAGE in debt_records[0].getMessage()
 
 
 def test_signer_with_non_bytes_signature_rejected() -> None:

--- a/test/provider/test_client.py
+++ b/test/provider/test_client.py
@@ -117,8 +117,9 @@ def test_login_posts_login_flexible_with_correct_payload(
     assert path == "/auth/login-flexible"
     assert auth is False  # login is unauthenticated
     assert set(body.keys()) == {"miner_hotkey", "message", "signature"}
-    decoded = json.loads(body["message"])
-    assert decoded["miner_hotkey"] == fake_signer.ss58_address
+    assert body["miner_hotkey"] == fake_signer.ss58_address
+    # DAH-2084: message is the bare Unix timestamp string the portal validates.
+    assert int(body["message"]) > 0
     # Signature is hex without the 0x prefix
     assert not body["signature"].startswith("0x")
 


### PR DESCRIPTION
## DAH-2084 — Provider Portal Auth Security Vulnerability

Part of the coordinated DAH-2084 fix. The backend (lium-miner-portal PR #125) hardens `/auth/login-flexible`: it now authenticates the **signed message itself** as a freshness proof — `int(message)`, a freshness-window check, and a Redis nonce to block replay.

### Problem
`build_login_payload` signed a JSON blob — `{"miner_hotkey": ..., "timestamp": ...}` — as the `message`. Against the hardened portal, `int(message)` on that JSON string raises `ValueError`, so **every CLI/SDK wallet login breaks** once the backend merges.

### Change
- `build_login_payload` now signs the current Unix timestamp as a decimal string (`str(int(time.time()))`).
- Removed the obsolete `PORTAL_LOGIN_REPLAY_DEBT` warning machinery (`REPLAY_DEBT_MESSAGE`, once-flag, lock, `reset_replay_debt_warned`) and its error code/hint — the portal now enforces freshness, so the security-debt marker no longer applies.
- Provider auth tests updated for the new wire format.

### Verification
- `ruff check` — clean
- `pytest test/provider/` — 169 passed (5 unrelated pre-existing failures in `test_cli_node.py`/`test_cli_queries.py`, identical on `main`)

### ⚠️ Coordinated release
Must ship together with backend PR #125 and miner-portal-frontend PR for DAH-2084. If the backend merges first, already-installed CLI versions in the field break with no client-side remedy — see the note on PR #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)