### PR TITLE
DAH-2081: fix CLI ephemeral template lifecycle metadata

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.22"
+__version__ = "0.0.23"

--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -139,6 +139,7 @@ class CreateEphemeralTemplateAction:
                 entrypoint=entrypoint,
                 environment=env if env else None,
                 is_private=True,
+                one_time_template=True,
             )
 
             return ActionResult(ok=True, data={"template": template})

--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -137,7 +137,7 @@ class CreateEphemeralTemplateAction:
                 ports=ports,
                 start_command=cmd,
                 entrypoint=entrypoint,
-                environment=env if env else None,
+                environment=env or {},
                 is_private=True,
                 one_time_template=True,
             )

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1,6 +1,7 @@
 """Lium SDK - Clean, Unix-style SDK for GPU pod management."""
 
 import getpass
+import os
 import re
 import shlex
 import socket
@@ -11,12 +12,15 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 from decimal import Decimal
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, Generator, List, Optional, Union
 from urllib.parse import parse_qs, urlparse
 
 import paramiko
 import requests
 from dotenv import load_dotenv
+
+from lium.__about__ import __version__ as fallback_version
 
 from .config import Config
 from .exceptions import (
@@ -46,6 +50,13 @@ load_dotenv()
 _PAY_API_KEY = "6RhXQ788J9BdnqeLua8z7ZSkXBDahclxhwjMB17qW1M"
 
 
+def _get_client_version() -> str:
+    try:
+        return version("lium.io")
+    except PackageNotFoundError:
+        return os.environ.get("LIUM_BUILD_VERSION", fallback_version)
+
+
 @dataclass(frozen=True)
 class AlphaQuote:
     """USD -> alpha quote from ``GET /balance/convert/alpha``.
@@ -67,7 +78,11 @@ class Lium:
 
     def __init__(self, config: Optional[Config] = None, source: str = "sdk"):
         self.config = config or Config.load()
-        self.headers = {"X-API-KEY": self.config.api_key, "X-Source": source}
+        self.headers = {
+            "X-API-KEY": self.config.api_key,
+            "X-Source": source,
+            "X-Lium-Client-Version": _get_client_version(),
+        }
 
     @with_retry()
     def _request(
@@ -1123,6 +1138,8 @@ class Lium:
                 - description (str): Template description.
                 - environment (Dict[str, str]): Environment variables.
                 - entrypoint (str): Container entrypoint.
+                - one_time_template (bool): Whether to delete template after pod removal.
+                - is_temporary (bool): Whether template is an internal temporary clone.
 
         Returns:
             Newly created :class:`Template`.
@@ -1140,6 +1157,8 @@ class Lium:
             "entrypoint": kwargs.get("entrypoint", ""),
             "environment": kwargs.get("environment", {}),
             "is_private": kwargs.get("is_private", True),
+            "one_time_template": kwargs.get("one_time_template", False),
+            "is_temporary": kwargs.get("is_temporary", False),
             "readme": kwargs.get("readme", name),
             "volumes": kwargs.get("volumes", ["/workspace"]),
         }

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1155,7 +1155,7 @@ class Lium:
             "container_start_immediately": kwargs.get("container_start_immediately", True),
             "description": kwargs.get("description", name),
             "entrypoint": kwargs.get("entrypoint", ""),
-            "environment": kwargs.get("environment", {}),
+            "environment": kwargs.get("environment") or {},
             "is_private": kwargs.get("is_private", True),
             "one_time_template": kwargs.get("one_time_template", False),
             "is_temporary": kwargs.get("is_temporary", False),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,22 +4,20 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.22"
+version = "0.0.23"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
-authors = [
-    {name = "Lium", email = "support@lium.io"}
-]
+authors = [{ name = "Lium", email = "support@lium.io" }]
 classifiers = [
-  "Development Status :: 4 - Beta",
-  "Intended Audience :: Developers",
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Operating System :: OS Independent"
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
 ]
 dependencies = [
     "typer>=0.12",

--- a/test/test_ephemeral_templates.py
+++ b/test/test_ephemeral_templates.py
@@ -35,8 +35,28 @@ def test_create_template_forwards_one_time_and_temporary_flags(monkeypatch):
 
     assert captured["method"] == "POST"
     assert captured["endpoint"] == "/templates"
+    assert captured["json"]["environment"] == {}
     assert captured["json"]["one_time_template"] is True
     assert captured["json"]["is_temporary"] is False
+
+
+def test_create_template_coerces_none_environment_to_empty_dict(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, endpoint, **kwargs):
+        captured["json"] = kwargs["json"]
+        return _Response()
+
+    monkeypatch.setattr(Lium, "_request", fake_request)
+
+    client = Lium(Config(api_key="test"))
+    client.create_template(
+        name="ephemeral-test",
+        docker_image="alpine",
+        environment=None,
+    )
+
+    assert captured["json"]["environment"] == {}
 
 
 def test_create_ephemeral_template_action_marks_template_one_time():
@@ -70,3 +90,34 @@ def test_create_ephemeral_template_action_marks_template_one_time():
     assert captured["name"].startswith("ephemeral-")
     assert captured["is_private"] is True
     assert captured["one_time_template"] is True
+
+
+def test_create_ephemeral_template_action_uses_empty_environment_when_no_env():
+    captured = {}
+
+    class FakeLium:
+        def create_template(self, **kwargs):
+            captured.update(kwargs)
+            return Template(
+                id="template-123",
+                huid="brave-fox-12",
+                name=kwargs["name"],
+                docker_image=kwargs["docker_image"],
+                docker_image_tag=kwargs["docker_image_tag"],
+                category="DOCKER",
+                status="VERIFY_SUCCESS",
+            )
+
+    result = CreateEphemeralTemplateAction().execute(
+        {
+            "lium": FakeLium(),
+            "image": "alpine:latest",
+            "env": {},
+            "entrypoint": "",
+            "cmd": "echo ok",
+            "ports": [22],
+        }
+    )
+
+    assert result.ok is True
+    assert captured["environment"] == {}

--- a/test/test_ephemeral_templates.py
+++ b/test/test_ephemeral_templates.py
@@ -1,0 +1,72 @@
+from lium.cli.up.actions import CreateEphemeralTemplateAction
+from lium.sdk import Config, Lium, Template
+
+
+class _Response:
+    def json(self):
+        return {
+            "id": "template-123",
+            "name": "ephemeral-test",
+            "docker_image": "alpine",
+            "docker_image_tag": "latest",
+            "category": "DOCKER",
+            "status": "VERIFY_SUCCESS",
+        }
+
+
+def test_create_template_forwards_one_time_and_temporary_flags(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs["json"]
+        return _Response()
+
+    monkeypatch.setattr(Lium, "_request", fake_request)
+
+    client = Lium(Config(api_key="test"))
+    client.create_template(
+        name="ephemeral-test",
+        docker_image="alpine",
+        one_time_template=True,
+        is_temporary=False,
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["endpoint"] == "/templates"
+    assert captured["json"]["one_time_template"] is True
+    assert captured["json"]["is_temporary"] is False
+
+
+def test_create_ephemeral_template_action_marks_template_one_time():
+    captured = {}
+
+    class FakeLium:
+        def create_template(self, **kwargs):
+            captured.update(kwargs)
+            return Template(
+                id="template-123",
+                huid="brave-fox-12",
+                name=kwargs["name"],
+                docker_image=kwargs["docker_image"],
+                docker_image_tag=kwargs["docker_image_tag"],
+                category="DOCKER",
+                status="VERIFY_SUCCESS",
+            )
+
+    result = CreateEphemeralTemplateAction().execute(
+        {
+            "lium": FakeLium(),
+            "image": "alpine:latest",
+            "env": {"A": "1"},
+            "entrypoint": "/bin/sh",
+            "cmd": "sleep infinity",
+            "ports": [22],
+        }
+    )
+
+    assert result.ok is True
+    assert captured["name"].startswith("ephemeral-")
+    assert captured["is_private"] is True
+    assert captured["one_time_template"] is True

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -1,0 +1,11 @@
+from lium.sdk import Config, Lium
+
+
+def test_client_sets_version_header(monkeypatch):
+    monkeypatch.setattr("lium.sdk.client._get_client_version", lambda: "1.2.3")
+
+    client = Lium(Config(api_key="test"), source="cli")
+
+    assert client.headers["X-API-KEY"] == "test"
+    assert client.headers["X-Source"] == "cli"
+    assert client.headers["X-Lium-Client-Version"] == "1.2.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1236,7 +1236,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.22"
+version = "0.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Mark `lium up` ephemeral templates as `one_time_template`.
- Forward template lifecycle flags through `Lium.create_template`.
- Send `X-Lium-Client-Version` on normal SDK/CLI API requests.
- Send `{}` instead of `null` for empty template environments, fixing no-env `lium up` requests against the backend schema.

## Problem

`lium up` created private `ephemeral-*` templates, but the SDK dropped the lifecycle flags when posting to `/templates`. The backend then stored those rows as normal templates, so they could leak permanently into the compute app DB.

While staging the smoke test, the working-tree CLI also exposed a small compatibility bug: no-env ephemeral template creation sent `environment: null`, which staging rejects because the backend expects a dictionary. This PR now coerces missing/`None` environments to `{}` from both the CLI action and SDK client path.

## Testing

- `uv run --extra dev pytest test/test_ephemeral_templates.py test/test_sdk_client.py`
- `python -m py_compile lium/sdk/client.py test/test_ephemeral_templates.py test/test_sdk_client.py`
- `git diff --check`
- `uv run python -m lium.cli.cli --version` -> `0.0.23`
- Staging smoke with local CLI checkout:
  - `lium up` without env vars succeeds
  - pod starts and logs stream
  - `lium rm --all` removes the pod
  - `lium templates ephemeral` shows no leaked templates
  - backend logs confirmed `x-lium-client-version: 0.0.23`

## Other PRs

- Backend companion PR: https://github.com/Datura-ai/lium-io-backend/pull/696
