### PR TITLE
Bump CLI version to 0.0.19

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.18"
+__version__ = "0.0.19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.18"
+version = "0.0.19"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump CLI version from 0.0.18 to 0.0.19

## Test plan
- [ ] Release workflow publishes 0.0.19 to PyPI