### PR TITLE
DAH-2172 - Add USD-denominated alpha funding to lium fund

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.21"
+__version__ = "0.0.22"

--- a/lium/cli/fund/actions.py
+++ b/lium/cli/fund/actions.py
@@ -321,7 +321,12 @@ class ExecuteAlphaTransferAction:
                     or getattr(resp, "error", None)
                     or "transfer_stake failed"
                 )
-                return ActionResult(ok=False, data={}, error=str(msg))
+                # The extrinsic was signed and submitted; the chain rejected it. Flag
+                # it so the caller can exit non-zero (distinct from the pre-flight
+                # guard aborts above, which never reach the chain).
+                return ActionResult(
+                    ok=False, data={"transfer_attempted": True}, error=str(msg)
+                )
 
             return ActionResult(
                 ok=True,

--- a/lium/cli/fund/actions.py
+++ b/lium/cli/fund/actions.py
@@ -2,6 +2,65 @@ import time
 from typing import Any
 
 from lium.cli.actions import ActionResult
+from .validation import subtensor_class, wallet_class
+
+# Lium's on-chain funding coldkey for the legacy TAO transfer. The alpha path no
+# longer uses this constant — it resolves the destination coldkey from the pay API
+# at fund time (see ``_alpha_fund``) so a rotated address can never silently send
+# alpha into a black hole.
+LIUM_FUNDING_ADDRESS = "5FqACMtcegZxxopgu1g7TgyrnyD8skurr9QDPLPhxNQzsThe"
+
+
+def _select_free_alpha(stake_infos, hotkey_ss58, netuid):
+    """Select the single StakeInfo for ``hotkey_ss58`` on ``netuid`` and return free alpha.
+
+    Free alpha is ``stake - locked`` (both alpha-denominated Balances). The match
+    must be on hotkey AND netuid; a coldkey can hold alpha under several hotkeys
+    and across several subnets, so a loose match would gate on the wrong balance.
+    ``netuid`` is the API-resolved subnet — never a hardcoded constant.
+
+    Returns:
+        ``(free_balance, "")`` on success, or ``(None, error_message)`` when there
+        is no matching stake (nothing to transfer) or — unexpectedly — more than
+        one matching row (ambiguous; never silently pick one).
+    """
+    rows = [
+        s
+        for s in (stake_infos or [])
+        if s.hotkey_ss58 == hotkey_ss58 and s.netuid == netuid
+    ]
+    if not rows:
+        return None, (
+            f"No free alpha: no stake found for hotkey {hotkey_ss58} on netuid {netuid}"
+        )
+    if len(rows) > 1:
+        return None, (
+            f"Unexpected multiple stake entries for hotkey {hotkey_ss58} "
+            f"on netuid {netuid}; aborting"
+        )
+    return rows[0].stake - rows[0].locked, ""
+
+
+def _movement_fee(subtensor, amount_bal, netuid):
+    """Best-effort on-chain stake-movement fee for the alpha transfer.
+
+    The transfer stays on one subnet (origin == destination netuid). This is purely
+    advisory: when available the fee is folded into the free-alpha gate and shown to
+    the user; when the node can't answer, the caller proceeds on ``free >= amount``
+    rather than blocking.
+
+    Returns:
+        ``(fee_balance, True)`` when obtained, else ``(None, False)``.
+    """
+    try:
+        fee = subtensor.get_stake_movement_fee(
+            origin_netuid=netuid,
+            destination_netuid=netuid,
+            amount=amount_bal,
+        )
+        return fee, True
+    except Exception:
+        return None, False
 
 
 class LoadWalletAction:
@@ -18,7 +77,8 @@ class LoadWalletAction:
 
         try:
             wallet_name = ctx["wallet_name"]
-            bt_wallet = bt.wallet(wallet_name)
+            # bittensor >=8 renamed the factory to ``bt.Wallet``; resolve either.
+            bt_wallet = wallet_class(bt)(wallet_name)
             wallet_address = bt_wallet.coldkeypub.ss58_address
 
             return ActionResult(
@@ -53,13 +113,19 @@ class CheckWalletRegistrationAction:
 
             needs_registration = wallet_address not in wallet_addresses
 
+            app_id = None
             if needs_registration:
-                lium.add_wallet(bt_wallet)
+                # add_wallet returns (app_id, customer_id) parsed from the same
+                # /tao/create-transfer round-trip; the alpha flow reuses app_id so
+                # it never issues a second create-transfer. The TAO flow ignores it.
+                registration = lium.add_wallet(bt_wallet)
+                if registration:
+                    app_id = registration[0]
                 time.sleep(2)  # Allow registration to complete
 
             return ActionResult(
                 ok=True,
-                data={"registered": not needs_registration}
+                data={"registered": not needs_registration, "app_id": app_id}
             )
         except Exception as e:
             return ActionResult(ok=False, data={}, error=str(e))
@@ -68,7 +134,7 @@ class CheckWalletRegistrationAction:
 class ExecuteTransferAction:
     """Execute TAO transfer to Lium funding address."""
 
-    LIUM_FUNDING_ADDRESS = "5FqACMtcegZxxopgu1g7TgyrnyD8skurr9QDPLPhxNQzsThe"
+    LIUM_FUNDING_ADDRESS = LIUM_FUNDING_ADDRESS
 
     def execute(self, ctx: dict) -> ActionResult:
         """Execute transfer.
@@ -84,16 +150,24 @@ class ExecuteTransferAction:
         tao_amount = ctx["tao_amount"]
 
         try:
-            subtensor = bt.subtensor()
+            subtensor = subtensor_class(bt)()
 
-            success = subtensor.transfer(
+            resp = subtensor.transfer(
                 wallet=bt_wallet,
-                dest=self.LIUM_FUNDING_ADDRESS,
-                amount=bt.Balance.from_tao(tao_amount)
+                destination_ss58=self.LIUM_FUNDING_ADDRESS,
+                amount=bt.Balance.from_tao(tao_amount),
             )
 
-            if not success:
-                return ActionResult(ok=False, data={}, error="Transfer failed")
+            # bittensor >=8 returns an ExtrinsicResponse (.success/.message); older
+            # versions returned a bare bool. Accept either.
+            ok = getattr(resp, "success", resp)
+            if not ok:
+                msg = (
+                    getattr(resp, "message", None)
+                    or getattr(resp, "error", None)
+                    or "Transfer failed"
+                )
+                return ActionResult(ok=False, data={}, error=str(msg))
 
             return ActionResult(ok=True, data={})
         except Exception as e:
@@ -139,3 +213,119 @@ class WaitForBalanceUpdateAction:
             data={},
             error=f"Balance not updated after {self.TIMEOUT}s timeout"
         )
+
+
+class CheckFreeAlphaAction:
+    """Phase A guardrail: read free SN51 alpha for display before the confirm prompt.
+
+    This is NOT the authoritative gate — balances can change between display and
+    signing, so the binding check is re-done inside :class:`ExecuteAlphaTransferAction`
+    immediately before the transfer.
+
+    Context:
+        bt: bittensor module
+        coldkey_ss58: str
+        hotkey_ss58: str
+        amount_bal: Balance (alpha, unit = resolved netuid)
+        netuid: int (API-resolved subnet)
+        dest_coldkey: str (API-resolved Lium funding coldkey)
+    """
+
+    def execute(self, ctx: dict) -> ActionResult:
+        bt = ctx["bt"]
+        coldkey = ctx["coldkey_ss58"]
+        hotkey = ctx["hotkey_ss58"]
+        amount = ctx["amount_bal"]
+        netuid = ctx["netuid"]
+        dest_coldkey = ctx["dest_coldkey"]
+
+        try:
+            subtensor = subtensor_class(bt)()
+            stake_infos = subtensor.get_stake_info_for_coldkey(coldkey)
+            free, err = _select_free_alpha(stake_infos, hotkey, netuid)
+            if err:
+                return ActionResult(ok=False, data={}, error=err)
+
+            fee, modeled = _movement_fee(subtensor, amount, netuid)
+            return ActionResult(
+                ok=True,
+                data={"free": free, "fee": fee, "fee_modeled": modeled},
+            )
+        except Exception as e:
+            return ActionResult(ok=False, data={}, error=str(e))
+
+
+class ExecuteAlphaTransferAction:
+    """Authoritative gate + execute: transfer free SN51 alpha to the Lium coldkey.
+
+    Constructs a single subtensor, performs a FRESH read of free alpha immediately
+    before signing (closing the time-of-check/time-of-use window), gates on
+    ``free_alpha >= requested_alpha``, then ``transfer_stake``s on the same instance.
+    The movement fee is denominated in TAO and paid from the coldkey separately from
+    the alpha being moved, so it is purely advisory (display/JSON) and never folded
+    into the alpha gate — the chain rejects (surfaced via ExtrinsicResponse) if the
+    coldkey lacks the TAO to cover it.
+
+    Context:
+        bt: bittensor module
+        bt_wallet: bittensor wallet (signs the extrinsic)
+        coldkey_ss58: str
+        hotkey_ss58: str
+        amount_bal: Balance (alpha, unit = resolved netuid)
+        netuid: int (API-resolved subnet; drives the transfer)
+        dest_coldkey: str (API-resolved Lium funding coldkey; the transfer destination)
+    """
+
+    def execute(self, ctx: dict) -> ActionResult:
+        bt = ctx["bt"]
+        bt_wallet = ctx["bt_wallet"]
+        coldkey = ctx["coldkey_ss58"]
+        hotkey = ctx["hotkey_ss58"]
+        amount = ctx["amount_bal"]
+        netuid = ctx["netuid"]
+        dest_coldkey = ctx["dest_coldkey"]
+
+        try:
+            subtensor = subtensor_class(bt)()
+            stake_infos = subtensor.get_stake_info_for_coldkey(coldkey)
+            free, err = _select_free_alpha(stake_infos, hotkey, netuid)
+            if err:
+                return ActionResult(ok=False, data={}, error=err)
+
+            # The movement fee is TAO-denominated and paid from the coldkey, NOT
+            # deducted from the alpha being moved — so the gate is a pure alpha-vs-alpha
+            # comparison. The fee is fetched only for display/JSON.
+            fee, modeled = _movement_fee(subtensor, amount, netuid)
+
+            if free < amount:
+                return ActionResult(
+                    ok=False,
+                    data={"free": free, "fee": fee, "fee_modeled": modeled},
+                    error=f"Insufficient free alpha: need {amount}, free {free}",
+                )
+
+            resp = subtensor.transfer_stake(
+                wallet=bt_wallet,
+                destination_coldkey_ss58=dest_coldkey,
+                hotkey_ss58=hotkey,
+                origin_netuid=netuid,
+                destination_netuid=netuid,
+                amount=amount,
+            )
+            # bittensor >=8 returns an ExtrinsicResponse (.success/.message); older
+            # versions returned a bare bool. Accept either.
+            ok = getattr(resp, "success", resp)
+            if not ok:
+                msg = (
+                    getattr(resp, "message", None)
+                    or getattr(resp, "error", None)
+                    or "transfer_stake failed"
+                )
+                return ActionResult(ok=False, data={}, error=str(msg))
+
+            return ActionResult(
+                ok=True,
+                data={"free": free, "fee": fee, "fee_modeled": modeled},
+            )
+        except Exception as e:
+            return ActionResult(ok=False, data={}, error=str(e))

--- a/lium/cli/fund/command.py
+++ b/lium/cli/fund/command.py
@@ -1,11 +1,13 @@
 """Fund account command."""
 
+import json
+from decimal import Decimal, ROUND_DOWN
 from typing import Optional
 
 import click
 from rich.prompt import Prompt
 
-from lium.sdk import Lium
+from lium.sdk import Lium, LiumError
 from lium.cli import ui
 from lium.cli.utils import handle_errors
 from lium.cli.settings import config
@@ -14,7 +16,18 @@ from .actions import (
     LoadWalletAction,
     CheckWalletRegistrationAction,
     ExecuteTransferAction,
+    CheckFreeAlphaAction,
+    ExecuteAlphaTransferAction,
 )
+
+# 1 alpha = 1e9 rao (same scale as TAO). Used to floor the API's Decimal alpha
+# quote at integer-rao precision before constructing the on-chain Balance.
+_RAO_PER_ALPHA = Decimal(10) ** 9
+
+# Shown wherever a USD amount is confirmed: the listener credits the actual alpha
+# moved, re-valued at on-chain inclusion time, so the credited USD can differ from
+# the quote.
+_USD_CAVEAT = "credited USD valued at on-chain inclusion time; may differ from quote"
 
 
 def _legacy_tao_fund(wallet: Optional[str], amount: Optional[str], yes: bool) -> None:
@@ -93,18 +106,240 @@ def _legacy_tao_fund(wallet: Optional[str], amount: Optional[str], yes: bool) ->
     ui.info("Done.")
 
 
+def _alpha_fund(
+    wallet: Optional[str],
+    amount: Optional[str],
+    hotkey: Optional[str],
+    yes: bool,
+    json_output: bool,
+) -> None:
+    """Fund the Lium account with free alpha via ``transfer_stake``.
+
+    The amount is denominated in USD: ``GET /balance/convert/alpha`` quotes both the
+    alpha amount to move and the subnet ``netuid`` to move it on, and
+    ``GET /wallet/company/`` supplies the destination coldkey. All three values are
+    resolved from pay-tao-api-v2 ONCE at the top of the flow — never hardcoded — so a
+    rotated netuid/address cannot silently send alpha into a black hole. Any API
+    failure ``raise``s ``LiumError`` (rendered as the JSON envelope under ``--json``)
+    before any on-chain call. Mirrors the TAO flow's wallet-load + registration.
+    """
+    try:
+        import bittensor as bt
+    except ImportError:
+        raise LiumError("Bittensor library not installed (pip install bittensor)")
+
+    # Resolve the wallet (coldkey).
+    if not wallet:
+        if json_output:
+            raise LiumError("wallet is required: pass --wallet")
+        default_wallet = config.get("funding.default_wallet", "default")
+        wallet = Prompt.ask("Bittensor wallet name", default=default_wallet).strip()
+
+    # Resolve and validate the origin hotkey. Accept either an SS58 address or a
+    # wallet hotkey NAME (resolved against --wallet), mirroring btcli's stake-move.
+    # --wallet is already resolved above, which a name lookup requires.
+    if not hotkey:
+        if json_output:
+            raise LiumError(
+                "hotkey is required for --alpha: pass --hotkey (SS58 or wallet hotkey name)"
+            )
+        hotkey = Prompt.ask(
+            "Origin hotkey (SS58 or wallet hotkey name) the alpha is staked under"
+        ).strip()
+    hotkey, error = validation.resolve_hotkey(hotkey, wallet, bt)
+    if error:
+        raise LiumError(error)
+
+    result = LoadWalletAction().execute({"bt": bt, "wallet_name": wallet})
+    if not result.ok:
+        raise LiumError(f"Failed to load wallet '{wallet}': {result.error}")
+    bt_wallet = result.data["wallet"]
+    coldkey_ss58 = result.data["address"]
+
+    # Resolve and validate the USD amount (fail fast, before any network call).
+    if not amount:
+        if json_output:
+            raise LiumError("amount is required: pass --amount")
+        amount = Prompt.ask("Enter USD amount to fund").strip()
+    usd_amount, error = validation.validate_amount(amount)
+    if error:
+        raise LiumError(error)
+
+    # Register the wallet so the backend can attribute the deposit (mirrors TAO flow).
+    lium = Lium()
+    reg_ctx = {
+        "lium": lium,
+        "wallet_address": coldkey_ss58,
+        "bt_wallet": bt_wallet,
+    }
+    result = ui.load(
+        "Checking wallet registration",
+        lambda: CheckWalletRegistrationAction().execute(reg_ctx),
+    )
+    if not result.ok:
+        raise LiumError(f"Failed to register wallet: {result.error}")
+    # app_id comes from the registration's single /tao/create-transfer parse when a
+    # new wallet was registered; otherwise discover it (still exactly one round-trip).
+    app_id = result.data.get("app_id") or lium._discover_app_id(bt_wallet)
+
+    # API-first resolution: destination coldkey first (404-fast, no chain), then the
+    # USD->alpha quote (503-prone). Both hard-fail (LiumError) on any API error.
+    funding_address = ui.load(
+        "Resolving funding address", lambda: lium.company_wallet(app_id)
+    )
+    # The destination is now trusted at runtime (no longer a source-pinned constant),
+    # so validate it before it can become a transfer target: it must be a well-formed
+    # SS58 and must not be the user's own coldkey. Abort (no fallback) otherwise.
+    funding_address, fa_err = validation.validate_ss58(funding_address, bt)
+    if fa_err:
+        raise LiumError(f"pay API returned an invalid funding address: {fa_err}")
+    if funding_address == coldkey_ss58:
+        raise LiumError(
+            "pay API returned the caller's own coldkey as the funding address; aborting"
+        )
+    quote = ui.load("Quoting alpha", lambda: lium.convert_alpha(usd_amount))
+    netuid = quote.netuid
+
+    # Decimal -> Balance: floor the quoted alpha at integer rao with ROUND_DOWN BEFORE
+    # set_unit, so we never transfer more than quoted (keeps the free+fee gate exact).
+    # Never via from_tao(float), which would inject binary-float error on a money path.
+    floored_rao = int(
+        (quote.alpha_amount * _RAO_PER_ALPHA).quantize(Decimal(1), rounding=ROUND_DOWN)
+    )
+    amount_bal = bt.Balance.from_rao(floored_rao).set_unit(netuid)
+    alpha_amount = floored_rao / float(_RAO_PER_ALPHA)
+
+    # Phase A: display free alpha + fee before the confirm prompt.
+    check_ctx = {
+        "bt": bt,
+        "coldkey_ss58": coldkey_ss58,
+        "hotkey_ss58": hotkey,
+        "amount_bal": amount_bal,
+        "netuid": netuid,
+        "dest_coldkey": funding_address,
+    }
+    result = ui.load(
+        "Checking free alpha", lambda: CheckFreeAlphaAction().execute(check_ctx)
+    )
+    if not result.ok:
+        raise LiumError(result.error)
+    free = result.data["free"]
+    fee = result.data["fee"]
+    fee_modeled = result.data["fee_modeled"]
+
+    if not json_output:
+        ui.info(f"Destination (Lium coldkey): {funding_address}")
+        ui.info(f"Free alpha (netuid {netuid}): {free}")
+        if fee_modeled:
+            ui.info(f"Movement fee: {fee}")
+        ui.info(_USD_CAVEAT)
+
+    # Confirm. --json is treated as non-interactive: never prompt, never hang.
+    if json_output and not yes:
+        raise LiumError("confirmation required: pass --yes")
+    if not json_output and not yes:
+        if not ui.confirm(
+            f"Fund account with ~${usd_amount} USD = {alpha_amount} alpha "
+            f"(netuid {netuid}) from {hotkey} -> {funding_address}?",
+            default=False,
+        ):
+            return
+
+    # Phase B drift guard: re-fetch the quote and re-validate its netuid against the
+    # value resolved at the top (value-vs-value, no constant). The TRANSFERRED amount
+    # stays the Phase-A confirmed amount_bal — the re-fetch only guards netuid drift,
+    # it never re-derives a new (possibly larger) signed amount.
+    fresh_quote = lium.convert_alpha(usd_amount)
+    if fresh_quote.netuid != netuid:
+        raise LiumError(
+            f"netuid changed mid-flight: resolved {netuid} but re-fetch returned "
+            f"{fresh_quote.netuid}; aborting to avoid an uncredited transfer"
+        )
+
+    # Phase B: authoritative fee-aware gate (fresh re-read) + transfer_stake.
+    exec_ctx = {
+        "bt": bt,
+        "bt_wallet": bt_wallet,
+        "coldkey_ss58": coldkey_ss58,
+        "hotkey_ss58": hotkey,
+        "amount_bal": amount_bal,
+        "netuid": netuid,
+        "dest_coldkey": funding_address,
+    }
+    result = ExecuteAlphaTransferAction().execute(exec_ctx)
+    if not result.ok:
+        raise LiumError(result.error)
+
+    fee_modeled = result.data.get("fee_modeled", fee_modeled)
+    result_fee = result.data.get("fee")
+    fee_caveat = (
+        None
+        if fee_modeled
+        else "stake-movement fee not modeled; a max-amount send may fail to credit"
+    )
+
+    if json_output:
+        envelope = {
+            "ok": True,
+            "tx": {
+                "coldkey": coldkey_ss58,
+                "hotkey": hotkey,
+                "netuid": netuid,
+                "usd": usd_amount,
+                "amount_alpha": alpha_amount,
+                "rate": float(quote.rate),
+                "dest_coldkey": funding_address,
+                "fee_alpha": float(result_fee.tao) if fee_modeled and result_fee is not None else None,
+                "fee_modeled": fee_modeled,
+                "fee_caveat": fee_caveat,
+                "usd_caveat": _USD_CAVEAT,
+            },
+        }
+        click.echo(json.dumps(envelope, sort_keys=True))
+        return
+
+    ui.success("Alpha transfer submitted.")
+    ui.info("Done.")
+
+
 @click.command("fund")
 @click.option("--wallet", "-w", help="Bittensor wallet name to fund from")
-@click.option("--amount", "-a", help="Amount of TAO to fund with")
+@click.option("--amount", "-a", help="Amount to fund with (TAO; USD when --alpha)")
+@click.option(
+    "--alpha", is_flag=True, default=False, help="Fund with free Subnet-51 alpha stake"
+)
+@click.option(
+    "--hotkey",
+    "-k",
+    default=None,
+    help="Origin hotkey the alpha is staked under — SS58 address or wallet hotkey "
+    "name (required with --alpha)",
+)
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Print machine-readable JSON"
+)
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
 @handle_errors
-def fund_command(wallet: Optional[str], amount: Optional[str], yes: bool):
-    """Fund your Lium account with TAO from a Bittensor wallet.
+def fund_command(
+    wallet: Optional[str],
+    amount: Optional[str],
+    alpha: bool,
+    hotkey: Optional[str],
+    json_output: bool,
+    yes: bool,
+):
+    """Fund your Lium account with TAO (or Subnet-51 alpha) from a Bittensor wallet.
 
     \b
     Examples:
       lium fund
       lium fund -w default -a 1.5
       lium fund -w mywal -a 0.5 -y
+      lium fund --alpha -k <hotkey-ss58> -a 25        # -a is USD when --alpha
+      lium fund --alpha -w default -k myhotkey -a 25  # -k may be a wallet hotkey name
+      lium fund --alpha -k <hotkey-ss58> -a 25 -y --json
     """
-    _legacy_tao_fund(wallet, amount, yes)
+    if alpha:
+        _alpha_fund(wallet, amount, hotkey, yes, json_output)
+    else:
+        _legacy_tao_fund(wallet, amount, yes)

--- a/lium/cli/fund/command.py
+++ b/lium/cli/fund/command.py
@@ -9,7 +9,7 @@ from rich.prompt import Prompt
 
 from lium.sdk import Lium, LiumError
 from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import handle_errors, _emit_json_error
 from lium.cli.settings import config
 from . import validation
 from .actions import (
@@ -128,10 +128,22 @@ def _alpha_fund(
     except ImportError:
         raise LiumError("Bittensor library not installed (pip install bittensor)")
 
+    # In non-interactive (--json) mode we never prompt, so every required arg must be
+    # supplied up front. Validate presence here — hotkey, then wallet, then amount —
+    # so the error deterministically names the first missing arg regardless of the
+    # resolution order below.
+    if json_output:
+        if not hotkey:
+            raise LiumError(
+                "hotkey is required for --alpha: pass --hotkey (SS58 or wallet hotkey name)"
+            )
+        if not wallet:
+            raise LiumError("wallet is required: pass --wallet")
+        if not amount:
+            raise LiumError("amount is required: pass --amount")
+
     # Resolve the wallet (coldkey).
     if not wallet:
-        if json_output:
-            raise LiumError("wallet is required: pass --wallet")
         default_wallet = config.get("funding.default_wallet", "default")
         wallet = Prompt.ask("Bittensor wallet name", default=default_wallet).strip()
 
@@ -139,10 +151,6 @@ def _alpha_fund(
     # wallet hotkey NAME (resolved against --wallet), mirroring btcli's stake-move.
     # --wallet is already resolved above, which a name lookup requires.
     if not hotkey:
-        if json_output:
-            raise LiumError(
-                "hotkey is required for --alpha: pass --hotkey (SS58 or wallet hotkey name)"
-            )
         hotkey = Prompt.ask(
             "Origin hotkey (SS58 or wallet hotkey name) the alpha is staked under"
         ).strip()
@@ -158,8 +166,6 @@ def _alpha_fund(
 
     # Resolve and validate the USD amount (fail fast, before any network call).
     if not amount:
-        if json_output:
-            raise LiumError("amount is required: pass --amount")
         amount = Prompt.ask("Enter USD amount to fund").strip()
     usd_amount, error = validation.validate_amount(amount)
     if error:
@@ -268,6 +274,13 @@ def _alpha_fund(
     }
     result = ExecuteAlphaTransferAction().execute(exec_ctx)
     if not result.ok:
+        # A signed transfer the chain rejected is a hard failure: exit non-zero so
+        # callers (and CI) detect it — unlike the pre-flight guard aborts above
+        # (insufficient/no/ambiguous stake), which print and exit 0.
+        if result.data.get("transfer_attempted"):
+            if json_output:
+                _emit_json_error("transfer_failed", result.error)  # exits non-zero
+            raise click.ClickException(result.error)
         raise LiumError(result.error)
 
     fee_modeled = result.data.get("fee_modeled", fee_modeled)

--- a/lium/cli/fund/validation.py
+++ b/lium/cli/fund/validation.py
@@ -1,16 +1,105 @@
 """Fund command validation."""
 
+import math
+
 
 def validate_amount(amount_str: str) -> tuple[float, str]:
-    """Validate TAO amount.
+    """Validate a fund amount (TAO or alpha).
 
     Returns:
         (amount, error_message) - amount is 0.0 if invalid
     """
     try:
         amount = float(amount_str)
-        if amount <= 0:
-            return 0.0, "Amount must be positive"
+        # Reject non-finite values (inf passes a bare > 0 check) on a money path.
+        if not math.isfinite(amount) or amount <= 0:
+            return 0.0, "Amount must be a positive finite number"
         return amount, ""
     except ValueError:
         return 0.0, "Invalid amount format"
+
+
+def validate_ss58(address: str, bt) -> tuple[str | None, str]:
+    """Validate an SS58 address (e.g. the funding/destination coldkey).
+
+    Delegates to bittensor's own checker rather than re-implementing SS58 decoding.
+
+    Returns:
+        (address, "") when valid, otherwise (None, error_message).
+    """
+    addr = (address or "").strip()
+    if not addr:
+        return None, "SS58 address is required"
+    if not bt.utils.is_valid_ss58_address(addr):
+        return None, f"invalid SS58 address: {addr}"
+    return addr, ""
+
+
+def resolve_hotkey(hotkey: str, wallet_name: str, bt) -> tuple[str | None, str]:
+    """Resolve an origin hotkey given as either an SS58 address or a hotkey NAME.
+
+    Mirrors btcli's ``stake move`` origin-hotkey handling: if the string is a valid
+    SS58 it is used as-is; otherwise it is treated as a hotkey *name* under
+    ``wallet_name`` and resolved to that hotkey's public SS58 (``hotkeypub`` first,
+    falling back to ``hotkey`` for pre-3.1.1 wallets — same as btcli's
+    ``get_hotkey_pub_ss58``). The hotkey SS58 is public, so no password is needed;
+    the alpha transfer signs with the coldkey and uses the hotkey only as an
+    identifier.
+
+    Returns:
+        (ss58, "") when resolved, otherwise (None, error_message).
+    """
+    raw = (hotkey or "").strip()
+    if not raw:
+        return None, "hotkey is required for --alpha (SS58 or wallet hotkey name)"
+    if bt.utils.is_valid_ss58_address(raw):
+        return raw, ""
+
+    # Not an SS58: treat ``raw`` as a hotkey name under the coldkey wallet.
+    # Construct the Wallet outside the swallow-all below — constructing is lazy
+    # (touches no disk), so a missing keyfile only surfaces on the ss58 read. This
+    # keeps API/programming errors (e.g. a renamed bittensor symbol) visible instead
+    # of being mislabelled "hotkey doesn't exist".
+    w = wallet_class(bt)(name=wallet_name, hotkey=raw)
+    ss58 = None
+    for attr in ("hotkeypub", "hotkey"):
+        try:
+            candidate = getattr(w, attr).ss58_address
+        except Exception:
+            # Missing/unreadable keyfile for this attr; try the next, then fall
+            # through to the friendly not-found message below.
+            continue
+        if candidate:
+            ss58 = candidate
+            break
+
+    if not ss58 or not bt.utils.is_valid_ss58_address(ss58):
+        return None, (
+            f"hotkey '{raw}' is neither a valid SS58 address nor a hotkey in "
+            f"wallet '{wallet_name}'"
+        )
+    return ss58, ""
+
+
+def wallet_class(bt):
+    """Return the bittensor Wallet class across library versions.
+
+    bittensor >=8 exposes ``bt.Wallet`` (the lowercase ``bt.wallet`` factory of older
+    releases was removed); fall back to ``bt.wallet`` for those older versions.
+    """
+    cls = getattr(bt, "Wallet", None) or getattr(bt, "wallet", None)
+    if cls is None:
+        raise AttributeError("bittensor exposes neither 'Wallet' nor 'wallet'")
+    return cls
+
+
+def subtensor_class(bt):
+    """Return the bittensor Subtensor class across library versions.
+
+    bittensor >=8 exposes ``bt.Subtensor`` (the lowercase ``bt.subtensor`` factory of
+    older releases was removed); fall back to ``bt.subtensor`` for those versions.
+    """
+    cls = getattr(bt, "Subtensor", None) or getattr(bt, "subtensor", None)
+    if cls is None:
+        raise AttributeError("bittensor exposes neither 'Subtensor' nor 'subtensor'")
+    return cls

--- a/lium/cli/fund/validation.py
+++ b/lium/cli/fund/validation.py
@@ -75,8 +75,8 @@ def resolve_hotkey(hotkey: str, wallet_name: str, bt) -> tuple[str | None, str]:
 
     if not ss58 or not bt.utils.is_valid_ss58_address(ss58):
         return None, (
-            f"hotkey '{raw}' is neither a valid SS58 address nor a hotkey in "
-            f"wallet '{wallet_name}'"
+            f"hotkey '{raw}' in wallet '{wallet_name}' is neither a valid SS58 "
+            f"address nor a known hotkey name"
         )
     return ss58, ""
 

--- a/lium/sdk/__init__.py
+++ b/lium/sdk/__init__.py
@@ -1,6 +1,6 @@
 """Public SDK exports."""
 
-from .client import Lium
+from .client import AlphaQuote, Lium
 from .config import Config
 from .decorators import machine
 from .exceptions import (
@@ -23,6 +23,7 @@ from .models import (
 
 __all__ = [
     "Lium",
+    "AlphaQuote",
     "Config",
     "ExecutorInfo",
     "PodInfo",

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -9,6 +9,8 @@ import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any, Dict, Generator, List, Optional, Union
 from urllib.parse import parse_qs, urlparse
 
@@ -38,6 +40,26 @@ from .ssh_key_cache import fingerprint, load_cache, save_cache
 from .utils import expand_gpu_shorthand, extract_gpu_type, generate_huid, with_retry
 
 load_dotenv()
+
+# Public API key for the pay API (pay-tao-api-v2). Single source of truth so the
+# literal is not re-typed across every pay-API call site.
+_PAY_API_KEY = "6RhXQ788J9BdnqeLua8z7ZSkXBDahclxhwjMB17qW1M"
+
+
+@dataclass(frozen=True)
+class AlphaQuote:
+    """USD -> alpha quote from ``GET /balance/convert/alpha``.
+
+    ``netuid`` is the subnet the alpha must be transferred on (the same subnet the
+    pay-tao-api-v2 listener credits), so it — not a hardcoded constant — drives the
+    on-chain ``transfer_stake``.
+    """
+
+    usd: Decimal           # echoes the API's ``original``
+    alpha_amount: Decimal  # the API's ``converted`` (raw Decimal; floored by the caller)
+    rate: Decimal          # the API's ``rate`` = USD per alpha
+    netuid: int            # the API's ``netuid`` — drives the transfer
+
 
 # Main SDK Class
 class Lium:
@@ -1245,7 +1267,7 @@ class Lium:
             Raw wallet records returned by the pay API.
         """
         user = self._request("GET", "/users/me").json()
-        pay_headers = {"X-API-KEY": "6RhXQ788J9BdnqeLua8z7ZSkXBDahclxhwjMB17qW1M"}
+        pay_headers = {"X-API-KEY": _PAY_API_KEY}
         resp = self._request(
             "GET",
             f"/wallet/available-wallets/{user['stripe_customer_id']}",
@@ -1254,28 +1276,55 @@ class Lium:
         )
         return resp.json()
 
-    def add_wallet(self, bt_wallet: Any) -> None:
+    def _create_transfer_app_credentials(self) -> tuple[str, str]:
+        """Read ``(app_id, customer_id)`` from the ``/tao/create-transfer`` redirect.
+
+        This is the single parse both :meth:`add_wallet` and :meth:`_discover_app_id`
+        share, so the alpha flow never issues more than one ``/tao/create-transfer``
+        round-trip.
+
+        Note the deliberate HTTP shape: this call uses the DEFAULT ``base_url`` (the
+        main Lium API) and NO pay ``X-API-KEY`` header — unlike the pay-API calls
+        (:meth:`wallets`, :meth:`convert_alpha`, :meth:`company_wallet`). Do not
+        "harmonize" it onto ``base_pay_url`` / the pay key; that returns 401/404.
+        """
+        create_transfer_response = self._request(
+            "POST", "/tao/create-transfer", json={"amount": 10}
+        )
+        redirect_url = create_transfer_response.json()["url"]
+        params = parse_qs(urlparse(redirect_url).query)
+        return params["app_id"][0], params["customer_id"][0]
+
+    def _discover_app_id(self, bt_wallet: Any = None) -> str:
+        """Resolve the pay-app id without registering a wallet.
+
+        Reuses :meth:`_create_transfer_app_credentials`, so it works identically
+        whether or not the coldkey is already registered. ``bt_wallet`` is accepted
+        for call-site symmetry but unused (the create-transfer parse needs no wallet).
+        """
+        app_id, _ = self._create_transfer_app_credentials()
+        return app_id
+
+    def add_wallet(self, bt_wallet: Any) -> tuple[str, str]:
         """Link a Bittensor wallet with the user account.
 
         Args:
             bt_wallet: Wallet object exposing ``coldkey``/``coldkeypub`` for signing.
 
+        Returns:
+            ``(app_id, customer_id)`` parsed from the ``/tao/create-transfer``
+            redirect — surfaced so the alpha funding flow can reuse the same single
+            round-trip for company-wallet lookup instead of issuing a second POST.
+
         Raises:
             LiumError: If verification or wallet polling fails.
         """
-        pay_headers = {"X-API-KEY": "6RhXQ788J9BdnqeLua8z7ZSkXBDahclxhwjMB17qW1M"}
+        pay_headers = {"X-API-KEY": _PAY_API_KEY}
         access_key = self._request(
             "GET", "/token/generate", base_url=self.config.base_pay_url, headers=pay_headers
         ).json()["access_key"]
         sig = bt_wallet.coldkey.sign(access_key.encode()).hex()
-        create_transfer_response = self._request("POST", "/tao/create-transfer", json={"amount": 10})
-        redirect_url = create_transfer_response.json()["url"]
-        
-        # Parse URL parameters elegantly
-        parsed_url = urlparse(redirect_url)
-        params = parse_qs(parsed_url.query)
-        app_id = params["app_id"][0]
-        stripe_customer_id = params["customer_id"][0]
+        app_id, stripe_customer_id = self._create_transfer_app_credentials()
 
         verify_response = self._request(
             "POST",
@@ -1296,9 +1345,49 @@ class Lium:
         for i in range(5):
             wallets = [w.get('wallet_hash', '') for w in self.wallets()]
             if bt_wallet.coldkeypub.ss58_address in wallets:
-                return
+                return app_id, stripe_customer_id
             time.sleep(2)
         raise LiumError("Failed to add wallet. Wallet not found after 5 attempts.")
+
+    def convert_alpha(self, usd: Any) -> AlphaQuote:
+        """Quote ``usd`` (USD) -> alpha via ``GET /balance/convert/alpha``.
+
+        The response carries both the alpha amount to transfer (``converted``) and
+        the subnet ``netuid`` the transfer must happen on. Hard-fails (no fallback)
+        on a pay-API error: ``_request`` maps 503 -> ``LiumServerError`` (a
+        ``LiumError``), so a down subtensor / unavailable alpha price aborts the
+        fund before any on-chain call.
+        """
+        pay_headers = {"X-API-KEY": _PAY_API_KEY}
+        resp = self._request(
+            "GET",
+            "/balance/convert/alpha",
+            base_url=self.config.base_pay_url,
+            headers=pay_headers,
+            params={"amount": str(usd)},
+        ).json()
+        return AlphaQuote(
+            usd=Decimal(str(resp["original"])),
+            alpha_amount=Decimal(str(resp["converted"])),
+            rate=Decimal(str(resp["rate"])),
+            netuid=int(resp["netuid"]),
+        )
+
+    def company_wallet(self, app_id: str) -> str:
+        """Resolve the Lium destination coldkey via ``GET /wallet/company/?app_id=``.
+
+        Returns the company ``wallet_hash`` (the SS58 the pay-tao-api-v2 listener
+        credits). Hard-fails (no fallback): a 404 (app has no wallet) maps to
+        ``LiumNotFoundError`` (a ``LiumError``), aborting before any on-chain call.
+        """
+        resp = self._request(
+            "GET",
+            "/wallet/company/",
+            base_url=self.config.base_pay_url,
+            headers={"X-API-KEY": _PAY_API_KEY},
+            params={"app_id": app_id},
+        ).json()
+        return resp["wallet_hash"]
 
     def backup_create(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.21"
+version = "0.0.22"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/test/test_fund_cli.py
+++ b/test/test_fund_cli.py
@@ -171,7 +171,13 @@ class FakeStakeInfo:
 
 
 def _stake(hotkey=HK, netuid=51, stake=5.0, locked=0.0):
-    return FakeStakeInfo(hotkey, netuid, FakeBalance(stake, 51), FakeBalance(locked, 51))
+    # A real StakeInfo's stake/locked Balances live on the stake's OWN subnet, so the
+    # FakeBalance unit must track ``netuid`` (not a hardcoded 51) — otherwise a
+    # non-51 netuid would trip the cross-currency guard against the (netuid-correct)
+    # transfer amount.
+    return FakeStakeInfo(
+        hotkey, netuid, FakeBalance(stake, netuid), FakeBalance(locked, netuid)
+    )
 
 
 class FakeSubtensor:

--- a/test/test_fund_cli.py
+++ b/test/test_fund_cli.py
@@ -8,7 +8,9 @@ removed.
 import json
 import sys
 import types
+from decimal import Decimal
 
+import pytest
 from click.testing import CliRunner
 
 import lium.sdk as sdk
@@ -16,7 +18,8 @@ from lium.cli.actions import ActionResult
 from lium.cli import balance as balance_module
 from lium.cli.cli import cli
 from lium.cli.fund import command as fund_module
-from lium.sdk import Lium
+from lium.sdk import AlphaQuote, Config, Lium
+from lium.sdk.exceptions import LiumNotFoundError, LiumServerError
 
 
 def test_fund_help_documents_tao_flow():
@@ -94,3 +97,911 @@ def test_sdk_no_longer_exposes_nowpayments():
     assert not hasattr(sdk, "NowPaymentsInvoice")
     assert not hasattr(Lium, "nowpayments_currencies")
     assert not hasattr(Lium, "create_nowpayments_invoice")
+
+
+# ---------------------------------------------------------------------------
+# Alpha-token top-up (`lium fund --alpha`)
+# ---------------------------------------------------------------------------
+
+from lium.cli.fund import actions as fund_actions  # noqa: E402
+
+HK = "5HotKeyExampleSS58AddressForTestingAAAAAAAAAAAAAAAAA"
+
+# Distinct from the TAO-path constant so tests prove the alpha destination is
+# sourced from the pay API (/wallet/company/) and not the hardcoded constant.
+FAKE_WALLET_HASH = "5CompanyWalletHashFromPayApiBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+
+class FakeBalance:
+    """Minimal alpha-denominated Balance: supports from_tao/set_unit/+/-/</.tao."""
+
+    def __init__(self, amount, netuid=0):
+        self.amount = float(amount)
+        self.netuid = netuid
+
+    @classmethod
+    def from_tao(cls, amount, netuid=0):
+        return cls(amount, netuid)
+
+    @classmethod
+    def from_rao(cls, rao, netuid=0):
+        # 1 alpha = 1e9 rao (same scale as TAO).
+        return cls(float(rao) / 1e9, netuid)
+
+    def set_unit(self, netuid):
+        self.netuid = netuid
+        return self
+
+    @property
+    def tao(self):
+        return self.amount
+
+    def _same_unit(self, other):
+        # Mirror real bittensor Balance: arithmetic across different netuids (e.g.
+        # alpha vs TAO) is forbidden. Guards against re-introducing amount+fee bugs.
+        if self.netuid != other.netuid:
+            raise TypeError(
+                "Cannot perform any operations between balances of different "
+                f"currencies: netuid {self.netuid} vs {other.netuid}"
+            )
+
+    def __add__(self, other):
+        self._same_unit(other)
+        return FakeBalance(self.amount + other.amount, self.netuid)
+
+    def __sub__(self, other):
+        self._same_unit(other)
+        return FakeBalance(self.amount - other.amount, self.netuid)
+
+    def __lt__(self, other):
+        self._same_unit(other)
+        return self.amount < other.amount
+
+    def __repr__(self):
+        return f"{self.amount}alpha(netuid={self.netuid})"
+
+
+class FakeStakeInfo:
+    def __init__(self, hotkey_ss58, netuid, stake, locked, coldkey_ss58="coldkey"):
+        self.hotkey_ss58 = hotkey_ss58
+        self.coldkey_ss58 = coldkey_ss58
+        self.netuid = netuid
+        self.stake = stake
+        self.locked = locked
+
+
+def _stake(hotkey=HK, netuid=51, stake=5.0, locked=0.0):
+    return FakeStakeInfo(hotkey, netuid, FakeBalance(stake, 51), FakeBalance(locked, 51))
+
+
+class FakeSubtensor:
+    """Records transfer_stake; serves stake-info reads (per-call, last repeats)."""
+
+    def __init__(self, stake_reads, fee=0.01, fee_raises=False, transfer_result=True):
+        # stake_reads: list of "reads", each a list[FakeStakeInfo].
+        self.stake_reads = stake_reads
+        self._call = 0
+        # Real stake-movement fee is TAO-denominated (netuid 0), distinct from the
+        # alpha amount (netuid 51) — so combining them must raise, never silently add.
+        self.fee = None if fee is None else FakeBalance(fee, 0)
+        self.fee_raises = fee_raises
+        self.transfer_result = transfer_result
+        self.transfer_called = False
+        self.transfer_kwargs = None
+
+    def get_stake_info_for_coldkey(self, coldkey, block=None):
+        idx = min(self._call, len(self.stake_reads) - 1)
+        self._call += 1
+        return self.stake_reads[idx]
+
+    def get_stake_movement_fee(self, **kwargs):
+        if self.fee_raises:
+            raise RuntimeError("fee API unavailable")
+        return self.fee
+
+    def transfer_stake(self, **kwargs):
+        self.transfer_called = True
+        self.transfer_kwargs = kwargs
+        return self.transfer_result
+
+
+class _RaisingKey:
+    """A hotkey whose ``.ss58_address`` raises — simulates a missing keyfile."""
+
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def ss58_address(self):
+        raise FileNotFoundError(f"no hotkey '{self._name}'")
+
+
+def _make_bt(subtensor, valid_ss58=True, hotkey_names=None):
+    bt = types.SimpleNamespace()
+    bt.Balance = FakeBalance
+    # Real bittensor >=8 exposes ``bt.Subtensor``; mirror that (lowercase alias kept
+    # so the version-safe ``subtensor_class`` lookup is exercised either way).
+    bt.Subtensor = lambda: subtensor
+    bt.subtensor = lambda: subtensor
+    # hotkey_names maps a hotkey NAME -> its public ss58 (for the name-resolution
+    # path). bt.wallet accepts an optional hotkey kwarg, mirroring real bittensor:
+    # a known name yields readable hotkey/hotkeypub ss58; an unknown name raises on
+    # attribute access (as a missing keyfile would).
+    names = hotkey_names or {}
+
+    def _wallet(name=None, hotkey=None, path=None):
+        ns = types.SimpleNamespace(
+            coldkeypub=types.SimpleNamespace(ss58_address="coldkey")
+        )
+        if hotkey is not None:
+            ss58 = names.get(hotkey)
+            if ss58 is None:
+                ns.hotkey = _RaisingKey(hotkey)
+                ns.hotkeypub = _RaisingKey(hotkey)
+            else:
+                ns.hotkey = types.SimpleNamespace(ss58_address=ss58)
+                ns.hotkeypub = types.SimpleNamespace(ss58_address=ss58)
+        return ns
+
+    # Real bittensor >=8 exposes the class as ``bt.Wallet``; mirror that so the
+    # tests exercise the version-safe ``wallet_class`` lookup. (``bt.wallet`` kept
+    # as a lowercase alias for robustness.)
+    bt.Wallet = _wallet
+    bt.wallet = _wallet
+    # valid_ss58 may be a bool (applies to every address) or a callable for
+    # per-address control (e.g. accept the hotkey but reject a bad funding hash).
+    is_valid = valid_ss58 if callable(valid_ss58) else (lambda a: valid_ss58)
+    bt.utils = types.SimpleNamespace(is_valid_ss58_address=is_valid)
+    return bt
+
+
+def _patch_common(
+    monkeypatch,
+    subtensor,
+    valid_ss58=True,
+    *,
+    wallet_hash=FAKE_WALLET_HASH,
+    convert_netuids=(51,),
+    alpha_per_usd=1.0,
+    rate=1.0,
+    alpha_amount_override=None,
+    convert_error=None,
+    company_error=None,
+    hotkey_names=None,
+):
+    """Patch bittensor + the SDK/registration seams; keep the real alpha actions.
+
+    The fake ``Lium`` mirrors the new pay-API surface:
+      - ``convert_alpha(usd)`` -> ``AlphaQuote`` (USD->alpha; netuid served per call,
+        last value repeating, so Phase-B drift can be exercised).
+      - ``company_wallet(app_id)`` -> the funding ``wallet_hash``.
+      - ``_discover_app_id`` -> a fixed app id.
+    """
+    monkeypatch.setitem(
+        sys.modules, "bittensor", _make_bt(subtensor, valid_ss58, hotkey_names)
+    )
+    netuids = list(convert_netuids)
+
+    class FakeLium:
+        def __init__(self):
+            self._convert_calls = 0
+
+        def _discover_app_id(self, bt_wallet=None):
+            return "app-123"
+
+        def company_wallet(self, app_id):
+            if company_error is not None:
+                raise company_error
+            return wallet_hash
+
+        def convert_alpha(self, usd):
+            if convert_error is not None:
+                raise convert_error
+            idx = self._convert_calls
+            self._convert_calls += 1
+            usd_d = Decimal(str(usd))
+            if alpha_amount_override is None:
+                alpha = usd_d * Decimal(str(alpha_per_usd))
+            elif isinstance(alpha_amount_override, (list, tuple)):
+                # Per-call alpha (last repeats) so Phase-B amount-pinning is testable.
+                a = alpha_amount_override[min(idx, len(alpha_amount_override) - 1)]
+                alpha = Decimal(str(a))
+            else:
+                alpha = Decimal(str(alpha_amount_override))
+            return AlphaQuote(
+                usd=usd_d,
+                alpha_amount=alpha,
+                rate=Decimal(str(rate)),
+                netuid=netuids[min(idx, len(netuids) - 1)],
+            )
+
+    class FakeReg:
+        def execute(self, ctx):
+            return ActionResult(ok=True, data={"registered": True})
+
+    monkeypatch.setattr(fund_module, "Lium", FakeLium)
+    monkeypatch.setattr(fund_module, "CheckWalletRegistrationAction", FakeReg)
+
+
+def test_alpha_happy_path(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Done." in result.output
+    assert sub.transfer_called
+    kw = sub.transfer_kwargs
+    # Destination comes from /wallet/company/ (the fetched wallet_hash), NOT the
+    # TAO-path constant.
+    assert kw["destination_coldkey_ss58"] == FAKE_WALLET_HASH
+    assert kw["hotkey_ss58"] == HK
+    assert kw["origin_netuid"] == 51 and kw["destination_netuid"] == 51
+    assert kw["amount"].tao == 2.0 and kw["amount"].netuid == 51
+
+
+def test_alpha_insufficient_free_alpha_aborts(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=1.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    # Human-mode aborts print the error and exit 0 (same as the TAO path);
+    # the binding guarantee is that no transfer was signed.
+    assert "Insufficient free alpha" in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_fee_not_added_to_alpha_gate(monkeypatch):
+    # The TAO-denominated movement fee must NOT be folded into the alpha gate:
+    # free == requested alpha still transfers even with a non-zero fee present.
+    sub = FakeSubtensor([[_stake(stake=2.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sub.transfer_called
+
+
+def test_alpha_fee_unavailable_still_transfers(monkeypatch):
+    # Fee is advisory: when the node can't report it we proceed on free >= amount
+    # (no hard abort, no buffer). free=5 >= amount=2 -> transfer goes through.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=None, fee_raises=True)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sub.transfer_called
+
+
+def test_alpha_fee_unavailable_still_transfers_json(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=None, fee_raises=True)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y", "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sub.transfer_called
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["ok"] is True
+    assert payload["tx"]["fee_modeled"] is False  # fee couldn't be modeled
+
+
+def test_alpha_fee_unavailable_still_gates_on_free(monkeypatch):
+    # Even without a fee, the bare free >= amount gate still protects us.
+    sub = FakeSubtensor([[_stake(stake=1.0)]], fee=None, fee_raises=True)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "Insufficient free alpha" in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_fee_buffer_option_removed(monkeypatch):
+    # --fee-buffer was deleted; passing it must be a usage error, not a silent no-op.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli,
+        ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "--fee-buffer", "0.1", "-y"],
+    )
+
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower()
+    assert not sub.transfer_called
+
+
+def test_alpha_transfer_failure_surfaces_message(monkeypatch):
+    # bittensor >=8 returns an ExtrinsicResponse(.success/.message) instead of a
+    # bool; a failed transfer must surface its message, not be reported as success.
+    sub = FakeSubtensor(
+        [[_stake(stake=5.0)]],
+        fee=0.01,
+        transfer_result=types.SimpleNamespace(success=False, message="on-chain rejected"),
+    )
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code != 0
+    assert "on-chain rejected" in result.output
+    assert sub.transfer_called  # we did attempt it, but it failed
+
+
+def test_alpha_shrink_between_reads(monkeypatch):
+    # Phase A read shows ample; Phase B re-read shows shrunk -> abort, no transfer.
+    sub = FakeSubtensor([[_stake(stake=5.0)], [_stake(stake=1.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "Insufficient free alpha" in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_multiple_rows_aborts(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0), _stake(stake=4.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "multiple stake entries" in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_no_stakeinfo_aborts(monkeypatch):
+    sub = FakeSubtensor([[]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "No free alpha" in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_json_no_yes_requires_confirm(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    called = {"confirm": False}
+    monkeypatch.setattr(fund_module.ui, "confirm", lambda *a, **k: called.__setitem__("confirm", True) or True)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "--json"]
+    )
+
+    assert result.exit_code != 0
+    assert "confirmation required" in result.output
+    assert not called["confirm"]
+    assert not sub.transfer_called
+
+
+def test_alpha_json_missing_hotkey(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(cli, ["fund", "--alpha", "-a", "2", "-y", "--json"])
+
+    assert result.exit_code != 0
+    assert "hotkey" in result.output.lower()
+    assert not sub.transfer_called
+
+
+def test_alpha_missing_hotkey_interactive_prompts(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+    monkeypatch.setattr(fund_module.Prompt, "ask", staticmethod(lambda *a, **k: HK))
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sub.transfer_called
+
+
+def test_alpha_invalid_hotkey_neither_ss58_nor_name(monkeypatch):
+    # "bogus" is neither a valid SS58 nor an existing hotkey name in --wallet, so
+    # the resolver hard-fails with a name-aware error before any chain call.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, valid_ss58=False)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", "bogus", "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "neither a valid SS58" in result.output
+    assert "wallet 'default'" in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_hotkey_by_name_resolves(monkeypatch):
+    # -k is a wallet hotkey NAME (not an ss58); it resolves to the staked hotkey's
+    # public ss58 under --wallet, then the transfer proceeds identically.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(
+        monkeypatch,
+        sub,
+        valid_ss58=lambda a: a != "myhot",  # the name is not a valid ss58; HK/dest are
+        hotkey_names={"myhot": HK},
+    )
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", "myhot", "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sub.transfer_called
+    # The transfer (and stake lookup) use the RESOLVED ss58, never the raw name.
+    assert sub.transfer_kwargs["hotkey_ss58"] == HK
+
+
+def test_alpha_hotkey_by_name_json_echoes_resolved_ss58(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(
+        monkeypatch,
+        sub,
+        valid_ss58=lambda a: a != "myhot",
+        hotkey_names={"myhot": HK},
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["fund", "--alpha", "-k", "myhot", "-w", "default", "-a", "2", "-y", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["tx"]["hotkey"] == HK  # resolved ss58, not "myhot"
+
+
+def test_alpha_hotkey_name_not_found(monkeypatch):
+    # A name with no matching keyfile under --wallet -> name-aware hard error,
+    # no chain/API call.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(
+        monkeypatch, sub, valid_ss58=lambda a: a != "ghost", hotkey_names={}
+    )
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", "ghost", "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "neither a valid SS58" in result.output
+    assert not sub.transfer_called
+
+
+def test_fund_alpha_hotkey_help_mentions_name():
+    result = CliRunner().invoke(cli, ["fund", "--help"])
+
+    assert result.exit_code == 0
+    # The --hotkey help must advertise that a wallet hotkey name is accepted too.
+    assert "wallet hotkey name" in result.output
+
+
+def test_alpha_displays_free_before_confirm(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+    # Decline at confirm so we abort right after the display.
+    monkeypatch.setattr(fund_module.ui, "confirm", lambda *a, **k: False)
+
+    result = CliRunner().invoke(cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2"])
+
+    assert "Free alpha" in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_json_success_envelope(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y", "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["ok"] is True
+    tx = payload["tx"]
+    assert tx["coldkey"] == "coldkey"
+    assert tx["hotkey"] == HK
+    assert tx["netuid"] == 51
+    assert tx["usd"] == 2.0
+    assert tx["amount_alpha"] == 2.0
+    assert tx["rate"] == 1.0
+    assert tx["dest_coldkey"] == FAKE_WALLET_HASH
+    assert tx["fee_alpha"] == 0.01
+    assert tx["fee_modeled"] is True
+    assert tx["fee_caveat"] is None
+    assert "on-chain inclusion time" in tx["usd_caveat"]
+    assert sub.transfer_called
+
+
+def test_alpha_locked_alpha_excluded_from_free(monkeypatch):
+    # free = stake - locked. With stake=5, locked=3, free=2 < requested 4 -> abort.
+    sub = FakeSubtensor([[_stake(stake=5.0, locked=3.0)]], fee=0.0)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "4", "-y"]
+    )
+
+    assert "Insufficient free alpha" in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_amount_rejects_non_finite(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "inf", "-y"]
+    )
+
+    assert "positive finite" in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_decoupled_from_funding_constants():
+    # Replaces test_alpha_dest_equals_tao_dest: the alpha path no longer derives its
+    # destination from the hardcoded constant (it comes from /wallet/company/), and
+    # the hardcoded netuid constant is deleted entirely. The TAO path still uses the
+    # shared funding-address constant.
+    assert not hasattr(fund_actions.ExecuteAlphaTransferAction, "LIUM_FUNDING_ADDRESS")
+    assert not hasattr(fund_actions, "NETUID")
+    assert (
+        fund_actions.ExecuteTransferAction.LIUM_FUNDING_ADDRESS
+        == fund_actions.LIUM_FUNDING_ADDRESS
+    )
+
+
+def test_alpha_messaging_says_alpha_not_tao(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+    seen = {}
+    monkeypatch.setattr(
+        fund_module.ui, "confirm", lambda msg, **k: seen.__setitem__("msg", msg) or False
+    )
+
+    CliRunner().invoke(cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2"])
+
+    assert "alpha (netuid 51)" in seen["msg"]
+    assert "TAO" not in seen["msg"]
+
+
+def test_alpha_usd_convert_called(monkeypatch):
+    # -a is USD; convert maps USD->alpha (0.5 alpha/USD here) and the floored
+    # `converted` becomes the transferred amount.
+    sub = FakeSubtensor([[_stake(stake=10.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, alpha_per_usd=0.5)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "10", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sub.transfer_called
+    assert sub.transfer_kwargs["amount"].tao == 5.0  # 10 USD * 0.5 alpha/USD
+
+
+def test_alpha_netuid_from_api(monkeypatch):
+    # The transfer uses the API-resolved netuid (38 here), not a hardcoded 51.
+    sub = FakeSubtensor([[_stake(netuid=38, stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, convert_netuids=(38,))
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    kw = sub.transfer_kwargs
+    assert kw["origin_netuid"] == 38 and kw["destination_netuid"] == 38
+    assert kw["amount"].netuid == 38
+
+
+def test_alpha_netuid_mismatch_aborts(monkeypatch):
+    # Phase A resolves netuid 51; the Phase-B re-fetch returns 38 -> abort, no transfer.
+    sub = FakeSubtensor([[_stake(netuid=51, stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, convert_netuids=(51, 38))
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "netuid changed" in result.output.lower()
+    assert not sub.transfer_called
+
+
+def test_alpha_dest_from_company_wallet(monkeypatch):
+    custom = "5DistinctCompanyWalletForThisTestCCCCCCCCCCCCCCCCCCC"
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, wallet_hash=custom)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sub.transfer_kwargs["destination_coldkey_ss58"] == custom
+
+
+def test_alpha_hard_fail_on_503(monkeypatch):
+    # convert_alpha 503 -> abort before any transfer; JSON renders the error envelope.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(
+        monkeypatch, sub, convert_error=LiumServerError("Server error: 503")
+    )
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y", "--json"]
+    )
+
+    assert result.exit_code != 0
+    assert '"ok": false' in result.output
+    assert not sub.transfer_called
+
+
+def test_alpha_hard_fail_on_404(monkeypatch):
+    # company_wallet 404 -> abort before any chain call.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(
+        monkeypatch, sub, company_error=LiumNotFoundError("Resource not found")
+    )
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "not found" in result.output.lower()
+    assert not sub.transfer_called
+
+
+def test_alpha_rao_floor_never_over_transfer(monkeypatch):
+    # A sub-rao quote (2 + 0.9 rao) floors down to exactly 2.0 alpha; we never
+    # transfer more than the floor, keeping the free+fee gate exact.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, alpha_amount_override="2.0000000009")
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sub.transfer_kwargs["amount"].tao == 2.0
+
+
+def test_alpha_usd_caveat_in_prompt_output(monkeypatch):
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "on-chain inclusion time" in result.output
+
+
+def test_alpha_shows_destination_before_confirm(monkeypatch):
+    # The runtime-resolved destination coldkey must be visible before signing.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, wallet_hash=FAKE_WALLET_HASH)
+    seen = {}
+    monkeypatch.setattr(
+        fund_module.ui, "confirm", lambda msg, **k: seen.__setitem__("msg", msg) or False
+    )
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2"]
+    )
+
+    assert FAKE_WALLET_HASH in result.output  # shown in the display block
+    assert FAKE_WALLET_HASH in seen["msg"]    # and in the confirm prompt
+    assert not sub.transfer_called
+
+
+def test_alpha_invalid_funding_address_aborts(monkeypatch):
+    # The hotkey is a valid SS58 but the API returns a bad funding hash -> abort.
+    bad = "not-an-ss58"
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(
+        monkeypatch, sub, valid_ss58=lambda a: a != bad, wallet_hash=bad
+    )
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "invalid funding address" in result.output.lower()
+    assert not sub.transfer_called
+
+
+def test_alpha_self_send_funding_address_aborts(monkeypatch):
+    # The API returns the caller's own coldkey as the destination -> abort.
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, wallet_hash="coldkey")  # == loaded coldkey address
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert "own coldkey" in result.output.lower()
+    assert not sub.transfer_called
+
+
+def test_alpha_phase_b_amount_pinned_to_confirmed(monkeypatch):
+    # The Phase-B re-fetch returns a LARGER alpha (3.0) than Phase A (2.0); the
+    # transferred amount must stay the Phase-A floored value (2.0), never the
+    # re-fetched value.
+    sub = FakeSubtensor([[_stake(stake=10.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, alpha_amount_override=["2.0", "3.0"])
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sub.transfer_kwargs["amount"].tao == 2.0
+
+
+# ---------------------------------------------------------------------------
+# SDK-level tests for the new pay-API methods
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _sdk_lium():
+    return Lium(config=Config(api_key="test"))
+
+
+def test_sdk_convert_alpha_parses_quote(monkeypatch):
+    lium = _sdk_lium()
+    captured = {}
+
+    def fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["kwargs"] = kwargs
+        return _Resp({"original": "10", "converted": "12.5", "rate": "0.8", "netuid": 38})
+
+    monkeypatch.setattr(lium, "_request", fake_request)
+    quote = lium.convert_alpha("10")
+
+    assert isinstance(quote, AlphaQuote)
+    assert quote.netuid == 38
+    assert quote.alpha_amount == Decimal("12.5")
+    assert quote.rate == Decimal("0.8")
+    assert captured["method"] == "GET"
+    assert captured["endpoint"] == "/balance/convert/alpha"
+    assert captured["kwargs"]["params"] == {"amount": "10"}
+    assert captured["kwargs"]["base_url"] == lium.config.base_pay_url
+
+
+def test_sdk_convert_alpha_503_propagates(monkeypatch):
+    lium = _sdk_lium()
+
+    def fake_request(*a, **k):
+        raise LiumServerError("Server error: 503")
+
+    monkeypatch.setattr(lium, "_request", fake_request)
+    with pytest.raises(LiumServerError):
+        lium.convert_alpha("10")
+
+
+def test_sdk_company_wallet_returns_hash(monkeypatch):
+    lium = _sdk_lium()
+    captured = {}
+
+    def fake_request(method, endpoint, **kwargs):
+        captured["endpoint"] = endpoint
+        captured["kwargs"] = kwargs
+        return _Resp({"wallet_hash": "5Funding", "id": 1, "created": "now"})
+
+    monkeypatch.setattr(lium, "_request", fake_request)
+    assert lium.company_wallet("app-1") == "5Funding"
+    assert captured["endpoint"] == "/wallet/company/"
+    assert captured["kwargs"]["params"] == {"app_id": "app-1"}
+    assert captured["kwargs"]["base_url"] == lium.config.base_pay_url
+
+
+def test_sdk_company_wallet_404_propagates(monkeypatch):
+    lium = _sdk_lium()
+
+    def fake_request(*a, **k):
+        raise LiumNotFoundError("Resource not found")
+
+    monkeypatch.setattr(lium, "_request", fake_request)
+    with pytest.raises(LiumNotFoundError):
+        lium.company_wallet("app-1")
+
+
+def test_sdk_discover_app_id_single_create_transfer(monkeypatch):
+    lium = _sdk_lium()
+    calls = []
+
+    def fake_request(method, endpoint, **kwargs):
+        calls.append(endpoint)
+        assert endpoint == "/tao/create-transfer"
+        # Must use the DEFAULT base_url + no pay header (unlike the pay-API calls).
+        assert "base_url" not in kwargs
+        assert "headers" not in kwargs
+        return _Resp({"url": "https://pay/redirect?app_id=APP&customer_id=CUS"})
+
+    monkeypatch.setattr(lium, "_request", fake_request)
+    assert lium._discover_app_id() == "APP"
+    assert calls.count("/tao/create-transfer") == 1
+
+
+def test_sdk_add_wallet_returns_app_id_single_create_transfer(monkeypatch):
+    lium = _sdk_lium()
+    calls = []
+
+    def fake_request(method, endpoint, **kwargs):
+        calls.append(endpoint)
+        if endpoint == "/token/generate":
+            return _Resp({"access_key": "ak"})
+        if endpoint == "/tao/create-transfer":
+            return _Resp({"url": "https://pay/redirect?app_id=APP&customer_id=CUS"})
+        if endpoint == "/token/verify":
+            return _Resp({"status": "ok"})
+        if endpoint == "/users/me":
+            return _Resp({"stripe_customer_id": "CUS"})
+        if endpoint.startswith("/wallet/available-wallets"):
+            return _Resp([{"wallet_hash": "coldkey"}])
+        raise AssertionError(f"unexpected endpoint {endpoint}")
+
+    monkeypatch.setattr(lium, "_request", fake_request)
+    bt_wallet = types.SimpleNamespace(
+        coldkey=types.SimpleNamespace(
+            sign=lambda b: types.SimpleNamespace(hex=lambda: "sig")
+        ),
+        coldkeypub=types.SimpleNamespace(ss58_address="coldkey"),
+    )
+
+    app_id, customer_id = lium.add_wallet(bt_wallet)
+
+    assert app_id == "APP" and customer_id == "CUS"
+    assert calls.count("/tao/create-transfer") == 1
+
+
+def test_fund_no_alpha_uses_tao_path(monkeypatch):
+    monkeypatch.setitem(sys.modules, "bittensor", types.SimpleNamespace())
+    calls = {"tao": False, "alpha": False}
+    monkeypatch.setattr(fund_module, "_legacy_tao_fund", lambda *a, **k: calls.__setitem__("tao", True))
+    monkeypatch.setattr(fund_module, "_alpha_fund", lambda *a, **k: calls.__setitem__("alpha", True))
+
+    result = CliRunner().invoke(cli, ["fund", "-w", "default", "-a", "1.5", "-y"])
+
+    assert result.exit_code == 0
+    assert calls["tao"] and not calls["alpha"]

--- a/uv.lock
+++ b/uv.lock
@@ -909,7 +909,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1236,7 +1236,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.18"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1236,7 +1236,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.21"
+version = "0.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2172](https://www.notion.so/DAH-2172)

Add a USD-denominated **alpha funding** path to `lium fund` (alongside the existing on-chain TAO flow) and bump the package version to `0.0.22`.

## Problem

`lium fund` only supported the legacy on-chain TAO transfer. There was no way to fund a Lium account with free alpha, and no SDK surface for resolving the alpha quote / destination coldkey needed to do so safely.

## Solution

Add an `--alpha` funding flow that denominates the amount in USD and moves alpha via `transfer_stake`. The alpha amount, subnet `netuid`, and destination company coldkey are resolved from pay-tao-api-v2 **once per run** (never hardcoded), so a rotated netuid/address cannot silently send alpha to a dead destination. Any API failure raises `LiumError` before any on-chain call, and renders as the JSON envelope under `--json`. Wallet load + registration mirror the existing TAO flow.

## Changes

- `lium/cli/fund/command.py` — new `_alpha_fund()` flow; USD amount → alpha quote → `transfer_stake`; `--json`-aware error handling and USD-valuation caveat.
- `lium/cli/fund/actions.py` — `CheckFreeAlphaAction`, `ExecuteAlphaTransferAction`.
- `lium/cli/fund/validation.py` — `validate_ss58`, `resolve_hotkey` (SS58 or wallet hotkey name), `wallet_class`/`subtensor_class` helpers.
- `lium/sdk/client.py` — `convert_alpha()` (USD→alpha quote), `company_wallet()` (destination coldkey), `add_wallet()`, `_discover_app_id()`, `_create_transfer_app_credentials()`.
- `lium/sdk/__init__.py` — export new SDK surface.
- `test/test_fund_cli.py` — extensive coverage for the alpha flow, validation, and error paths.
- `lium/__about__.py`, `pyproject.toml` — version `0.0.21` → `0.0.22`.

## Deployment Steps

Use GitHub Action (PyPI release workflow) once merged.

## Review Request

- [ ] Just code review
- [ ] QA – local test on reviewer side

## Other PRs

None.

## Risks

- On-chain `transfer_stake` is irreversible; the flow mitigates by resolving netuid/destination from the API at run time and failing fast before any chain call.
- Credited USD is valued at on-chain inclusion time and may differ from the quoted amount — surfaced to the user as a caveat.

## Test Cases

### Test Case 1

**Actions**

`lium fund --alpha --wallet <name> --hotkey <ss58|name> --amount <usd>`

**Expected Output**

Resolves alpha quote + destination coldkey, confirms, then performs `transfer_stake`. Credits the account.

### Test Case 2

**Actions**

Run the alpha flow with `--json` while an upstream API call fails.

**Expected Output**

Error rendered as the JSON envelope; no on-chain call is made.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
