### PR TITLE
DAH-2111 - Add --min-cuda filter to lium ls (CLI + SDK)

### DIFF
--- a/lium/cli/ls/actions.py
+++ b/lium/cli/ls/actions.py
@@ -16,6 +16,7 @@ class GetExecutorsAction:
         lat = ctx.get("lat")
         lon = ctx.get("lon")
         max_distance = ctx.get("max_distance")
+        min_cuda_version = ctx.get("min_cuda_version")
 
         try:
             executors = lium.ls(
@@ -24,6 +25,7 @@ class GetExecutorsAction:
                 lat=lat,
                 lon=lon,
                 max_distance_miles=max_distance,
+                min_cuda_version=min_cuda_version,
             )
             return ActionResult(
                 ok=True,

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -37,6 +37,7 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download")
 @click.command("ls")
 @click.option("--gpu", "gpu_type", shell_complete=get_gpu_completions, help="Filter by GPU type, e.g. A100")
 @click.option("--count", "gpu_count", type=int, help="Exact GPU count to match (e.g., 1, 8)")
+@click.option("--min-cuda", "min_cuda_version", type=float, help="Minimum CUDA version, e.g. 12.4 (NVIDIA drivers are backward compatible)")
 @click.option("--lat", type=float, help="Latitude for distance filtering")
 @click.option("--lon", type=float, help="Longitude for distance filtering")
 @click.option("--max-distance", "max_distance", type=int, help="Maximum distance in miles from --lat/--lon")
@@ -64,11 +65,12 @@ def ls_command(
     sort_by: str,
     limit: Optional[int],
     output_format: str,
+    min_cuda_version: Optional[float],
 ):
     """List available GPU executors."""
 
     # Validate
-    _, error = validation.validate(sort_by, limit, lat, lon, max_distance)
+    _, error = validation.validate(sort_by, limit, lat, lon, max_distance, min_cuda_version)
     if error:
         ui.error(error)
         return
@@ -82,6 +84,7 @@ def ls_command(
         "lat": lat,
         "lon": lon,
         "max_distance": max_distance,
+        "min_cuda_version": min_cuda_version,
     }
 
     action = GetExecutorsAction()

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -122,6 +122,7 @@ def _add_table_columns(t: Table) -> None:
     t.add_column("", justify="right", width=3, no_wrap=True, style="dim")
     t.add_column("Id", justify="left", ratio=8, min_width=24, overflow="fold")
     t.add_column("Config", justify="left", width=12, no_wrap=True)
+    t.add_column("Max CUDA", justify="right", width=10, no_wrap=True)
     t.add_column("$/GPU·h", justify="right", width=8, no_wrap=True)
     t.add_column("Location", justify="left", ratio=4, min_width=10, overflow="fold")
     t.add_column("VRAM (Gb)", justify="right", width=11, no_wrap=True)
@@ -166,6 +167,7 @@ def compact_executor(exe: ExecutorInfo, is_pareto: bool, index: int) -> Dict[str
         "available_ports": _intish(s["Ports"]),
         "docker_in_docker": exe.docker_in_docker,
         "is_pareto": is_pareto,
+        "max_cuda_version": exe.max_cuda_version,
     }
 
 
@@ -239,10 +241,13 @@ def build_executors_table(
             else s["Download"]
         )
 
+        cuda_display = f"{exe.max_cuda_version:.1f}" if exe.max_cuda_version is not None else "-"
+
         table.add_row(
             str(idx),
             huid_display,
             _cfg(exe),
+            cuda_display,
             console.get_styled(_money(exe.price_per_gpu), 'success'),
             _country_name(exe.location),
             s["VRAM"],

--- a/lium/cli/ls/validation.py
+++ b/lium/cli/ls/validation.py
@@ -7,6 +7,7 @@ def validate(
     lat: float | None,
     lon: float | None,
     max_distance: int | None,
+    min_cuda_version: float | None = None,
 ) -> tuple[bool, str | None]:
     """Validate ls command options, returns (is_valid, error_message)."""
 
@@ -27,5 +28,8 @@ def validate(
 
     if max_distance is not None and (lat is None or lon is None):
         return False, "--max-distance requires --lat and --lon"
+
+    if min_cuda_version is not None and min_cuda_version <= 0:
+        return False, "--min-cuda must be positive"
 
     return True, None

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -162,6 +162,7 @@ class Lium:
             available_port_count=specs.get("available_port_count"),
             effective_upload_speed_mbps=executor_dict.get("effective_upload_speed_mbps"),
             effective_download_speed_mbps=executor_dict.get("effective_download_speed_mbps"),
+            max_cuda_version=executor_dict.get("max_cuda_version"),
         )
 
     def list_ssh_keys(self) -> List[SSHKey]:
@@ -417,6 +418,7 @@ class Lium:
         lat: Optional[float] = None,
         lon: Optional[float] = None,
         max_distance_miles: Optional[int] = None,
+        min_cuda_version: Optional[float] = None,
     ) -> List[ExecutorInfo]:
         """List available executors.
 
@@ -426,6 +428,9 @@ class Lium:
             lat: Optional latitude for geospatial filtering. Must be used together with ``lon`` and ``max_distance_miles``.
             lon: Optional longitude for geospatial filtering. Must be used together with ``lat`` and ``max_distance_miles``.
             max_distance_miles: Optional radius (in miles) for geospatial filtering. Must be used together with ``lat`` and ``lon``.
+            min_cuda_version: Optional minimum CUDA version to require (e.g. ``12.4``). Executors whose
+                ``max_cuda_version`` is ``None`` or below this threshold are excluded. NVIDIA drivers are
+                backward compatible, so an executor with a higher driver CUDA version satisfies the requirement.
 
         Returns:
             A list of :class:`ExecutorInfo` objects that satisfy the filters.
@@ -453,6 +458,12 @@ class Lium:
         data = self._request("GET", "/executors", params=params).json()
         executors = [self._dict_to_executor_info(d) for d in data]
         executors = [e for e in executors if e]  # Filter None values
+
+        if min_cuda_version is not None:
+            executors = [
+                e for e in executors
+                if e.max_cuda_version is not None and e.max_cuda_version >= min_cuda_version
+            ]
 
         return executors
 

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -22,6 +22,7 @@ class ExecutorInfo:
     available_port_count: Optional[int] = None
     effective_upload_speed_mbps: Optional[float] = None
     effective_download_speed_mbps: Optional[float] = None
+    max_cuda_version: Optional[float] = None
 
     @property
     def driver_version(self) -> str:

--- a/test/test_ls_cuda_filter.py
+++ b/test/test_ls_cuda_filter.py
@@ -1,0 +1,121 @@
+"""Unit tests for ``Lium.ls()`` client-side CUDA version filtering."""
+
+from __future__ import annotations
+
+from lium.sdk import Config, Lium
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _make_executor_dict(executor_id: str, max_cuda_version) -> dict:
+    """Build a minimal executor dict as returned by the /executors endpoint."""
+    return {
+        "id": executor_id,
+        "machine_name": "NVIDIA H100 SXM 8x",
+        "executor_ip_address": "1.2.3.4",
+        "price_per_gpu": 2.5,
+        "status": "available",
+        "location": {"country": "US"},
+        "specs": {
+            "gpu": {
+                "count": 8,
+                "details": [{"name": "H100", "capacity": 81920, "pcie_speed": 16}],
+                "driver": "535.104.05",
+            },
+            "ram": {"total": 2097152},
+            "hard_disk": {"total": 10485760},
+            "sysbox_runtime": False,
+        },
+        "max_cuda_version": max_cuda_version,
+        "effective_upload_speed_mbps": 500.0,
+        "effective_download_speed_mbps": 1000.0,
+    }
+
+
+def _fake_executors():
+    """Three executors: one above threshold, one below, one with None."""
+    return [
+        _make_executor_dict("above-threshold", 12.6),
+        _make_executor_dict("below-threshold", 11.8),
+        _make_executor_dict("cuda-unknown", None),
+    ]
+
+
+def test_ls_cuda_filter_keeps_only_above_threshold(monkeypatch):
+    """Only the executor whose max_cuda_version >= min_cuda_version is returned."""
+    client = Lium(Config(api_key="test-key"))
+
+    def fake_request(method, endpoint, **kwargs):
+        return _Response(_fake_executors())
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = client.ls(min_cuda_version=12.4)
+
+    ids = [e.id for e in result]
+    assert ids == ["above-threshold"], f"Expected only above-threshold, got {ids}"
+
+
+def test_ls_cuda_filter_excludes_none(monkeypatch):
+    """Executors with max_cuda_version=None are excluded when min_cuda_version is set."""
+    client = Lium(Config(api_key="test-key"))
+
+    def fake_request(method, endpoint, **kwargs):
+        return _Response(_fake_executors())
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = client.ls(min_cuda_version=12.4)
+
+    assert all(e.max_cuda_version is not None for e in result)
+
+
+def test_ls_no_cuda_filter_returns_all(monkeypatch):
+    """When min_cuda_version is not set, all executors are returned."""
+    client = Lium(Config(api_key="test-key"))
+
+    def fake_request(method, endpoint, **kwargs):
+        return _Response(_fake_executors())
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = client.ls()
+
+    assert len(result) == 3
+
+
+def test_ls_cuda_filter_exact_boundary_included(monkeypatch):
+    """An executor whose max_cuda_version equals min_cuda_version is included."""
+    client = Lium(Config(api_key="test-key"))
+
+    executors = [_make_executor_dict("exact", 12.4)]
+
+    def fake_request(method, endpoint, **kwargs):
+        return _Response(executors)
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = client.ls(min_cuda_version=12.4)
+
+    assert len(result) == 1
+    assert result[0].id == "exact"
+
+
+def test_ls_cuda_version_stored_on_executor_info(monkeypatch):
+    """max_cuda_version is correctly mapped onto ExecutorInfo."""
+    client = Lium(Config(api_key="test-key"))
+
+    def fake_request(method, endpoint, **kwargs):
+        return _Response([_make_executor_dict("e1", 12.6)])
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = client.ls()
+
+    assert result[0].max_cuda_version == 12.6


### PR DESCRIPTION
## Summary

Add a `--min-cuda` filter to `lium ls` (CLI + SDK).

### Task Link

DAH-2111

## Problem

`lium ls` could not filter executors by CUDA version. Users needing a specific CUDA version had to inspect machines manually.

## Solution

Client-side filter. The backend returns `max_cuda_version` per executor, but the `/executors` endpoint has no CUDA query parameter, so filtering is applied after fetch. NVIDIA drivers are backward compatible, so an executor satisfies the requirement when `max_cuda_version >= min_cuda_version`; executors with no CUDA value are excluded.

## Changes

- SDK: `ExecutorInfo.max_cuda_version` field; `Lium.ls(min_cuda_version=...)` client-side filter
- CLI: `lium ls --min-cuda <version>` flag with positive-value validation
- display: `Max CUDA` table column and `max_cuda_version` in JSON output
- test: `test/test_ls_cuda_filter.py` — threshold, exact boundary, null exclusion, no-filter

## Deployment Steps

Released to PyPI via the release workflow.

## Review Request

- [ ] Just code review
- [ ] QA – local test on reviewer side

## Other PRs

Companion PRs for DAH-2111 in `lium-io-frontend` and `lium-docs`.

## Risks

Low. Additive change; `ls()` behavior is unchanged when `--min-cuda` is not passed. `ExecutorInfo.max_cuda_version` is a new optional trailing field.

## Test Cases

### Test Case 1

**Actions**: `lium ls --min-cuda 12.4`

**Expected Output**: Only executors with Max CUDA >= 12.4 are listed; lower and unknown-CUDA executors are excluded.

### Test Case 2

**Actions**: `lium ls --min-cuda 0`

**Expected Output**: Validation error: `--min-cuda must be positive`.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described

---

Verified: `pytest test/test_ls_cuda_filter.py` — 5 passed.
