### PR TITLE
DAH-2081: hide internal template flag from SDK docs

### DIFF
--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1139,7 +1139,6 @@ class Lium:
                 - environment (Dict[str, str]): Environment variables.
                 - entrypoint (str): Container entrypoint.
                 - one_time_template (bool): Whether to delete template after pod removal.
-                - is_temporary (bool): Whether template is an internal temporary clone.
 
         Returns:
             Newly created :class:`Template`.
@@ -1158,6 +1157,7 @@ class Lium:
             "environment": kwargs.get("environment") or {},
             "is_private": kwargs.get("is_private", True),
             "one_time_template": kwargs.get("one_time_template", False),
+            # Internal backend clone marker; intentionally omitted from the public SDK docs.
             "is_temporary": kwargs.get("is_temporary", False),
             "readme": kwargs.get("readme", name),
             "volumes": kwargs.get("volumes", ["/workspace"]),

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1138,7 +1138,8 @@ class Lium:
                 - description (str): Template description.
                 - environment (Dict[str, str]): Environment variables.
                 - entrypoint (str): Container entrypoint.
-                - one_time_template (bool): Whether to delete template after pod removal.
+                - one_time_template (bool): Whether to delete template after pod removal
+                  (defaults to ``False``).
 
         Returns:
             Newly created :class:`Template`.


### PR DESCRIPTION
## Summary

- Remove `is_temporary` from the public `Lium.create_template` docstring so SDK reference generation does not publish it.
- Keep forwarding the flag in the SDK payload because it is still needed as an internal backend clone marker.
- Add a source comment explaining that the flag is intentionally omitted from public SDK docs.
- Document that public `one_time_template` defaults to `False`, so generated SDK docs show the default clearly.

## Why

The SDK reference in `lium-docs` is generated from public SDK docstrings using pdoc. Since `create_template()` is public, listing `is_temporary` under `**kwargs` caused the generated docs to expose an internal backend flag. The generator does not support hiding one kwarg with `@private`; that marker would hide the whole public method, so the source docstring is the right place to keep the public surface clean.

## Testing

- `python -m py_compile lium/sdk/client.py`
- `uv run --extra dev pytest test/test_ephemeral_templates.py test/test_sdk_client.py`
- `git diff --check`
- Regenerated `lium-docs` SDK reference locally with `LIUM_SDK_ROOT=/Users/shumail/hobby/pixel/lium npm run sdk:reference` and confirmed `one_time_template` includes its `False` default while `is_temporary` is not generated.