### PR TITLE
DAH-2121 - Rename executor to node in user-facing CLI strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ AGENTS.md
 .codex
 .claude
 .omx/
+.omc/

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ versioned binary under `~/.lium/versions/<version>/lium`.
 # First-time setup
 lium init
 
-# List available executors (GPU machines)
+# List available nodes (GPU machines)
 lium ls
 
-# Create a pod using executor index
-lium up 1  # Use executor #1 from previous ls
+# Create a pod using node index
+lium up 1  # Use node #1 from previous ls
 
 # Or create a pod using filters
-lium up --gpu A100  # Auto-select best A100 executor
+lium up --gpu A100  # Auto-select best A100 node
 
 # List your pods
 lium ps
@@ -96,8 +96,8 @@ Direct SDK usage follows the same pattern:
 from lium.sdk import Lium
 
 lium = Lium()
-executor = lium.ls(gpu_type="A100")[0]
-pod = lium.up(executor=executor.id, name="demo")
+node = lium.ls(gpu_type="A100")[0]
+pod = lium.up(executor_id=node.id, name="demo")
 ready = lium.wait_ready(pod, timeout=600)
 print(lium.exec(ready, command="nvidia-smi")["stdout"])
 lium.down(ready)
@@ -123,8 +123,8 @@ The `lium` CLI exposes the full pod lifecycle. Run `lium --help` to see everythi
 ### Core Commands
 
 - `lium init` - Initialize configuration (API key, SSH keys)
-- `lium ls [GPU_TYPE]` - List available executors
-- `lium up [EXECUTOR_ID]` - Create a pod (use executor ID or filters like `--gpu`, `--count`, `--country`)
+- `lium ls [GPU_TYPE]` - List available nodes
+- `lium up [NODE_ID]` - Create a pod (use node ID or filters like `--gpu`, `--count`, `--country`)
 - `lium ps` - List active pods
 - `lium ssh <POD>` - SSH into a pod
 - `lium exec <POD> <COMMAND>` - Execute command on pod
@@ -191,7 +191,7 @@ Full reference with every flag and runnable examples: <https://docs.lium.io/deve
 ### Other Commands
 
 - `lium theme [THEME]` - Get or set UI theme (light/dark/auto)
-- `lium mine` - Set up a compute subnet executor/miner
+- `lium mine` - Set up a compute subnet node/miner
 - `sudo lium gpu-splitting setup [--device /dev/...] [--yes]` - Prepare Docker storage for LIUM GPU splitting
 - `lium gpu-splitting check [--device /dev/...]` - Inspect the host and print the GPU-splitting plan
 - `lium gpu-splitting verify` - Verify Docker storage matches LIUM GPU-splitting requirements
@@ -199,21 +199,21 @@ Full reference with every flag and runnable examples: <https://docs.lium.io/deve
 ### Command Examples
 
 ```bash
-# Filter executors by GPU type
+# Filter nodes by GPU type
 lium ls H100
 lium ls A100
 
-# Create pod with executor index
+# Create pod with node index
 lium up 1 --name my-pod --yes
 
-# Create pod with filters (auto-selects best executor)
+# Create pod with filters (auto-selects best node)
 lium up --gpu A100 --count 8 --name my-pod --yes
 lium up --gpu H200 --country US
 
 # Create pod with specific template
 lium up 1 --template_id <TEMPLATE_ID> --yes
 
-# Set up executor bootstrap flow
+# Set up node bootstrap flow
 lium mine --auto --hotkey <HOTKEY>
 
 # Provider-portal automation (same surface as the portal frontend)
@@ -312,8 +312,8 @@ lium fund -w mywal -a 0.5 -y       # Skip confirmation
 ## Features
 
 - **Dual Interface**: Same package ships both the `lium` CLI and a Python SDK (`lium.sdk.Lium` + `@lium.machine` decorator)
-- **Pareto Optimization**: `ls` command shows optimal executors with ★ indicator
-- **Flexible Pod Creation**: Use executor index or auto-select with filters (GPU type, count, country)
+- **Pareto Optimization**: `ls` command shows optimal nodes with ★ indicator
+- **Flexible Pod Creation**: Use node index or auto-select with filters (GPU type, count, country)
 - **Index Selection**: Use numbers from `ls` output in commands
 - **Full-Width Tables**: Clean, readable terminal output
 - **Cost Tracking**: See spending and hourly rates in `ps`

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -49,8 +49,8 @@ Direct SDK usage follows the same pattern:
    from lium.sdk import Lium
 
    lium = Lium()
-   executor = lium.ls(gpu_type="A100")[0]
-   pod = lium.up(executor=executor.id, name="demo")
+   node = lium.ls(gpu_type="A100")[0]
+   pod = lium.up(executor_id=node.id, name="demo")
    ready = lium.wait_ready(pod, timeout=600)
    print(lium.exec(ready, command="nvidia-smi")["stdout"])
 

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.19"
+__version__ = "0.0.20"

--- a/lium/cli/commands/mine.py
+++ b/lium/cli/commands/mine.py
@@ -82,15 +82,15 @@ def _exists(cmd: str) -> bool:
 
 
 def _show_setup_summary():
-    table = Table(title="Executor Setup Plan", show_header=False, box=box.SIMPLE_HEAVY)
+    table = Table(title="Node Setup Plan", show_header=False, box=box.SIMPLE_HEAVY)
     table.add_column("Step", style="cyan", no_wrap=True)
     table.add_column("What happens")
     table.add_row("1", "Clone or update compute-subnet repo")
-    table.add_row("2", "Install executor dependencies")
+    table.add_row("2", "Install node dependencies")
     table.add_row("3", "Prerequisite check (Docker, NVIDIA GPU)")
-    table.add_row("4", "Configure executor .env (ports, hotkey)")
-    table.add_row("5", "Start executor with docker compose")
-    table.add_row("6", "Validate executor configuration")
+    table.add_row("4", "Configure node .env (ports, hotkey)")
+    table.add_row("5", "Start node with docker compose")
+    table.add_row("6", "Validate node configuration")
     console.print(table)
     console.print()
 
@@ -246,7 +246,7 @@ def _start_executor(executor_dir: Path, wait_secs: int = 180):
             if health_status == "healthy":
                 return
         time.sleep(3)
-    raise Exception(f"Executor health check timed out after {wait_secs}s")
+    raise Exception(f"Node health check timed out after {wait_secs}s")
 
 def _apply_env_overrides(
     executor_dir: Path,
@@ -290,9 +290,9 @@ def _gather_inputs(
         ))
     else:
         # Show informative header about port configuration
-        console.print("\n[bold]We're setting up how your executor can be reached.[/bold]\n")
-        console.print("• [cyan]Service port[/cyan] → where the executor's HTTP API listens (default 8080).")
-        console.print("• [cyan]Executor SSH port[/cyan] → used by validators to SSH into the container (default 2200).")
+        console.print("\n[bold]We're setting up how your node can be reached.[/bold]\n")
+        console.print("• [cyan]Service port[/cyan] → where the node's HTTP API listens (default 8080).")
+        console.print("• [cyan]Node SSH port[/cyan] → used by validators to SSH into the container (default 2200).")
         console.print("• [cyan]Public SSH port[/cyan] → only if your server is behind NAT and you forward a different public port.")
         console.print("• [cyan]Renting port range[/cyan] → optional, used only if your firewall limits outbound ports.\n")
         
@@ -312,10 +312,10 @@ def _gather_inputs(
                 console.warning("Port must be an integer between 1 and 65535.")
         
         # Service ports
-        service_port = ask_port("Service port (where the executor API will be reachable)", 8080)
+        service_port = ask_port("Service port (where the node API will be reachable)", 8080)
         answers["internal_port"] = service_port
         answers["external_port"] = service_port  # Set external same as internal
-        answers["ssh_port"] = ask_port("Executor SSH port (used by validator to SSH into the container)", 2200)
+        answers["ssh_port"] = ask_port("Node SSH port (used by validator to SSH into the container)", 2200)
         
         # Optional ports
         ssh_public = Prompt.ask("Public SSH port (optional, only if behind NAT and forwarding a different port)", default="")
@@ -372,7 +372,7 @@ def mine_command(ctx, hotkey, dir_, branch, auto, verbose):
         with timed_step_status(1, TOTAL_STEPS, "Ensuring repository"):
             _clone_or_update_repo(target_dir, branch)
 
-        with timed_step_status(2, TOTAL_STEPS, "Installing executor tools"):
+        with timed_step_status(2, TOTAL_STEPS, "Installing node tools"):
             _install_executor_tools(target_dir)
 
         with timed_step_status(3, TOTAL_STEPS, "Checking prerequisites"):
@@ -381,7 +381,7 @@ def mine_command(ctx, hotkey, dir_, branch, auto, verbose):
         with timed_step_status(4, TOTAL_STEPS, "Configuring environment"):
             executor_dir = target_dir / "neurons" / "executor"
             if not executor_dir.exists():
-                raise Exception(f"Executor directory not found at {executor_dir}")
+                raise Exception(f"Node directory not found at {executor_dir}")
 
             _setup_executor_env(
                 str(executor_dir),
@@ -397,10 +397,10 @@ def mine_command(ctx, hotkey, dir_, branch, auto, verbose):
                 rng=answers["port_range"],
             )
 
-        with timed_step_status(5, TOTAL_STEPS, "Starting executor"):
+        with timed_step_status(5, TOTAL_STEPS, "Starting node"):
             _start_executor(executor_dir)
 
-        with timed_step_status(6, TOTAL_STEPS, "Validating executor"):
+        with timed_step_status(6, TOTAL_STEPS, "Validating node"):
             # Pass any extra arguments to the validator
             _validate_executor(ctx.args if ctx.args else None)
 
@@ -415,7 +415,7 @@ def mine_command(ctx, hotkey, dir_, branch, auto, verbose):
     # Get the external port from answers
     external_port = answers.get("external_port", "8080")
     
-    console.success("\n✨ Executor setup complete!")
+    console.success("\n✨ Node setup complete!")
     console.print()
     
     details_table = Table(show_header=False, box=None)
@@ -427,7 +427,7 @@ def mine_command(ctx, hotkey, dir_, branch, auto, verbose):
     details_table.add_row("📂 Directory", str(executor_dir))
     details_table.add_row("🔑 Hotkey", answers.get("hotkey", "Not set")[:20] + "..." if len(answers.get("hotkey", "")) > 20 else answers.get("hotkey", "Not set"))
     
-    console.print(Panel(details_table, title="[bold]Executor Details[/bold]", border_style="green"))
+    console.print(Panel(details_table, title="[bold]Node Details[/bold]", border_style="green"))
     
     # Generate URL for adding executor via web interface
     from urllib.parse import urlencode
@@ -444,5 +444,5 @@ def mine_command(ctx, hotkey, dir_, branch, auto, verbose):
     # Build full URL with proper encoding
     add_url = f"https://provider.lium.io/executors?{urlencode(params)}"
     
-    console.print("\n[bold cyan]Add this executor via web interface:[/bold cyan]")
+    console.print("\n[bold cyan]Add this node via web interface:[/bold cyan]")
     console.print(f"[yellow]{add_url}[/yellow]\n")

--- a/lium/cli/commands/mine.py
+++ b/lium/cli/commands/mine.py
@@ -442,7 +442,7 @@ def mine_command(ctx, hotkey, dir_, branch, auto, verbose):
     }
     
     # Build full URL with proper encoding
-    add_url = f"https://provider.lium.io/executors?{urlencode(params)}"
+    add_url = f"https://provider.lium.io/nodes?{urlencode(params)}"
     
     console.print("\n[bold cyan]Add this node via web interface:[/bold cyan]")
     console.print(f"[yellow]{add_url}[/yellow]\n")

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -13,7 +13,7 @@ from .actions import GetExecutorsAction
 
 
 def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download") -> List[ExecutorInfo]:
-    """Load and store executors without displaying them."""
+    """Load and store nodes without displaying them."""
     lium = Lium()
     executors = lium.ls(gpu_type=gpu_type)
 
@@ -67,7 +67,7 @@ def ls_command(
     output_format: str,
     min_cuda_version: Optional[float],
 ):
-    """List available GPU executors."""
+    """List available GPU nodes."""
 
     # Validate
     _, error = validation.validate(sort_by, limit, lat, lon, max_distance, min_cuda_version)
@@ -91,7 +91,7 @@ def ls_command(
     if output_format == "json":
         result = action.execute(ctx)
     else:
-        result = ui.load("Loading executors", lambda: action.execute(ctx))
+        result = ui.load("Loading nodes", lambda: action.execute(ctx))
 
     if not result.ok:
         ui.error(result.error)

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -136,9 +136,9 @@ def _add_table_columns(t: Table) -> None:
 def format_header(executor_count: int, pareto_count: int, show_pareto: bool) -> str:
     """Format header text for executors list."""
     if show_pareto and pareto_count > 0:
-        return f"Executors  ({executor_count} shown, ★ {pareto_count} optimal)"
+        return f"Nodes  ({executor_count} shown, ★ {pareto_count} optimal)"
     else:
-        return f"Executors  ({executor_count} shown)"
+        return f"Nodes  ({executor_count} shown)"
 
 
 def format_tip() -> str:

--- a/lium/cli/mine/gpu_splitting.py
+++ b/lium/cli/mine/gpu_splitting.py
@@ -31,7 +31,7 @@ from .storage import (
     resolve_explicit_target,
 )
 
-GPU_SPLITTING_DOC_URL = "https://docs.lium.io/miner-portal/executors/manage?_highlight=gpu&_highlight=split#gpu-splitting"
+GPU_SPLITTING_DOC_URL = "https://docs.lium.io/providers/nodes/gpu-splitting"
 
 
 @dataclass

--- a/lium/cli/plugin_example.py
+++ b/lium/cli/plugin_example.py
@@ -88,15 +88,15 @@ def compose_up(ctx, file: str, detach: bool):
         # Get available executors
         executors = lium.ls(gpu_type=gpu_type)
         if not executors:
-            click.echo(f"No executors available for {gpu_type}", err=True)
+            click.echo(f"No nodes available for {gpu_type}", err=True)
             continue
-        
+
         # Start pod
         executor = executors[0]
         pod = lium.up(
-            executor=executor.id,
+            executor_id=executor.id,
             name=model_name,
-            template=template_id,
+            template_id=template_id,
         )
         
         click.echo(f"✓ Started {model_name} on {executor.huid}")

--- a/lium/cli/provider/status.py
+++ b/lium/cli/provider/status.py
@@ -26,7 +26,7 @@ from lium.provider.errors import ARG_INVALID, ProviderError
 @with_provider_overrides
 @click.pass_context
 def status_command(ctx: click.Context, netuid: int) -> None:
-    """Show a snapshot of registration, portal session, and executor count."""
+    """Show a snapshot of registration, portal session, and node count."""
     opts = (ctx.obj or {}).get("provider_opts") or {}
     if not opts.get("hotkey"):
         ctx.exit(

--- a/lium/cli/ssh_keys/list/command.py
+++ b/lium/cli/ssh_keys/list/command.py
@@ -30,7 +30,7 @@ def ssh_keys_list_command():
 
     if not keys:
         ui.info("No SSH keys registered yet.")
-        ui.dim("Tip: lium up <executor>  # auto-registers your local key")
+        ui.dim("Tip: lium up <node>  # auto-registers your local key")
         return
 
     table, header = build_ssh_keys_table(keys)

--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -26,19 +26,19 @@ class ResolveExecutorAction:
                 if executor_id.isdigit():
                     resolved_ids, error = resolve_executor_indices([executor_id])
                     if error or not resolved_ids:
-                        return ActionResult(ok=False, data={}, error=error or "Failed to resolve executor index")
+                        return ActionResult(ok=False, data={}, error=error or "Failed to resolve node index")
                     executor_id = resolved_ids[0]
 
                 executor = lium.get_executor(executor_id)
                 if not executor:
-                    return ActionResult(ok=False, data={}, error=f"Executor '{executor_id}' not found")
+                    return ActionResult(ok=False, data={}, error=f"Node '{executor_id}' not found")
 
                 if ports and (not executor.available_port_count or executor.available_port_count < ports):
                     available = executor.available_port_count or 0
                     return ActionResult(
                         ok=False,
                         data={},
-                        error=f"Executor {executor.huid} has insufficient ports (available: {available}, required: {ports})"
+                        error=f"Node {executor.huid} has insufficient ports (available: {available}, required: {ports})"
                     )
             else:
                 executors = lium.ls(gpu_type=gpu)
@@ -67,7 +67,7 @@ class ResolveExecutorAction:
                     if ports:
                         filters.append(f"min ports={ports}")
                     filter_desc = ', '.join(filters) if filters else "specified filters"
-                    return ActionResult(ok=False, data={}, error=f"No executors available with {filter_desc}")
+                    return ActionResult(ok=False, data={}, error=f"No nodes available with {filter_desc}")
 
                 from lium.cli.ls.command import ls_store_executor
                 ls_store_executor(gpu_type=gpu)

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -20,14 +20,14 @@ from .actions import (
 
 
 @click.command("up")
-@click.argument("executor_id", required=False)
+@click.argument("executor_id", required=False, metavar="NODE_ID")
 @click.option("--name", "-n", help="Custom pod name")
 @click.option("--template_id", "-t", help="Template ID")
 @click.option("--volume", "-v", help="Volume spec: 'id:<HUID>' or 'new:name=<NAME>[,desc=<DESC>]'")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
-@click.option("--gpu", help="Filter executors by GPU type (e.g., H200, A6000)", shell_complete=get_gpu_completions)
+@click.option("--gpu", help="Filter nodes by GPU type (e.g., H200, A6000)", shell_complete=get_gpu_completions)
 @click.option("--count", "-c", type=int, help="Number of GPUs per pod")
-@click.option("--country", help="Filter executors by ISO country code (e.g., US, FR)")
+@click.option("--country", help="Filter nodes by ISO country code (e.g., US, FR)")
 @click.option("--ports", "-p", type=int, help="Minimum number of available ports required")
 @click.option("--ttl", help="Auto-terminate after duration (e.g., 6h, 45m, 2d)")
 @click.option("--until", help="Auto-terminate at time in local timezone (e.g., 'today 23:00', 'tomorrow 01:00', '2025-10-20 15:30')")
@@ -60,17 +60,17 @@ def up_command(
     ssh_name: Optional[str],
 ):
     """\b
-    Create a new GPU pod on an executor.
+    Create a new GPU pod on a node.
     \b
-    EXECUTOR_ID: Executor UUID, HUID, or index from last 'lium ls'.
-    If not provided, uses filters to auto-select best executor.
+    NODE_ID: Node UUID, HUID, or index from last 'lium ls'.
+    If not provided, uses filters to auto-select best node.
     \b
     Examples:
-      lium up cosmic-hawk-f2                # Create pod on specific executor
-      lium up 1                             # Create pod on executor #1 from last ls
-      lium up --gpu H200                    # Auto-select best H200 executor
-      lium up --gpu A6000 -c 2              # Auto-select best 2×A6000 executor
-      lium up --country US                  # Auto-select best executor in US
+      lium up cosmic-hawk-f2                # Create pod on specific node
+      lium up 1                             # Create pod on node #1 from last ls
+      lium up --gpu H200                    # Auto-select best H200 node
+      lium up --gpu A6000 -c 2              # Auto-select best 2×A6000 node
+      lium up --country US                  # Auto-select best node in US
       lium up --gpu H200 --country FR       # Combine multiple filters
       lium up --ports 5                     # Auto-select with minimum 5 ports
       lium up 1 --name my-pod               # Create with custom name

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -121,7 +121,7 @@ def up_command(
 
     action = ResolveExecutorAction()
     result = ui.load(
-        "Finding executor",
+        "Finding node",
         lambda: action.execute({
             "lium": lium,
             "executor_id": executor_id,

--- a/lium/cli/up/validation.py
+++ b/lium/cli/up/validation.py
@@ -15,10 +15,10 @@ def validate(
 ) -> tuple[bool, str]:
     """Validate up command inputs."""
     if executor_id and (gpu or count or country):
-        return False, "Cannot use filters (--gpu, --count, --country) when specifying an executor ID"
+        return False, "Cannot use filters (--gpu, --count, --country) when specifying a node ID"
 
     if not executor_id and not (gpu or count or country):
-        return False, "Must provide either EXECUTOR_ID or filters (--gpu, --count, --country)"
+        return False, "Must provide either NODE_ID or filters (--gpu, --count, --country)"
 
     if ttl and until:
         return False, "Cannot specify both --ttl and --until"

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -586,7 +586,7 @@ def resolve_executor_indices(indices: List[str]) -> Tuple[List[str], Optional[st
     
     executors = last_selection.get('executors', [])
     if not executors:
-        return [], "No executors in last selection."
+        return [], "No nodes in last selection."
     
     resolved_ids = []
     failed_resolutions = []

--- a/lium/cli/volumes/display.py
+++ b/lium/cli/volumes/display.py
@@ -33,7 +33,7 @@ def format_file_count(count: int) -> str:
 
 def build_volumes_table(volumes: List[VolumeInfo]) -> tuple[Table, str, str]:
     header = f"{Text('Volumes', style='bold')}  ({len(volumes)} total)"
-    tip = f"Tip: {ui.styled('lium up <executor> --volume id:<HUID>', 'success')} {ui.styled('# attach volume to pod', 'dim')}"
+    tip = f"Tip: {ui.styled('lium up <node> --volume id:<HUID>', 'success')} {ui.styled('# attach volume to pod', 'dim')}"
 
     table = Table(
         show_header=True,

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -282,12 +282,12 @@ class Lium:
         ssh_keys: Optional[List[str]] = None,
         ssh_name: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Start a new pod on a specific executor.
+        """Start a new pod on a specific node.
 
         Args:
-            executor_id: Target executor ID string.
+            executor_id: Target node ID string.
             name: Human-friendly pod name (defaults to ``"Your Pod"``).
-            template_id: Template ID. Defaults to the executor's default template.
+            template_id: Template ID. Defaults to the node's default template.
             volume_id: Optional volume ID to attach on spawn.
             ports: Number of exposed ports to request.
             ssh_keys: SSH public keys to authorize. Defaults to the keys discovered by the Config.
@@ -353,7 +353,7 @@ class Lium:
             pod_id: The unique identifier of the pod to retrieve.
 
         Returns:
-            Raw pod data dictionary including template, executor, status, and connection info.
+            Raw pod data dictionary including template, node, status, and connection info.
         """
         return self._request("GET", f"/pods/{pod_id}").json()
 
@@ -438,7 +438,7 @@ class Lium:
         max_distance_miles: Optional[int] = None,
         min_cuda_version: Optional[float] = None,
     ) -> List[ExecutorInfo]:
-        """List available executors.
+        """List available nodes.
 
         Args:
             gpu_type: Optional GPU filter such as ``"A100"`` or ``"H200"``.
@@ -446,9 +446,9 @@ class Lium:
             lat: Optional latitude for geospatial filtering. Must be used together with ``lon`` and ``max_distance_miles``.
             lon: Optional longitude for geospatial filtering. Must be used together with ``lat`` and ``max_distance_miles``.
             max_distance_miles: Optional radius (in miles) for geospatial filtering. Must be used together with ``lat`` and ``lon``.
-            min_cuda_version: Optional minimum CUDA version to require (e.g. ``12.4``). Executors whose
+            min_cuda_version: Optional minimum CUDA version to require (e.g. ``12.4``). Nodes whose
                 ``max_cuda_version`` is ``None`` or below this threshold are excluded. NVIDIA drivers are
-                backward compatible, so an executor with a higher driver CUDA version satisfies the requirement.
+                backward compatible, so a node with a higher driver CUDA version satisfies the requirement.
 
         Returns:
             A list of :class:`ExecutorInfo` objects that satisfy the filters.
@@ -598,16 +598,16 @@ class Lium:
         return templates[0]
 
     def default_docker_template(self, executor_id: str) -> Template:
-        """Resolve the best default template for an executor ID.
+        """Resolve the best default template for a node ID.
 
         Args:
-            executor_id: Executor identifier returned by :meth:`ls`.
+            executor_id: Node identifier returned by :meth:`ls`.
 
         Returns:
-            :class:`Template` best suited for the executor.
+            :class:`Template` best suited for the node.
 
         Raises:
-            ValueError: If no matching executor or template exists.
+            ValueError: If no matching node or template exists.
         """
         executor = self.get_executor(executor_id)
         if not executor:
@@ -672,10 +672,10 @@ class Lium:
 
 
     def get_executor(self, executor: str) -> Optional[ExecutorInfo]:
-        """Resolve an executor by ID.
+        """Resolve a node by ID.
 
         Args:
-            executor: Executor ID string.
+            executor: Node ID string.
 
         Returns:
             Matching :class:`ExecutorInfo` or ``None`` if not found.
@@ -1462,10 +1462,10 @@ class Lium:
             return []
 
     def get_deployment_estimate(self, executor_id: str, template_id: str) -> dict:
-        """Estimate deployment time for a template on an executor.
+        """Estimate deployment time for a template on a node.
 
         Args:
-            executor_id: Executor UUID.
+            executor_id: Node UUID.
             template_id: Template UUID.
 
         Returns:

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -300,7 +300,7 @@ class Lium:
         """
         executor_info = self.get_executor(executor_id)
         if not executor_info:
-            raise ValueError(f"Executor with ID '{executor_id}' not found")
+            raise ValueError(f"Node with ID '{executor_id}' not found")
 
         if template_id is None:
             selected_template = self.default_docker_template(executor_info.id)
@@ -611,7 +611,7 @@ class Lium:
         """
         executor = self.get_executor(executor_id)
         if not executor:
-            raise ValueError(f"No executor found with id {executor_id}")
+            raise ValueError(f"No node found with id {executor_id}")
 
         default_images = self.get_default_images(executor.gpu_model, executor.driver_version)
 
@@ -630,7 +630,7 @@ class Lium:
         if fallback:
             return fallback
 
-        raise ValueError("No templates available to use for executor")
+        raise ValueError("No templates available to use for node")
 
 
     def templates(self, filter: Optional[str] = None, only_my: bool = False) -> List[Template]:

--- a/lium/sdk/decorators.py
+++ b/lium/sdk/decorators.py
@@ -49,7 +49,7 @@ def machine(
                         break
 
                 if not matching_executor:
-                    raise LiumError(f"No executor found matching machine type: {machine}")
+                    raise LiumError(f"No node found matching machine type: {machine}")
 
                 # Step 2: Create pod
                 pod_name = f"remote-{func.__name__}-{int(time.time())}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.19"
+version = "0.0.20"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2121](https://www.notion.so/DAH-2121)

Rename user-facing terminology from "executor" to "node" across the CLI, aligning with the 2026 Provider rename already reflected in the provider command surface.

## Problem

The CLI still surfaces "executor" in help text, prompts, status messages, table titles, and SDK error messages, while the product terminology has moved to "node" (the user-facing term after the Provider rename).

## Solution

Replace "executor" with "node" in user-visible strings only. Internal identifiers and code structure (`executor_id`, `executor_dir`, `get_executor`, etc.) are intentionally left unchanged to keep the diff surface-level and avoid behavioural risk.

## Changes

- `lium up`: help text, `EXECUTOR_ID` → `NODE_ID` arg metavar, filter descriptions, examples, validation messages, and resolve/error messages.
- `lium ls`: command help, loading spinner text, and list header ("Nodes (...)").
- `lium mine`: setup plan table, port-config prompts, step labels, completion panel, and health-check error text.
- `lium provider status`: command docstring.
- `lium ssh-keys` / `lium volumes`: tip strings referencing `lium up <node>`.
- SDK (`client.py`, `decorators.py`): "not found" / "no templates" error messages.
- `.gitignore`: add `.omc/`.

## Deployment Steps

Use GitHub Action. No special steps; string-only changes.

## Review Request

- [ ] Just code review

## Other PRs

None.

## Risks

- Low. Changes are limited to user-facing strings; no logic, arguments, or internal identifiers were altered. The `up` argument metavar changed from `EXECUTOR_ID` to `NODE_ID` (display only — the option name and positional behaviour are unchanged).

## Test Cases

### Test Case 1

**Actions**

Run `lium up --help`, `lium ls`, and `lium mine` (interactive prompts).

**Expected Output**

Help text, prompts, headers, and messages read "node" instead of "executor"; commands behave identically to before.

## Checklist

- [ ] Proper labels added (`ready-review`)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
