### PR TITLE
feat: DAH-2231 - add --dockerfile custom build to lium up (SDK + CLI)

### DIFF
--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -170,7 +170,8 @@ class RentPodAction:
     def execute(self, ctx: dict) -> ActionResult:
         lium: Lium = ctx["lium"]
         executor: ExecutorInfo = ctx["executor"]
-        template: Template = ctx["template"]
+        template: Optional[Template] = ctx.get("template")
+        dockerfile_content: Optional[str] = ctx.get("dockerfile_content")
         name: Optional[str] = ctx.get("name")
         volume_id: Optional[str] = ctx.get("volume_id")
         ports: Optional[int] = ctx.get("ports")
@@ -184,6 +185,7 @@ class RentPodAction:
                 executor_id=executor.id,
                 name=name,
                 template_id=template.id if template else None,
+                dockerfile_content=dockerfile_content,
                 volume_id=volume_id,
                 ports=ports,
                 ssh_name=ssh_name,

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -34,6 +34,7 @@ from .actions import (
 @click.option("--jupyter", is_flag=True, help="Install Jupyter Notebook (automatically selects available port)")
 @click.option("--image", help="Docker image to run (e.g., pytorch/pytorch:2.0, nvidia/cuda:12.0)")
 @click.option("--internal-ports", help="Internal ports to expose (comma-separated, e.g., 22,8000,8080)")
+@click.option("--dockerfile", type=click.Path(exists=True, dir_okay=False, readable=True), help="Path to a Dockerfile to build the pod image from (custom build; mutually exclusive with --image/--template_id)")
 @click.option("-e", "--env", multiple=True, help="Environment variables (KEY=VALUE), can be repeated")
 @click.option("--entrypoint", default="", help="Container entrypoint")
 @click.option("--cmd", default="", help="Command to run in the container")
@@ -54,6 +55,7 @@ def up_command(
     jupyter: bool,
     image: Optional[str],
     internal_ports: Optional[str],
+    dockerfile: Optional[str],
     env: Tuple[str, ...],
     entrypoint: Optional[str],
     cmd: Optional[str],
@@ -89,13 +91,20 @@ def up_command(
       lium up --gpu A6000 --image python:3.11 --cmd "python -c 'print(1+1)'"
       lium up --gpu A4000 --image myimg --entrypoint /bin/sh --cmd "-c 'echo hi'"
       lium up --gpu A4000 --image myimg --internal-ports 22,8000,8080
+    \b
+    Custom Dockerfile build (image built remotely from your Dockerfile):
+      lium up --gpu A4000 --dockerfile ./Dockerfile
+      lium up cosmic-hawk-f2 --dockerfile ./Dockerfile --name my-build
     """
     ensure_config()
 
-    # Check if we're in docker-run mode
+    # Check if we're in docker-run mode or custom-Dockerfile build mode
     docker_run_mode = image is not None
+    dockerfile_mode = dockerfile is not None
 
-    valid, error = validation.validate(executor_id, gpu, count, country, ttl, until, image, template_id)
+    valid, error = validation.validate(
+        executor_id, gpu, count, country, ttl, until, image, template_id, dockerfile
+    )
     if not valid:
         ui.error(error)
         return
@@ -116,6 +125,48 @@ def up_command(
     termination_time = parsed.get("termination_time")
     volume_id = parsed.get("volume_id")
     volume_create_params = parsed.get("volume_create_params")
+
+    # Custom-Dockerfile build: read the Dockerfile text the CLI will send to the
+    # backend (the image is built remotely; no build context is uploaded).
+    dockerfile_content = None
+    if dockerfile_mode:
+        from pathlib import Path
+
+        # These flags only apply to template/--image mode. In a custom build the
+        # Dockerfile itself defines the image's env/entrypoint/command/ports, so
+        # reject them explicitly rather than silently dropping them.
+        unsupported = [
+            flag
+            for flag, supplied in (
+                ("--env", bool(env)),
+                ("--entrypoint", bool(entrypoint)),
+                ("--cmd", bool(cmd)),
+                ("--internal-ports", bool(internal_ports)),
+            )
+            if supplied
+        ]
+        if unsupported:
+            ui.error(
+                f"{', '.join(unsupported)} cannot be combined with --dockerfile "
+                "(the Dockerfile defines the image's env, entrypoint, command, and ports)"
+            )
+            return
+
+        try:
+            dockerfile_content = Path(dockerfile).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            ui.error(f"Could not read Dockerfile: {exc}")
+            return
+        if not dockerfile_content.strip():
+            ui.error("Dockerfile is empty")
+            return
+        max_bytes = 64 * 1024
+        size_bytes = len(dockerfile_content.encode("utf-8"))
+        if size_bytes > max_bytes:
+            ui.error(
+                f"Dockerfile is too large ({size_bytes} bytes); max is {max_bytes} bytes (64 KiB)"
+            )
+            return
 
     lium = Lium(source="cli")
 
@@ -146,8 +197,12 @@ def up_command(
         if is_slow and warning_msg:
             ui.warning(f"Warning: {warning_msg}")
 
-    # Resolve or create template
-    if docker_run_mode:
+    # Resolve or create template (skipped for custom Dockerfile builds, which are
+    # built remotely from the supplied Dockerfile and use no template).
+    template = None
+    if dockerfile_mode:
+        pass
+    elif docker_run_mode:
         # Parse internal ports (default to [22] if not specified)
         ports_list = [22]
         if internal_ports:
@@ -172,6 +227,10 @@ def up_command(
                 "ports": ports_list,
             })
         )
+        if not result.ok:
+            ui.error(result.error)
+            return
+        template = result.data["template"]
     else:
         action = ResolveTemplateAction()
         result = action.execute({
@@ -179,28 +238,25 @@ def up_command(
             "template_id": template_id,
             "executor": executor
         })
-
-        if result.ok:
-            template = result.data["template"]
-            # API-based estimate using resolved template ID
-            try:
-                estimate = lium.get_deployment_estimate(executor.id, template.id)
-                est_secs = estimate.get("estimated_seconds")
-                if est_secs:
-                    dl_speed = executor.download_speed
-                    raw_bytes = estimate.get("docker_image_size")
-                    img_gb = raw_bytes / 1e9 if raw_bytes is not None else None
-                    _show_estimate(
-                        est_secs, dl_speed, img_gb,
-                        estimate.get("is_slow_machine", False),
-                        estimate.get("warning_message"),
-                    )
-            except Exception:
-                pass
-
-    if not result.ok:
-        ui.error(result.error)
-        return
+        if not result.ok:
+            ui.error(result.error)
+            return
+        template = result.data["template"]
+        # API-based estimate using resolved template ID
+        try:
+            estimate = lium.get_deployment_estimate(executor.id, template.id)
+            est_secs = estimate.get("estimated_seconds")
+            if est_secs:
+                dl_speed = executor.download_speed
+                raw_bytes = estimate.get("docker_image_size")
+                img_gb = raw_bytes / 1e9 if raw_bytes is not None else None
+                _show_estimate(
+                    est_secs, dl_speed, img_gb,
+                    estimate.get("is_slow_machine", False),
+                    estimate.get("warning_message"),
+                )
+        except Exception:
+            pass
 
     if not yes:
         confirm_msg = (
@@ -210,8 +266,6 @@ def up_command(
         )
         if not ui.confirm(confirm_msg):
             return
-
-    template = result.data["template"]
 
     if volume_create_params:
         action = CreateVolumeAction()
@@ -236,6 +290,7 @@ def up_command(
             "lium": lium,
             "executor": executor,
             "template": template,
+            "dockerfile_content": dockerfile_content,
             "name": name,
             "volume_id": volume_id,
             "ports": ports,

--- a/lium/cli/up/validation.py
+++ b/lium/cli/up/validation.py
@@ -12,6 +12,7 @@ def validate(
     until: str | None,
     image: str | None = None,
     template_id: str | None = None,
+    dockerfile: str | None = None,
 ) -> tuple[bool, str]:
     """Validate up command inputs."""
     if executor_id and (gpu or count or country):
@@ -25,6 +26,12 @@ def validate(
 
     if image and template_id:
         return False, "Cannot specify both --image and --template_id"
+
+    if dockerfile and image:
+        return False, "Cannot specify both --dockerfile and --image"
+
+    if dockerfile and template_id:
+        return False, "Cannot specify both --dockerfile and --template_id"
 
     return True, ""
 

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -312,6 +312,7 @@ class Lium:
         executor_id: str,
         name: str = "Your Pod",
         template_id: Optional[str] = None,
+        dockerfile_content: Optional[str] = None,
         volume_id: Optional[str] = None,
         ports: Optional[int] = None,
         ssh_keys: Optional[List[str]] = None,
@@ -323,6 +324,12 @@ class Lium:
             executor_id: Target node ID string.
             name: Human-friendly pod name (defaults to ``"Your Pod"``).
             template_id: Template ID. Defaults to the node's default template.
+                Mutually exclusive with ``dockerfile_content``.
+            dockerfile_content: Raw Dockerfile text to build the pod image from on
+                the node (custom build). Mutually exclusive with ``template_id`` —
+                pass exactly one. The image is built remotely with no network
+                access, so the Dockerfile must be self-contained (no ``ADD <url>``
+                or ``ADD ${var}`` directives).
             volume_id: Optional volume ID to attach on spawn.
             ports: Number of exposed ports to request.
             ssh_keys: SSH public keys to authorize. Defaults to the keys discovered by the Config.
@@ -333,11 +340,16 @@ class Lium:
         Returns:
             Pod metadata as returned by the rent API (id, name, status, ssh command, etc.).
         """
+        if template_id is not None and dockerfile_content is not None:
+            raise ValueError(
+                "Provide either template_id or dockerfile_content, not both"
+            )
+
         executor_info = self.get_executor(executor_id)
         if not executor_info:
             raise ValueError(f"Node with ID '{executor_id}' not found")
 
-        if template_id is None:
+        if template_id is None and dockerfile_content is None:
             selected_template = self.default_docker_template(executor_info.id)
             template_id = selected_template.id
 
@@ -350,6 +362,7 @@ class Lium:
         payload = {
             "pod_name": name,
             "template_id": template_id,
+            "dockerfile_content": dockerfile_content,
             "volume_id": volume_id,
             "user_public_key": ssh_material,
             "initial_port_count": ports,

--- a/test/test_up_dockerfile.py
+++ b/test/test_up_dockerfile.py
@@ -1,0 +1,289 @@
+"""Tests for custom-Dockerfile pod deployment via `lium up --dockerfile`.
+
+Covers the three surfaces the feature touches:
+  * SDK  — `Lium.up()` payload shape (dockerfile vs template) + the XOR guard.
+  * CLI  — `--dockerfile` validation (mutually exclusive with --image/--template_id)
+           and the file-read → SDK wiring.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from lium.sdk import Config, Lium
+from lium.cli import up as up_pkg  # noqa: F401  (ensures package import works)
+from lium.cli.up import command as up_command
+from lium.cli.up import validation as up_validation
+from lium.cli.up.actions import RentPodAction
+from lium.cli.actions import ActionResult
+
+
+class _Resp:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def _stub_up(monkeypatch, client, captured):
+    """Stub out network + ssh helpers on a real Lium so up() reaches payload build."""
+    monkeypatch.setattr(client, "get_executor", lambda executor_id: SimpleNamespace(id="exec-1"))
+    monkeypatch.setattr(
+        client, "default_docker_template", lambda executor_id: SimpleNamespace(id="tmpl-default")
+    )
+    monkeypatch.setattr(client, "_ensure_ssh_keys_registered", lambda *a, **k: None)
+
+    def fake_request(method, endpoint, json=None, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["payload"] = json
+        return _Resp({"id": "pod-1", "name": (json or {}).get("pod_name"), "status": "PENDING"})
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+
+# --------------------------------------------------------------------------- #
+# SDK: Lium.up() payload shape
+# --------------------------------------------------------------------------- #
+
+
+def test_up_with_dockerfile_sends_content_and_null_template(monkeypatch):
+    # Arrange
+    client = Lium(Config(api_key="test"))
+    captured: dict = {}
+    _stub_up(monkeypatch, client, captured)
+    dockerfile = 'FROM busybox\nCMD ["true"]'
+
+    # Act
+    client.up(
+        executor_id="exec-1",
+        name="custom-pod",
+        dockerfile_content=dockerfile,
+        ssh_keys=["ssh-ed25519 AAA"],
+    )
+
+    # Assert
+    assert captured["endpoint"] == "/executors/exec-1/rent"
+    payload = captured["payload"]
+    assert payload["dockerfile_content"] == dockerfile
+    assert payload["template_id"] is None
+
+
+def test_up_with_template_sends_template_and_null_dockerfile(monkeypatch):
+    # Arrange
+    client = Lium(Config(api_key="test"))
+    captured: dict = {}
+    _stub_up(monkeypatch, client, captured)
+
+    # Act
+    client.up(executor_id="exec-1", template_id="tmpl-xyz", ssh_keys=["ssh-ed25519 AAA"])
+
+    # Assert
+    payload = captured["payload"]
+    assert payload["template_id"] == "tmpl-xyz"
+    assert payload["dockerfile_content"] is None
+
+
+def test_up_without_template_or_dockerfile_falls_back_to_default_template(monkeypatch):
+    # Arrange
+    client = Lium(Config(api_key="test"))
+    captured: dict = {}
+    _stub_up(monkeypatch, client, captured)
+
+    # Act
+    client.up(executor_id="exec-1", ssh_keys=["ssh-ed25519 AAA"])
+
+    # Assert
+    payload = captured["payload"]
+    assert payload["template_id"] == "tmpl-default"
+    assert payload["dockerfile_content"] is None
+
+
+def test_up_rejects_both_template_and_dockerfile(monkeypatch):
+    # Arrange
+    client = Lium(Config(api_key="test"))
+    captured: dict = {}
+    _stub_up(monkeypatch, client, captured)
+
+    # Act / Assert — XOR guard fires before any network call
+    with pytest.raises(ValueError, match="not both"):
+        client.up(
+            executor_id="exec-1",
+            template_id="tmpl-xyz",
+            dockerfile_content="FROM busybox",
+            ssh_keys=["ssh-ed25519 AAA"],
+        )
+    assert "payload" not in captured
+
+
+# --------------------------------------------------------------------------- #
+# CLI: validation XOR
+# --------------------------------------------------------------------------- #
+
+
+def test_validate_rejects_dockerfile_with_image():
+    ok, error = up_validation.validate(
+        "node-1", None, None, None, None, None, image="pytorch/pytorch", dockerfile="./Dockerfile"
+    )
+    assert ok is False
+    assert "--dockerfile" in error and "--image" in error
+
+
+def test_validate_rejects_dockerfile_with_template_id():
+    ok, error = up_validation.validate(
+        "node-1", None, None, None, None, None, template_id="tmpl-1", dockerfile="./Dockerfile"
+    )
+    assert ok is False
+    assert "--dockerfile" in error and "--template_id" in error
+
+
+def test_validate_allows_dockerfile_alone():
+    ok, error = up_validation.validate(
+        "node-1", None, None, None, None, None, dockerfile="./Dockerfile"
+    )
+    assert ok is True
+    assert error == ""
+
+
+# --------------------------------------------------------------------------- #
+# CLI: RentPodAction threads dockerfile_content into the SDK
+# --------------------------------------------------------------------------- #
+
+
+def test_rent_pod_action_passes_dockerfile_content_and_no_template():
+    # Arrange
+    captured: dict = {}
+
+    class FakeLium:
+        def up(self, **kwargs):
+            captured.update(kwargs)
+            return {"id": "pod-1", "name": kwargs["name"]}
+
+    # Act
+    result = RentPodAction().execute(
+        {
+            "lium": FakeLium(),
+            "executor": SimpleNamespace(id="exec-1", huid="brave-fox-3a"),
+            "template": None,
+            "dockerfile_content": "FROM busybox\nCMD [\"true\"]",
+            "name": "custom-pod",
+        }
+    )
+
+    # Assert
+    assert result.ok
+    assert captured["dockerfile_content"] == 'FROM busybox\nCMD ["true"]'
+    assert captured["template_id"] is None
+    assert captured["executor_id"] == "exec-1"
+
+
+# --------------------------------------------------------------------------- #
+# CLI: full `lium up --dockerfile` path reads the file and forwards its content
+# --------------------------------------------------------------------------- #
+
+
+def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path):
+    # Arrange — a real Dockerfile on disk
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile_text = 'FROM nvidia/cuda:12.8.0-runtime-ubuntu24.04\nCMD ["sleep", "infinity"]\n'
+    dockerfile.write_text(dockerfile_text)
+
+    captured: dict = {}
+    executor = SimpleNamespace(
+        id="exec-1",
+        huid="brave-fox-3a",
+        gpu_count=1,
+        gpu_type="A6000",
+        price_per_hour=0.24,
+        available_port_count=10,
+        download_speed=1000,
+    )
+    pod = SimpleNamespace(id="pod-1", name="custom-pod")
+
+    class _FakeResolveExecutor:
+        def execute(self, ctx):
+            return ActionResult(ok=True, data={"executor": executor})
+
+    class _FakeRentPod:
+        def execute(self, ctx):
+            captured["ctx"] = ctx
+            return ActionResult(ok=True, data={"pod_info": {}, "pod_id": "pod-1", "pod_name": "custom-pod"})
+
+    class _FakeWaitReady:
+        def execute(self, ctx):
+            return ActionResult(ok=True, data={"pod": pod})
+
+    class _FakePrepareSSH:
+        def execute(self, ctx):
+            return ActionResult(ok=True, data={"ssh_cmd": "ssh root@host -p 22", "pod": pod})
+
+    monkeypatch.setattr(up_command, "ensure_config", lambda: None)
+    monkeypatch.setattr(up_command, "Lium", lambda **kwargs: SimpleNamespace())
+    monkeypatch.setattr(up_command, "ResolveExecutorAction", _FakeResolveExecutor)
+    monkeypatch.setattr(up_command, "RentPodAction", _FakeRentPod)
+    monkeypatch.setattr(up_command, "WaitReadyAction", _FakeWaitReady)
+    monkeypatch.setattr(up_command, "PrepareSSHAction", _FakePrepareSSH)
+    monkeypatch.setattr("lium.cli.ssh.command.ssh_to_pod", lambda *a, **k: None)
+
+    # Act
+    result = CliRunner().invoke(
+        up_command.up_command,
+        ["brave-fox-3a", "--dockerfile", str(dockerfile), "--yes"],
+    )
+
+    # Assert
+    assert result.exit_code == 0, result.output
+    assert "ctx" in captured, "RentPodAction was never reached"
+    assert captured["ctx"]["dockerfile_content"] == dockerfile_text
+    assert captured["ctx"]["template"] is None
+
+
+def test_up_command_rejects_dockerfile_with_image(monkeypatch, tmp_path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM busybox\n")
+    monkeypatch.setattr(up_command, "ensure_config", lambda: None)
+
+    result = CliRunner().invoke(
+        up_command.up_command,
+        ["brave-fox-3a", "--dockerfile", str(dockerfile), "--image", "pytorch/pytorch:2.0"],
+    )
+
+    assert result.exit_code == 0
+    assert "Cannot specify both --dockerfile and --image" in result.output
+
+
+def test_up_command_rejects_env_with_dockerfile(monkeypatch, tmp_path):
+    # --env/--cmd/--entrypoint/--internal-ports have no delivery path in a custom
+    # build, so they must be rejected rather than silently ignored.
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM busybox\n")
+    monkeypatch.setattr(up_command, "ensure_config", lambda: None)
+
+    result = CliRunner().invoke(
+        up_command.up_command,
+        ["brave-fox-3a", "--dockerfile", str(dockerfile), "-e", "KEY=VAL"],
+    )
+
+    assert result.exit_code == 0
+    assert "--env" in result.output
+    assert "--dockerfile" in result.output
+
+
+def test_up_command_reports_non_utf8_dockerfile(monkeypatch, tmp_path):
+    # A binary / non-UTF-8 file passes click's readable check but must yield a
+    # clean error, not an uncaught UnicodeDecodeError.
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_bytes(b"\xff\xfe\x00\x01binary-not-text")
+    monkeypatch.setattr(up_command, "ensure_config", lambda: None)
+
+    result = CliRunner().invoke(
+        up_command.up_command,
+        ["brave-fox-3a", "--dockerfile", str(dockerfile)],
+    )
+
+    assert result.exit_code == 0
+    assert "Could not read Dockerfile" in result.output


### PR DESCRIPTION
## DAH-2231 — Deploy a Pod from a custom Dockerfile (SDK + CLI)

Adds `lium up --dockerfile PATH` so users can deploy a pod whose image is built remotely from their own Dockerfile. The backend already supports this (DAH-2211, `dockerfile_content` on `POST /executors/{id}/rent`); this PR builds the SDK + CLI consumer surfaces.

### SDK (`lium/sdk/client.py`)
- `Lium.up()` gains `dockerfile_content: Optional[str]`, mutually exclusive with `template_id` (raises `ValueError` if both are given). When a Dockerfile is supplied, no default template is resolved and `template_id` is sent as `None`.

### CLI (`lium/cli/up/`)
- New `--dockerfile PATH` option (`click.Path(exists=True, dir_okay=False, readable=True)`). The CLI reads the file and passes the raw text to the SDK.
- XOR with `--image` / `--template_id` (`validation.py`).
- `--env` / `--entrypoint` / `--cmd` / `--internal-ports` are rejected with a clear error in dockerfile mode (the Dockerfile defines these) rather than silently dropped.
- Empty-file, 64 KiB-size, and non-UTF-8 guards with friendly errors.
- Post-deploy uses the standard SSH flow — a custom build still yields an SSH-accessible pod, like a template-based pod.

### Tests
- `test/test_up_dockerfile.py` — 12 tests: SDK payload shape, SDK XOR guard, CLI XOR validation, file-read → SDK wiring, flag rejection, non-UTF-8 handling. All pass; `lium up --help` renders the new flag.

### Docs
Documented in the companion **lium-docs** PR (CLI reference + regenerated SDK reference). Note: the lium-docs SDK-reference drift gate stays red until **this** PR lands on `main` (it regenerates against `Datura-ai/lium@main`).

Constraints mirror the backend: the build runs `--network=none`, `ADD <url>` / `ADD ${var}` are rejected server-side, and the Dockerfile must be self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
