### PR TITLE
DAH-2110 - Add lium topup commands for stablecoin top-ups

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.20"
+__version__ = "0.0.21"

--- a/lium/cli/cli.py
+++ b/lium/cli/cli.py
@@ -25,6 +25,7 @@ from .config import config_command
 # from .commands.image import image_command  # Disabled for beta.1
 from .balance import balance_command
 from .fund import fund_command
+from .topup import topup_command
 from .gpu_splitting import gpu_splitting_command
 from .bk import bk_command
 from .mine import mine_command
@@ -81,6 +82,7 @@ cli.add_command(config_command)
 # cli.add_command(image_command)  # Disabled for beta.1
 cli.add_command(balance_command)
 cli.add_command(fund_command)
+cli.add_command(topup_command)
 cli.add_command(gpu_splitting_command)
 cli.add_command(bk_command, name="bk")
 cli.add_command(mine_command)

--- a/lium/cli/topup/__init__.py
+++ b/lium/cli/topup/__init__.py
@@ -1,0 +1,5 @@
+"""Self-serve stablecoin top-up commands."""
+
+from .command import topup_command
+
+__all__ = ["topup_command"]

--- a/lium/cli/topup/command.py
+++ b/lium/cli/topup/command.py
@@ -10,7 +10,7 @@ import json
 
 import click
 
-from lium.sdk import Lium
+from lium.sdk import Lium, LiumError
 from lium.cli import ui
 from lium.cli.utils import handle_errors
 
@@ -40,12 +40,16 @@ def currencies_command(refresh: bool, json_output: bool):
     """
     currencies = Lium().topup_currencies(refresh=refresh)
 
+    # Treat an empty list as an error in both modes: a caller (human or agent)
+    # cannot top up with no supported currency. Raising routes it through
+    # handle_errors, which emits a JSON error envelope (non-zero exit) under
+    # --json and a readable message otherwise — instead of silently printing
+    # `{"currencies": []}` that an agent would mistake for success.
+    if not currencies:
+        raise LiumError("No supported currencies returned")
+
     if json_output:
         click.echo(json.dumps({"currencies": currencies}, sort_keys=True))
-        return
-
-    if not currencies:
-        ui.warning("No supported currencies returned")
         return
 
     rows = [

--- a/lium/cli/topup/command.py
+++ b/lium/cli/topup/command.py
@@ -1,0 +1,98 @@
+"""Self-serve stablecoin top-up commands (TMC Pay).
+
+These let an agent (or user) fund their own Lium balance with a stablecoin:
+create an invoice, read the deposit address + exact crypto amount, then send
+the funds from their own wallet. The balance is credited automatically once the
+provider confirms the transfer — the transfer itself happens outside Lium.
+"""
+
+import json
+
+import click
+
+from lium.sdk import Lium
+from lium.cli import ui
+from lium.cli.utils import handle_errors
+
+
+@click.group("topup")
+def topup_command():
+    """Top up your Lium balance with a stablecoin.
+
+    \b
+    Examples:
+      lium topup currencies
+      lium topup create -a 20 -c USDT -n tron
+    """
+
+
+@topup_command.command("currencies")
+@click.option("--refresh", is_flag=True, help="Bypass the cache and re-fetch")
+@click.option("--json", "json_output", is_flag=True, help="Print machine-readable JSON")
+@handle_errors
+def currencies_command(refresh: bool, json_output: bool):
+    """List supported stablecoins and networks.
+
+    \b
+    Examples:
+      lium topup currencies
+      lium topup currencies --json
+    """
+    currencies = Lium().topup_currencies(refresh=refresh)
+
+    if json_output:
+        click.echo(json.dumps({"currencies": currencies}, sort_keys=True))
+        return
+
+    if not currencies:
+        ui.warning("No supported currencies returned")
+        return
+
+    rows = [
+        [c.get("code", ""), c.get("network", ""), str(c.get("display_decimals", ""))]
+        for c in currencies
+    ]
+    ui.table(["Currency", "Network", "Decimals"], rows)
+
+
+@topup_command.command("create")
+@click.option("--amount", "-a", type=float, required=True, help="Top-up amount in USD")
+@click.option("--currency", "-c", required=True, help="Stablecoin code, e.g. USDT")
+@click.option("--network", "-n", required=True, help="Network, e.g. tron")
+@click.option("--json", "json_output", is_flag=True, help="Print machine-readable JSON")
+@handle_errors
+def create_command(amount: float, currency: str, network: str, json_output: bool):
+    """Create a top-up invoice and print its deposit address.
+
+    Send exactly the returned crypto_amount of the currency to the deposit
+    address on the given network. The balance is credited automatically once
+    the transfer is confirmed.
+
+    \b
+    Examples:
+      lium topup create -a 20 -c USDT -n tron
+      lium topup create -a 20 -c USDT -n tron --json
+    """
+    invoice = Lium().topup_create_invoice(
+        amount=amount, crypto_currency=currency, crypto_network=network
+    )
+
+    if json_output:
+        click.echo(json.dumps(invoice, sort_keys=True))
+        return
+
+    ui.success("Invoice created")
+    ui.info(f"Invoice ID:      {invoice.get('invoice_id', '')}")
+    ui.info(f"Deposit address: {invoice.get('deposit_address', '')}")
+    ui.info(
+        f"Send:            {invoice.get('crypto_amount', '')} "
+        f"{invoice.get('crypto_currency', '')} on {invoice.get('crypto_network', '')}"
+    )
+    ui.info(
+        f"For:             ${invoice.get('fiat_amount', '')} "
+        f"{invoice.get('fiat_currency', 'USD')}"
+    )
+    if invoice.get("expires_at"):
+        ui.dim(f"Expires at:      {invoice.get('expires_at')}")
+    if invoice.get("hosted_invoice_url"):
+        ui.dim(f"Hosted page:     {invoice.get('hosted_invoice_url')}")

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -243,25 +243,53 @@ def timed_step_status(step: int = 0, total_steps: int = 0, message: str = ""):
         raise
 
 
+def _emit_json_error(code: str, message: str) -> None:
+    """Print a machine-readable error envelope to stderr and exit non-zero.
+
+    Keeps stdout clean for JSON consumers (agents): on success stdout carries
+    the result JSON, on failure stdout is empty, the error JSON goes to stderr,
+    and the process exits with a non-zero status so callers can detect it.
+    """
+    envelope = {"ok": False, "error": {"code": code, "message": message}}
+    click.echo(json.dumps(envelope, sort_keys=True), err=True)
+    raise SystemExit(1)
+
+
 def handle_errors(func):
-    """Decorator to handle CLI errors gracefully."""
+    """Decorator to handle CLI errors gracefully.
+
+    When the wrapped command was invoked with ``--json`` (a ``json_output``
+    flag), errors are rendered as a JSON envelope on stderr and the process
+    exits non-zero, so machine consumers get parseable output instead of
+    Rich-formatted text on stdout. Otherwise the human-readable rendering is
+    preserved.
+    """
     @wraps(func)
     def wrapper(*args, **kwargs):
+        json_output = bool(kwargs.get("json_output"))
         try:
             return func(*args, **kwargs)
         except (click.ClickException, click.Abort):
             raise
         except ValueError as e:
-            # Check if it's the API key error from SDK
-            if "No API key found" in str(e):
+            is_missing_api_key = "No API key found" in str(e)
+            if json_output:
+                _emit_json_error(
+                    "no_api_key" if is_missing_api_key else "value_error", str(e)
+                )
+            elif is_missing_api_key:
                 console.error("No API key configured")
                 console.warning("Please run 'lium init' to set up your API key")
                 console.dim("Or set LIUM_API_KEY environment variable")
             else:
                 console.error(f"Error: {e}")
         except LiumError as e:
+            if json_output:
+                _emit_json_error("lium_error", str(e))
             console.error(f"Error: {e}")
         except Exception as e:
+            if json_output:
+                _emit_json_error("unexpected_error", str(e))
             console.error(f"Unexpected error: {e}")
     return wrapper
 

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1485,6 +1485,44 @@ class Lium:
         """
         return float(self._request("GET", "/users/me").json().get("balance") or 0)
 
+    def topup_currencies(self, refresh: bool = False) -> List[Dict[str, Any]]:
+        """List stablecoin currencies/networks supported for self-serve top-ups.
+
+        Args:
+            refresh: Bypass the server-side cache and re-fetch from the provider.
+
+        Returns:
+            List of ``{"code", "network", "decimals", "display_decimals"}`` dicts.
+        """
+        params = {"refresh": "true"} if refresh else None
+        data = self._request("GET", "/tmc-pay/currencies", params=params).json()
+        return data.get("currencies", [])
+
+    def topup_create_invoice(
+        self, amount: float, crypto_currency: str, crypto_network: str
+    ) -> Dict[str, Any]:
+        """Create a stablecoin top-up invoice for the current account.
+
+        The returned ``deposit_address`` is where the exact ``crypto_amount`` of
+        ``crypto_currency`` (on ``crypto_network``) must be sent. Once the provider
+        confirms the transfer, the account balance is credited automatically.
+
+        Args:
+            amount: Top-up amount in USD.
+            crypto_currency: Stablecoin code (e.g. ``"USDT"``), see :meth:`topup_currencies`.
+            crypto_network: Network the stablecoin is sent on (e.g. ``"tron"``).
+
+        Returns:
+            Invoice dict including ``invoice_id``, ``deposit_address``, ``crypto_amount``,
+            ``crypto_currency``, ``crypto_network``, ``exchange_rate`` and ``expires_at``.
+        """
+        payload = {
+            "amount": amount,
+            "crypto_currency": crypto_currency,
+            "crypto_network": crypto_network,
+        }
+        return self._request("POST", "/tmc-pay/create-invoice", json=payload).json()
+
     def volumes(self) -> List[VolumeInfo]:
         """List all volumes for the current user.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.20"
+version = "0.0.21"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/test/test_topup_cli.py
+++ b/test/test_topup_cli.py
@@ -1,0 +1,82 @@
+"""DAH-2110: `lium topup` stablecoin commands and JSON error handling.
+
+`topup` lets a user (or an autonomous agent) fund their balance with a
+stablecoin. Because the `--json` paths are meant for machine consumers, an
+error under `--json` must be emitted as a parseable JSON envelope on stderr
+with a non-zero exit code — never Rich-formatted text on stdout with a success
+exit code. The human (non-`--json`) rendering is preserved.
+"""
+
+import json
+
+from click.testing import CliRunner
+
+from lium.cli.cli import cli
+from lium.cli.topup import command as topup_module
+from lium.sdk import LiumError
+
+
+def test_topup_currencies_json_success(monkeypatch):
+    class FakeLium:
+        def topup_currencies(self, refresh=False):
+            return [
+                {
+                    "code": "USDT",
+                    "network": "tron",
+                    "decimals": 6,
+                    "display_decimals": 2,
+                }
+            ]
+
+    monkeypatch.setattr(topup_module, "Lium", FakeLium)
+
+    result = CliRunner().invoke(cli, ["topup", "currencies", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "currencies": [
+            {
+                "code": "USDT",
+                "network": "tron",
+                "decimals": 6,
+                "display_decimals": 2,
+            }
+        ]
+    }
+
+
+def test_topup_create_json_error_is_json_envelope_on_stderr(monkeypatch):
+    class FakeLium:
+        def topup_create_invoice(self, amount, crypto_currency, crypto_network):
+            raise LiumError("Server error: 503")
+
+    monkeypatch.setattr(topup_module, "Lium", FakeLium)
+
+    result = CliRunner().invoke(
+        cli, ["topup", "create", "-a", "1", "-c", "USDT", "-n", "tron", "--json"]
+    )
+
+    # Non-zero exit so machine callers detect the failure.
+    assert result.exit_code != 0
+    # stdout stays clean — no Rich text leaks into the JSON stream.
+    assert result.stdout == ""
+    # Error is a parseable JSON envelope on stderr.
+    payload = json.loads(result.stderr)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "lium_error"
+    assert "503" in payload["error"]["message"]
+
+
+def test_topup_create_human_error_is_unchanged(monkeypatch):
+    class FakeLium:
+        def topup_create_invoice(self, amount, crypto_currency, crypto_network):
+            raise LiumError("Server error: 503")
+
+    monkeypatch.setattr(topup_module, "Lium", FakeLium)
+
+    result = CliRunner().invoke(
+        cli, ["topup", "create", "-a", "1", "-c", "USDT", "-n", "tron"]
+    )
+
+    # Human path keeps the readable, non-JSON message.
+    assert "Error: Server error: 503" in result.output

--- a/test/test_topup_cli.py
+++ b/test/test_topup_cli.py
@@ -45,6 +45,36 @@ def test_topup_currencies_json_success(monkeypatch):
     }
 
 
+def test_topup_currencies_empty_json_emits_error_envelope(monkeypatch):
+    # An empty list must not look like success under --json: the agent would
+    # otherwise read `{"currencies": []}` and proceed with nothing to pay in.
+    class FakeLium:
+        def topup_currencies(self, refresh=False):
+            return []
+
+    monkeypatch.setattr(topup_module, "Lium", FakeLium)
+
+    result = CliRunner().invoke(cli, ["topup", "currencies", "--json"])
+
+    assert result.exit_code != 0
+    assert result.stdout == ""
+    payload = json.loads(result.stderr)
+    assert payload["ok"] is False
+    assert "No supported currencies" in payload["error"]["message"]
+
+
+def test_topup_currencies_empty_human_errors(monkeypatch):
+    class FakeLium:
+        def topup_currencies(self, refresh=False):
+            return []
+
+    monkeypatch.setattr(topup_module, "Lium", FakeLium)
+
+    result = CliRunner().invoke(cli, ["topup", "currencies"])
+
+    assert "Error: No supported currencies returned" in result.output
+
+
 def test_topup_create_json_error_is_json_envelope_on_stderr(monkeypatch):
     class FakeLium:
         def topup_create_invoice(self, amount, crypto_currency, crypto_network):


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2110](https://www.notion.so/DAH-2110)

Adds a `lium topup` command group (and matching SDK methods) so a user — or an autonomous agent with its own crypto wallet — can fund their Lium balance with a stablecoin from the CLI. The commands wrap the existing backend TMC Pay endpoints; the on-chain transfer stays in the user's wallet.

## Problem

The CLI only supported funding via TAO (`lium fund`, Bittensor wallet). There was no shell-driven way to top up with a stablecoin, and nothing an AI agent could call to self-fund without a human opening the web billing page.

## Solution

Add a `topup` command group backed by three SDK methods that call the existing backend endpoints (`GET /tmc-pay/currencies`, `POST /tmc-pay/create-invoice`). The agent flow is: create an invoice → read `deposit_address` + `crypto_amount` from the response → send the funds from its own wallet → poll `lium balance`. Every subcommand supports `--json` for machine consumption.

## Changes

- `lium/sdk/client.py`: add `topup_currencies(refresh=False)` and `topup_create_invoice(amount, crypto_currency, crypto_network)`.
- `lium/cli/topup/` (new): `topup` group with subcommands `currencies` and `create`, each with `--json`. `create` prints the deposit address, exact crypto amount, network, fiat value, and expiry.
- `lium/cli/cli.py`: register `topup_command`.

## Deployment Steps

Ships with the next CLI/SDK release (PyPI `lium.io` + binary). No server changes — consumes endpoints already live in `lium-io-backend`.

## Review Request

- [x] Just code review

## Other PRs

- `lium-docs`: documents the `lium topup` commands and the agent self-funding loop (opened alongside this PR).
- No `lium-io-backend` PR: `topup` consumes the existing `/tmc-pay/create-invoice` and `/tmc-pay/currencies` endpoints. (The earlier deposit-address lookup endpoint was dropped as redundant — the create response already returns the address and amount.)

## Risks

- Low. Additive only — a new command group and two SDK methods; no existing command or code path is modified beyond registration.
- `topup create` surfaces whatever the backend returns; if the backend's create response omits `crypto_amount` it would come through as `0` — out of scope for this PR (backend-side concern noted on DAH-2110).

## Test Cases

### Test Case 1

**Actions**
`lium topup currencies --json`

**Expected Output**
JSON `{ "currencies": [ { code, network, decimals, display_decimals }, ... ] }`.

### Test Case 2

**Actions**
`lium topup create -a 20 -c USDT -n tron --json`

**Expected Output**
JSON invoice including `invoice_id`, `deposit_address`, `crypto_amount`, `crypto_currency`, `crypto_network`, `expires_at`.

### Test Case 3

**Actions**
`lium topup --help`, `lium topup create --help`

**Expected Output**
Group lists `currencies` and `create`; `create` shows required `-a/-c/-n` options and `--json`.

> Note: command tree and SDK method wiring were verified by loading the CLI/SDK in-process; the `--json` paths were not exercised against a live backend in this branch.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
