### PR TITLE
DAH-2111 - Bump version to 0.0.17

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.16"
+version = "0.0.17"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump the package version `0.0.16` → `0.0.17`.

### Task Link

DAH-2111

## Problem

PR #77 added the `lium ls --min-cuda` CUDA version filter (CLI + SDK) but did not bump the package version, so the change cannot be published to PyPI.

## Solution

Bump `version` in `pyproject.toml` and `__version__` in `lium/__about__.py` to `0.0.17`.

## Changes

- `pyproject.toml`: `version = "0.0.17"`
- `lium/__about__.py`: `__version__ = "0.0.17"`

## Deployment Steps

After merge, trigger the **Build and Publish Python Package** workflow (`release.yml`, `workflow_dispatch`) with:
- `version`: `0.0.17`
- `release_mode`: `full-release`

## Review Request

- [ ] Just code review

## Other PRs

- #77 — the `--min-cuda` feature this release ships

## Risks

None. Version-string change only.

## Checklist

- [x] PR description is clear and complete
- [x] Risks are documented
