### PR TITLE
DAH-2192: add provider Discord onboarding CLI

### DIFF
--- a/lium/cli/provider/_render.py
+++ b/lium/cli/provider/_render.py
@@ -47,6 +47,14 @@ from lium.provider.errors import (
 from lium.provider.models import ProviderStatus
 
 
+DISCORD_INCENTIVE_WARNING_CODE = "DISCORD_REQUIRED_FOR_EXTRA_INCENTIVES"
+DISCORD_INCENTIVE_WARNING_MESSAGE = (
+    "Discord is not connected. No Discord = no extra incentives. "
+    "Run `lium provider config connect-discord` to become eligible."
+)
+DISCORD_CONNECT_COMMAND = "lium provider config connect-discord"
+_DISCORD_STATUS_WARNING = "discord: not connected; extra incentives are disabled"
+
 # code -> exit-code mapping. Anything missing falls back to ``1``.
 _EXIT_CODES: dict[str, int] = {
     # 1: user/arg errors
@@ -82,6 +90,7 @@ def render(
     payload: Any,
     *,
     summary: str | None = None,
+    warnings: Iterable[Mapping[str, str]] | None = None,
 ) -> None:
     """Render a successful result.
 
@@ -89,8 +98,11 @@ def render(
     prints ``summary`` (if provided) followed by a Rich table or panel
     chosen by payload shape.
     """
+    structured_warnings = _normalise_warnings(warnings)
     if _json_mode(ctx):
         envelope = {"ok": True, "data": _to_serialisable(payload)}
+        if structured_warnings:
+            envelope["warnings"] = structured_warnings
         click.echo(json.dumps(envelope, sort_keys=True, default=str))
         return
 
@@ -146,10 +158,20 @@ def emit_warning(ctx: click.Context, code: str, message: str) -> None:
         # The status command surfaces warnings via ProviderStatus.warnings;
         # for one-shot warnings we deliberately keep stdout clean.
         return
-    click.echo(
-        click.style(f"[{code}]", fg="yellow", bold=True) + f" {message}",
-        err=True,
-    )
+    _emit_structured_warnings([{"code": code, "message": message}])
+
+
+def discord_incentive_warnings(
+    discord_connected: bool | None,
+) -> list[dict[str, str]]:
+    if discord_connected is not False:
+        return []
+    return [
+        {
+            "code": DISCORD_INCENTIVE_WARNING_CODE,
+            "message": DISCORD_INCENTIVE_WARNING_MESSAGE,
+        }
+    ]
 
 
 def _json_mode(ctx: click.Context) -> bool:
@@ -174,6 +196,29 @@ def _to_serialisable(payload: Any) -> Any:
     if isinstance(payload, (list, tuple)):
         return [_to_serialisable(v) for v in payload]
     return payload
+
+
+def _normalise_warnings(
+    warnings: Iterable[Mapping[str, str]] | None,
+) -> list[dict[str, str]]:
+    if not warnings:
+        return []
+    normalised: list[dict[str, str]] = []
+    for warning in warnings:
+        code = str(warning.get("code", "")).strip()
+        message = str(warning.get("message", "")).strip()
+        if code and message:
+            normalised.append({"code": code, "message": message})
+    return normalised
+
+
+def _emit_structured_warnings(warnings: Iterable[Mapping[str, str]]) -> None:
+    for warning in warnings:
+        click.echo(
+            click.style(f"[{warning['code']}]", fg="yellow", bold=True)
+            + f" {warning['message']}",
+            err=True,
+        )
 
 
 def fatal(ctx: click.Context, err: ProviderError) -> None:
@@ -533,8 +578,17 @@ def _render_record(body: Mapping[str, Any]) -> None:
     table = _new_table(headers=False, expand=False)
     table.add_column("Field", style="dim", justify="right", no_wrap=True)
     table.add_column("Value", overflow="fold")
+    extra_incentives_disabled = body.get("extra_incentive_eligible") is False
+    extra_incentive_note_rendered = False
     for key, value in body.items():
+        if key == "extra_incentive_eligible" and extra_incentives_disabled:
+            continue
         table.add_row(_human_label(key), _format_record_value(key, value))
+        if key == "discord_connected" and extra_incentives_disabled:
+            table.add_row("Extra Incentives", _format_discord_incentive_next_step())
+            extra_incentive_note_rendered = True
+    if extra_incentives_disabled and not extra_incentive_note_rendered:
+        table.add_row("Extra Incentives", _format_discord_incentive_next_step())
     console.print(table)
 
 
@@ -565,6 +619,12 @@ def _format_record_value(key: str, value: Any) -> str:
     a single record is the right place to reveal full identifiers."""
     if value is None or value == "":
         return console.get_styled("—", "dim")
+    if key == "extra_incentive_eligible" and value is False:
+        return _format_extra_incentive_eligible(
+            value,
+            true_label="true",
+            false_label="false",
+        )
     if isinstance(value, bool):
         return _bool_icon(value, true_label="true", false_label="false")
     if isinstance(value, (list, tuple)):
@@ -603,6 +663,26 @@ def _format_record_value(key: str, value: Any) -> str:
     return text
 
 
+def _format_extra_incentive_eligible(
+    value: Any,
+    *,
+    true_label: str = "yes",
+    false_label: str = "no",
+) -> str:
+    return _bool_icon(value, true_label=true_label, false_label=false_label)
+
+
+def _format_discord_connect_command() -> str:
+    return console.get_styled(DISCORD_CONNECT_COMMAND, "warning")
+
+
+def _format_discord_incentive_next_step() -> str:
+    return (
+        "No Discord = no extra incentives.\nRun: "
+        + _format_discord_connect_command()
+    )
+
+
 def _render_provider_status(status: ProviderStatus) -> None:
     """Multi-section render for the aggregated ``status`` command."""
     overview = _new_table(headers=False, expand=False)
@@ -623,6 +703,19 @@ def _render_provider_status(status: ProviderStatus) -> None:
         else console.get_styled("inactive", "warning"),
     )
     overview.add_row("Provider id", _format_record_value("provider_id", status.provider_id))
+    overview.add_row(
+        "Discord connected",
+        _bool_icon(status.discord_connected)
+        if status.discord_connected is not None
+        else console.get_styled("unknown", "dim"),
+    )
+    if status.extra_incentive_eligible is False:
+        overview.add_row("Extra incentives", _format_discord_incentive_next_step())
+    elif status.extra_incentive_eligible is not None:
+        overview.add_row(
+            "Extra incentive eligible",
+            _format_extra_incentive_eligible(status.extra_incentive_eligible),
+        )
     overview.add_row("Nodes", _value_or_dash(status.node_count))
     console.print(overview)
 
@@ -638,15 +731,19 @@ def _render_provider_status(status: ProviderStatus) -> None:
         )
         _render_rows([w.model_dump() for w in status.validator_weights])
 
-    if status.warnings:
+    visible_warnings = [
+        warning for warning in status.warnings if warning != _DISCORD_STATUS_WARNING
+    ]
+    if visible_warnings:
         console.print(
-            console.get_styled(f"\nWarnings ({len(status.warnings)})", "warning")
+            console.get_styled(f"\nWarnings ({len(visible_warnings)})", "warning")
         )
-        for w in status.warnings:
+        for w in visible_warnings:
             console.print("  " + console.get_styled(f"⚠ {w}", "warning"))
 
 
 __all__ = [
+    "discord_incentive_warnings",
     "emit_error",
     "emit_warning",
     "exit_code_for",

--- a/lium/cli/provider/config.py
+++ b/lium/cli/provider/config.py
@@ -5,14 +5,19 @@ Subcommands:
 - ``show``                       -- ``GET /auth/me`` rich profile.
 - ``opt-in / opt-out``           -- toggle the lium.io central miner server.
 - ``set-email <email>``          -- update contact email.
+- ``set-password``               -- set password using signature authentication.
+- ``connect-discord``            -- start Discord OAuth linking.
 - ``set-subscriptions``          -- machine-request notification subscriptions.
 
 Distinction from ``lium config`` (CLI-side ConfigManager) and
 ``lium provider portal`` (JWT/session): this group is for *portal-account*
-state held server-side. Mutating commands run the persona gate.
+state held server-side. Some account mutations run the persona gate.
 """
 
 from __future__ import annotations
+
+import time
+import webbrowser
 
 import click
 
@@ -23,8 +28,9 @@ from lium.cli.provider._guards import (
     require_persona_ack,
 )
 from lium.cli.provider._overrides import with_provider_overrides
-from lium.cli.provider._render import render
-from lium.provider.errors import ProviderError
+from lium.cli.provider._render import discord_incentive_warnings, render
+from lium.provider.client import discord_connected_from_profile, with_discord_eligibility
+from lium.provider.errors import ARG_INVALID, ProviderError
 
 
 @click.group("config")
@@ -43,13 +49,26 @@ def show(ctx: click.Context) -> None:
     except ProviderError as e:
         ctx.exit(handle_provider_error(ctx, e))
         return
+    if isinstance(body, dict):
+        body = with_discord_eligibility(body)
     summary_parts: list[str] = []
     if isinstance(body, dict):
-        for key in ("miner_hotkey", "miner_uid", "email", "opt_in_status"):
+        for key in (
+            "miner_hotkey",
+            "miner_uid",
+            "email",
+            "opt_in_status",
+            "discord_connected",
+        ):
             if key in body:
                 summary_parts.append(f"{key}={body[key]}")
     summary = "config: " + ", ".join(summary_parts) if summary_parts else "config"
-    render(ctx, body, summary=summary)
+    warnings = (
+        discord_incentive_warnings(body.get("discord_connected"))
+        if isinstance(body, dict)
+        else []
+    )
+    render(ctx, body, summary=summary, warnings=warnings)
 
 
 def _set_opt_in(ctx: click.Context, value: bool) -> None:
@@ -100,6 +119,137 @@ def set_email(ctx: click.Context, email: str) -> None:
 
 
 @config_command.command(
+    "set-password",
+    short_help="Set the provider portal password with hotkey signature auth.",
+)
+@click.option(
+    "--password",
+    "new_password",
+    envvar="LIUM_PROVIDER_NEW_PASSWORD",
+    help="New password. Prompts when omitted outside --json.",
+)
+@with_provider_overrides
+@click.pass_context
+def set_password(ctx: click.Context, new_password: str | None) -> None:
+    require_hotkey(ctx, group="config")
+    if not new_password:
+        if _json_mode(ctx):
+            ctx.exit(
+                handle_provider_error(
+                    ctx,
+                    ProviderError(
+                        "config set-password requires --password or LIUM_PROVIDER_NEW_PASSWORD under --json",
+                        code=ARG_INVALID,
+                    ),
+                )
+            )
+            return
+        new_password = click.prompt(
+            "New password",
+            hide_input=True,
+            confirmation_prompt=True,
+        )
+
+    client = build_client(ctx)
+    try:
+        body = client.set_password(new_password)
+    except ProviderError as e:
+        ctx.exit(handle_provider_error(ctx, e))
+        return
+    render(ctx, body, summary="password set")
+
+
+@config_command.command(
+    "connect-discord",
+    short_help="Start Discord OAuth linking for extra incentive eligibility.",
+)
+@click.option(
+    "--no-wait",
+    is_flag=True,
+    help="Return immediately after printing the Discord authorization URL.",
+)
+@click.option(
+    "--timeout",
+    type=click.IntRange(min=0),
+    default=120,
+    show_default=True,
+    help="Seconds to wait for Discord linking outside --no-wait.",
+)
+@click.option(
+    "--poll-interval",
+    type=click.FloatRange(min=0.1),
+    default=3.0,
+    show_default=True,
+    help="Seconds between Discord status checks while waiting.",
+)
+@with_provider_overrides
+@click.pass_context
+def connect_discord(
+    ctx: click.Context,
+    no_wait: bool,
+    timeout: int,
+    poll_interval: float,
+) -> None:
+    require_hotkey(ctx, group="config")
+    client = build_client(ctx)
+    try:
+        authorization_url = client.create_discord_oauth_authorization_url()
+        browser_opened = _open_authorization_url(authorization_url)
+        discord_connected = _wait_for_discord_connection(
+            client,
+            no_wait=no_wait,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+    except ProviderError as e:
+        ctx.exit(handle_provider_error(ctx, e))
+        return
+
+    next_action = (
+        "discord_connected"
+        if discord_connected is True
+        else "open_authorization_url_and_complete_discord_oauth"
+    )
+    json_payload = {
+        "authorization_url": authorization_url,
+        "browser_opened": bool(browser_opened),
+        "discord_connected": discord_connected,
+        "extra_incentive_eligible": discord_connected
+        if discord_connected is not None
+        else None,
+        "next_action": next_action,
+    }
+    if _json_mode(ctx):
+        render(
+            ctx,
+            json_payload,
+            warnings=discord_incentive_warnings(discord_connected),
+        )
+        return
+
+    human_payload = {
+        "discord_connected": discord_connected,
+        "extra_incentive_eligible": discord_connected
+        if discord_connected is not None
+        else None,
+        "authorization_url": authorization_url,
+    }
+    if not browser_opened:
+        human_payload["browser_status"] = "Browser did not open automatically."
+
+    summary = (
+        "Discord connected; extra incentives enabled"
+        if discord_connected is True
+        else "Discord is not connected yet. Complete authorization using the URL below."
+    )
+    render(
+        ctx,
+        human_payload,
+        summary=summary,
+    )
+
+
+@config_command.command(
     "set-subscriptions",
     short_help="Set machine-request GPU type subscriptions.",
 )
@@ -125,6 +275,42 @@ def set_subscriptions(ctx: click.Context, gpu_types: tuple[str, ...]) -> None:
         body,
         summary=f"subscriptions: [{', '.join(gpu_types) if gpu_types else 'cleared'}]",
     )
+
+
+def _json_mode(ctx: click.Context) -> bool:
+    opts = (ctx.obj or {}).get("provider_opts") or {}
+    return bool(opts.get("json"))
+
+
+def _open_authorization_url(authorization_url: str) -> bool:
+    try:
+        return bool(webbrowser.open(authorization_url))
+    except Exception:
+        return False
+
+
+def _wait_for_discord_connection(
+    client,
+    *,
+    no_wait: bool,
+    timeout: int,
+    poll_interval: float,
+) -> bool | None:
+    if no_wait:
+        return _read_discord_connection(client)
+
+    deadline = time.monotonic() + timeout
+    while True:
+        connected = _read_discord_connection(client)
+        if connected is True:
+            return True
+        if time.monotonic() >= deadline:
+            return connected
+        time.sleep(poll_interval)
+
+
+def _read_discord_connection(client) -> bool | None:
+    return discord_connected_from_profile(client.whoami())
 
 
 __all__ = ["config_command"]

--- a/lium/cli/provider/portal.py
+++ b/lium/cli/provider/portal.py
@@ -6,7 +6,12 @@ import click
 
 from lium.cli.provider._client import build_client
 from lium.cli.provider._overrides import with_provider_overrides
-from lium.cli.provider._render import emit_error, render
+from lium.cli.provider._render import (
+    discord_incentive_warnings,
+    emit_error,
+    render,
+)
+from lium.provider.client import discord_connected_from_profile
 from lium.provider.errors import ARG_INVALID, ProviderError
 
 
@@ -43,6 +48,13 @@ def login(ctx: click.Context, force: bool) -> None:
         ctx.exit(emit_error(ctx, e))
         return
 
+    discord_connected: bool | None = None
+    try:
+        discord_connected = discord_connected_from_profile(client.whoami())
+    except ProviderError:
+        if response.provider.discord_id is not None:
+            discord_connected = bool(response.provider.discord_id)
+
     summary = f"logged in as provider_id={response.provider.id} (hotkey {response.provider.miner_hotkey})"
     render(
         ctx,
@@ -50,8 +62,13 @@ def login(ctx: click.Context, force: bool) -> None:
             "provider_id": response.provider.id,
             "hotkey": response.provider.miner_hotkey,
             "token_present": bool(response.token),
+            "discord_connected": discord_connected,
+            "extra_incentive_eligible": discord_connected
+            if discord_connected is not None
+            else None,
         },
         summary=summary,
+        warnings=discord_incentive_warnings(discord_connected),
     )
 
 

--- a/lium/cli/provider/status.py
+++ b/lium/cli/provider/status.py
@@ -56,6 +56,12 @@ def status_command(ctx: click.Context, netuid: int) -> None:
         else "registered=unknown"
     )
     summary_parts.append(f"portal={'active' if snapshot.portal_session_active else 'down'}")
+    if snapshot.discord_connected is not None:
+        summary_parts.append(f"discord_connected={snapshot.discord_connected}")
+    if snapshot.extra_incentive_eligible is not None:
+        summary_parts.append(
+            f"extra_incentive_eligible={snapshot.extra_incentive_eligible}"
+        )
     summary_parts.append(f"nodes={snapshot.node_count or 0}")
     summary_parts.append(f"weights={len(snapshot.validator_weights)}")
     summary = "provider status: " + ", ".join(summary_parts)

--- a/lium/provider/_routes.py
+++ b/lium/provider/_routes.py
@@ -13,8 +13,10 @@ executor). Re-add only when a corresponding portal route is re-enabled.
 LOGIN_FLEXIBLE = "/auth/login-flexible"
 LOGOUT = "/auth/logout"
 ME = "/auth/me"
+DISCORD_OAUTH_URL = "/auth/me/discord/oauth-url"
 SET_EMAIL = "/auth/set-email"
 SET_MACHINE_REQUEST_SUBSCRIPTION = "/auth/set-machine-request-subscription"
+SET_PASSWORD = "/auth/set-password"
 
 # Provider / miner
 PROVIDER_OPT_IN = "/providers/opt-in"
@@ -54,6 +56,7 @@ ESTIMATED_REWARDS = "/machines/estimated-rewards"
 __all__ = [
     "BILLING",
     "BILLING_BY_MINER",
+    "DISCORD_OAUTH_URL",
     "ESTIMATED_REWARDS",
     "EXECUTOR_BY_ID",
     "EXECUTOR_MACHINE_ADDED",
@@ -73,6 +76,7 @@ __all__ = [
     "PROVIDER_OPT_IN",
     "SET_EMAIL",
     "SET_MACHINE_REQUEST_SUBSCRIPTION",
+    "SET_PASSWORD",
     "SYNC_EXECUTOR_CENTRAL_MINER",
     "SYNC_EXECUTOR_CENTRAL_PROVIDER",
     "SYNC_EXECUTOR_MINER_PORTAL",

--- a/lium/provider/client.py
+++ b/lium/provider/client.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 
 import logging
 import re as _re
+import time
 from typing import Any
 
 from lium.provider._routes import (
     BILLING,
     BILLING_BY_MINER,
+    DISCORD_OAUTH_URL,
     ESTIMATED_REWARDS,
     EXECUTOR_BY_ID,
     EXECUTOR_MACHINE_ADDED,
@@ -40,6 +42,7 @@ from lium.provider._routes import (
     MINER_OPT_IN,
     SET_EMAIL,
     SET_MACHINE_REQUEST_SUBSCRIPTION,
+    SET_PASSWORD,
     SYNC_EXECUTOR_CENTRAL_MINER,
     SYNC_EXECUTOR_MINER_PORTAL,
     UPDATE_GPU,
@@ -64,6 +67,7 @@ from lium.provider.models import (
     SetMachineRequestSubscriptionPayload,
     SetMinGpuCountForRentalPayload,
     SetOptInRequest,
+    SetPasswordPayload,
     UpdateGpuPayload,
     UpdatePricePayload,
     ValidatorWeight,
@@ -230,11 +234,22 @@ class ProviderClient:
         try:
             me_body = self.whoami()
             out.portal_session_active = True
+            out.discord_connected = discord_connected_from_profile(me_body)
+            if out.discord_connected is not None:
+                out.extra_incentive_eligible = out.discord_connected
+                if not out.discord_connected:
+                    warnings.append(
+                        "discord: not connected; extra incentives are disabled"
+                    )
             # /auth/me returns a flat dict: {provider_id, miner_hotkey, ...}.
             # Older / alternate shapes (nested {provider: {id: ...}}) are also
             # accepted so unit fixtures and any future portal rev land cleanly.
             if isinstance(me_body, dict):
-                provider_id = me_body.get("provider_id") or me_body.get("id")
+                provider_id = (
+                    me_body.get("provider_id")
+                    or me_body.get("miner_id")
+                    or me_body.get("id")
+                )
                 if not provider_id:
                     nested = me_body.get("provider")
                     if isinstance(nested, dict):
@@ -307,6 +322,41 @@ class ProviderClient:
         """
         payload = _build_payload(SetEmailPayload, email=email)
         return self._http.post(SET_EMAIL, json_body=payload)
+
+    def set_password(
+        self, new_password: str, *, wait_for_fresh_timestamp: bool = True
+    ) -> dict[str, Any]:
+        """``POST /auth/set-password`` using fresh hotkey signature auth.
+
+        The backend replay guard keys nonces by ``(hotkey, timestamp)``.
+        Waiting for a new second avoids flakiness when automation calls
+        ``portal login`` and ``config set-password`` back-to-back.
+        """
+        if wait_for_fresh_timestamp:
+            _wait_until_next_timestamp_second()
+        payload = {
+            **build_login_payload(self.signer),
+            "new_password": new_password,
+        }
+        return self._http.post(
+            SET_PASSWORD,
+            json_body=_build_payload(SetPasswordPayload, **payload),
+            auth=False,
+        )
+
+    def create_discord_oauth_authorization_url(self) -> str:
+        """``GET /auth/me/discord/oauth-url`` and return the OAuth URL."""
+        body = self._http.get(DISCORD_OAUTH_URL)
+        authorization_url = (
+            body.get("authorization_url") if isinstance(body, dict) else None
+        )
+        if not isinstance(authorization_url, str) or not authorization_url:
+            raise ProviderError(
+                "portal returned an unexpected Discord OAuth URL response shape",
+                code="PORTAL_CONTRACT_DRIFT",
+                context={"body": _summarise_body(body)},
+            )
+        return authorization_url
 
     def set_machine_request_subscription(self, gpu_types: list[str]) -> dict[str, Any]:
         """``POST /auth/set-machine-request-subscription``.
@@ -665,6 +715,33 @@ def _summarise_body(body: Any, *, max_chars: int = 240) -> str:
     return text if len(text) <= max_chars else text[:max_chars] + "..."
 
 
+def discord_connected_from_profile(profile: dict[str, Any] | None) -> bool | None:
+    """Return Discord connection state from a portal profile body.
+
+    ``None`` means the field was unavailable, which is different from a
+    known disconnected provider where ``discord_id`` is present but empty.
+    """
+    if not isinstance(profile, dict) or "discord_id" not in profile:
+        return None
+    return bool(profile.get("discord_id"))
+
+
+def with_discord_eligibility(profile: dict[str, Any]) -> dict[str, Any]:
+    """Copy a profile dict and add Discord incentive readiness fields."""
+    enriched = dict(profile)
+    connected = discord_connected_from_profile(enriched)
+    enriched["discord_connected"] = connected
+    enriched["extra_incentive_eligible"] = connected if connected is not None else None
+    return enriched
+
+
+def _wait_until_next_timestamp_second() -> None:
+    """Wait until ``int(time.time())`` advances at least once."""
+    start = int(time.time())
+    while int(time.time()) <= start:
+        time.sleep(0.05)
+
+
 def _read_metagraph(
     *,
     hotkey_ss58: str | None,
@@ -718,4 +795,8 @@ def _read_metagraph(
     return True, rows
 
 
-__all__ = ["ProviderClient"]
+__all__ = [
+    "ProviderClient",
+    "discord_connected_from_profile",
+    "with_discord_eligibility",
+]

--- a/lium/provider/models.py
+++ b/lium/provider/models.py
@@ -35,6 +35,7 @@ class SafeProviderResponse(BaseModel):
     miner_hotkey: str
     provider_coldkey: str = Field(alias="miner_coldkey")
     email: str | None = None
+    discord_id: str | None = None
     machine_request_subscription: list[str] = Field(default_factory=list)
     created_at: str
     updated_at: str
@@ -64,6 +65,12 @@ class ProviderCredentials(BaseModel):
     miner_hotkey: str
     message: str
     signature: str
+
+
+class SetPasswordPayload(ProviderCredentials):
+    """Wire payload for ``POST /auth/set-password``."""
+
+    new_password: str = Field(min_length=8, max_length=128)
 
 
 # --- Executors ----------------------------------------------------------
@@ -191,6 +198,8 @@ class ProviderStatus(BaseModel):
     netuid: int | None = None
     portal_session_active: bool | None = None
     provider_id: str | None = None
+    discord_connected: bool | None = None
+    extra_incentive_eligible: bool | None = None
     node_count: int | None = None
     nodes: list[ExecutorInfo] = Field(default_factory=list)
     validator_weights: list[ValidatorWeight] = Field(default_factory=list)

--- a/test/provider/test_cli_config.py
+++ b/test/provider/test_cli_config.py
@@ -25,6 +25,8 @@ class _Portal:
 
     def get(self, path, *, params=None, auth=True):
         self.gets.append((path, params, auth))
+        if isinstance(self._get_body, dict) and path in self._get_body:
+            return self._get_body[path]
         return self._get_body or {}
 
     def post(self, path, *, json_body=None, auth=True):
@@ -74,6 +76,55 @@ def test_config_show(patched_build_client) -> None:
         ["--hotkey", "hk1", "config", "show"],
     )
     assert result.exit_code == 0, result.output
+
+
+def test_config_show_json_adds_discord_eligibility(patched_build_client) -> None:
+    portal = _Portal(
+        get_body={
+            "miner_hotkey": "5Foo",
+            "miner_uid": 7,
+            "discord_id": None,
+        }
+    )
+    patched_build_client(portal)
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_command,
+        ["--hotkey", "hk1", "--json", "config", "show"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip())
+    assert payload["data"]["discord_connected"] is False
+    assert payload["data"]["extra_incentive_eligible"] is False
+    assert payload["warnings"] == [
+        {
+            "code": "DISCORD_REQUIRED_FOR_EXTRA_INCENTIVES",
+            "message": "Discord is not connected. No Discord = no extra incentives. Run `lium provider config connect-discord` to become eligible.",
+        }
+    ]
+
+
+def test_config_show_human_renders_discord_hint_inline(patched_build_client) -> None:
+    portal = _Portal(
+        get_body={
+            "miner_hotkey": "5Foo",
+            "miner_uid": 7,
+            "discord_id": None,
+        }
+    )
+    patched_build_client(portal)
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_command,
+        ["--hotkey", "hk1", "config", "show"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Discord Connected" in result.output
+    assert "Extra Incentives" in result.output
+    assert "No Discord = no extra incentives" in result.output
+    assert "lium provider config connect-discord" in result.output
+    assert "Extra Incentive Eligible" not in result.output
+    assert "DISCORD_REQUIRED_FOR_EXTRA_INCENTIVES" not in result.output
 
 
 def test_config_opt_in_renders_central_endpoints(patched_build_client) -> None:
@@ -158,6 +209,135 @@ def test_config_set_email_rejects_invalid(patched_build_client) -> None:
     )
     assert result.exit_code != 0, result.output
     assert portal.posts == []
+
+
+def test_config_set_password_posts_signature_payload(
+    patched_build_client, monkeypatch
+) -> None:
+    portal = _Portal(post_body={"message": "Password set successfully"})
+    patched_build_client(portal)
+    monkeypatch.setattr(
+        "lium.provider.client._wait_until_next_timestamp_second",
+        lambda: None,
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_command,
+        [
+            "--hotkey",
+            "hk1",
+            "--json",
+            "config",
+            "set-password",
+            "--password",
+            "change-me-8+",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    path, payload, auth = portal.posts[0]
+    assert path == "/auth/set-password"
+    assert auth is False
+    assert payload["new_password"] == "change-me-8+"
+    assert payload["message"].isdigit()
+
+
+def test_config_set_password_json_requires_password(patched_build_client) -> None:
+    portal = _Portal(post_body={"data": {}})
+    patched_build_client(portal)
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_command,
+        ["--hotkey", "hk1", "--json", "config", "set-password"],
+    )
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output.strip())
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "ARG_INVALID"
+    assert portal.posts == []
+
+
+def test_config_connect_discord_no_wait_json(patched_build_client, monkeypatch) -> None:
+    portal = _Portal(
+        get_body={
+            "/auth/me/discord/oauth-url": {
+                "authorization_url": "https://discord.com/oauth2/authorize?x=1"
+            },
+            "/auth/me": {"discord_id": None},
+        }
+    )
+    patched_build_client(portal)
+    monkeypatch.setattr(
+        "lium.cli.provider.config._open_authorization_url",
+        lambda url: False,
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_command,
+        [
+            "--hotkey",
+            "hk1",
+            "--json",
+            "config",
+            "connect-discord",
+            "--no-wait",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip())
+    assert payload["data"] == {
+        "authorization_url": "https://discord.com/oauth2/authorize?x=1",
+        "browser_opened": False,
+        "discord_connected": False,
+        "extra_incentive_eligible": False,
+        "next_action": "open_authorization_url_and_complete_discord_oauth",
+    }
+    assert payload["warnings"] == [
+        {
+            "code": "DISCORD_REQUIRED_FOR_EXTRA_INCENTIVES",
+            "message": "Discord is not connected. No Discord = no extra incentives. Run `lium provider config connect-discord` to become eligible.",
+        }
+    ]
+    assert [call[0] for call in portal.gets] == [
+        "/auth/me/discord/oauth-url",
+        "/auth/me",
+    ]
+
+
+def test_config_connect_discord_no_wait_human_omits_agent_fields(
+    patched_build_client, monkeypatch
+) -> None:
+    portal = _Portal(
+        get_body={
+            "/auth/me/discord/oauth-url": {
+                "authorization_url": "https://discord.com/oauth2/authorize?x=1"
+            },
+            "/auth/me": {"discord_id": None},
+        }
+    )
+    patched_build_client(portal)
+    monkeypatch.setattr(
+        "lium.cli.provider.config._open_authorization_url",
+        lambda url: False,
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_command,
+        [
+            "--hotkey",
+            "hk1",
+            "config",
+            "connect-discord",
+            "--no-wait",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.count("https://discord.com/oauth2/authorize?x=1") == 1
+    assert "Next Action" not in result.output
+    assert "open_authorization_url_and_complete_discord_oauth" not in result.output
+    assert "Discord Connected" in result.output
+    assert "Extra Incentives" in result.output
+    assert "No Discord = no extra incentives" in result.output
+    assert "Browser Status" in result.output
 
 
 def test_config_set_subscriptions_multiple(patched_build_client) -> None:

--- a/test/provider/test_cli_portal.py
+++ b/test/provider/test_cli_portal.py
@@ -113,11 +113,13 @@ def test_portal_login_json_envelope(patched_build_client, fake_signer) -> None:
                 "id": "m-7",
                 "miner_hotkey": fake_signer.ss58_address,
                 "provider_coldkey": "5CK",
+                "discord_id": "5477543105",
                 "created_at": "x",
                 "updated_at": "x",
             },
             "token": _make_jwt(int(time.time()) + 3600),
-        }
+        },
+        get_body={"discord_id": "5477543105"},
     )
     patched_build_client(portal)
 
@@ -130,6 +132,83 @@ def test_portal_login_json_envelope(patched_build_client, fake_signer) -> None:
     payload = json.loads(result.output.strip())
     assert payload["ok"] is True
     assert payload["data"]["provider_id"] == "m-7"
+    assert payload["data"]["discord_connected"] is True
+    assert payload["data"]["extra_incentive_eligible"] is True
+
+
+def test_portal_login_warns_when_discord_missing(
+    patched_build_client, fake_signer
+) -> None:
+    portal = _Portal(
+        post_body={
+            "provider": {
+                "id": "m-7",
+                "miner_hotkey": fake_signer.ss58_address,
+                "provider_coldkey": "5CK",
+                "discord_id": None,
+                "created_at": "x",
+                "updated_at": "x",
+            },
+            "token": _make_jwt(int(time.time()) + 3600),
+        },
+        get_body={"discord_id": None},
+    )
+    patched_build_client(portal)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_command,
+        ["--hotkey", "hk1", "portal", "login"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Token Present" in result.output
+    assert "Discord Connected" in result.output
+    assert "Extra Incentives" in result.output
+    assert (
+        result.output.index("Token Present")
+        < result.output.index("Discord Connected")
+        < result.output.index("Extra Incentives")
+    )
+    assert "No Discord = no extra incentives" in result.output
+    assert "lium provider config connect-discord" in result.output
+    assert "Extra Incentive Eligible" not in result.output
+    assert "DISCORD_REQUIRED_FOR_EXTRA_INCENTIVES" not in result.output
+
+
+def test_portal_login_json_warns_when_discord_missing(
+    patched_build_client, fake_signer
+) -> None:
+    portal = _Portal(
+        post_body={
+            "provider": {
+                "id": "m-7",
+                "miner_hotkey": fake_signer.ss58_address,
+                "provider_coldkey": "5CK",
+                "discord_id": None,
+                "created_at": "x",
+                "updated_at": "x",
+            },
+            "token": _make_jwt(int(time.time()) + 3600),
+        },
+        get_body={"discord_id": None},
+    )
+    patched_build_client(portal)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_command,
+        ["--hotkey", "hk1", "--json", "portal", "login"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip())
+    assert payload["data"]["discord_connected"] is False
+    assert payload["data"]["extra_incentive_eligible"] is False
+    assert payload["warnings"] == [
+        {
+            "code": "DISCORD_REQUIRED_FOR_EXTRA_INCENTIVES",
+            "message": "Discord is not connected. No Discord = no extra incentives. Run `lium provider config connect-discord` to become eligible.",
+        }
+    ]
 
 
 def test_portal_login_auth_error_returns_exit_2(patched_build_client) -> None:

--- a/test/provider/test_client_extended.py
+++ b/test/provider/test_client_extended.py
@@ -69,6 +69,39 @@ def test_set_email_posts_payload(client) -> None:
     assert portal.posts[0] == ("/auth/set-email", {"email": "a@b.co"}, True)
 
 
+def test_set_password_posts_signature_payload(client) -> None:
+    portal = _Portal(post_body={"message": "Password set successfully"})
+    c = client(portal)
+    c.set_password("change-me-8+", wait_for_fresh_timestamp=False)
+    path, payload, auth = portal.posts[0]
+    assert path == "/auth/set-password"
+    assert auth is False
+    assert payload["miner_hotkey"] == c.hotkey_ss58
+    assert payload["new_password"] == "change-me-8+"
+    assert payload["message"].isdigit()
+    assert payload["signature"]
+
+
+def test_create_discord_oauth_authorization_url(client) -> None:
+    portal = _Portal(
+        get_body={"authorization_url": "https://discord.com/oauth2/authorize?x=1"}
+    )
+    c = client(portal)
+    assert (
+        c.create_discord_oauth_authorization_url()
+        == "https://discord.com/oauth2/authorize?x=1"
+    )
+    assert portal.gets[0] == ("/auth/me/discord/oauth-url", None, True)
+
+
+def test_create_discord_oauth_authorization_url_rejects_drift(client) -> None:
+    portal = _Portal(get_body={"unexpected": "shape"})
+    c = client(portal)
+    with pytest.raises(ProviderError) as exc_info:
+        c.create_discord_oauth_authorization_url()
+    assert exc_info.value.code == "PORTAL_CONTRACT_DRIFT"
+
+
 def test_set_machine_request_subscription(client) -> None:
     portal = _Portal(post_body={"data": {}})
     c = client(portal)
@@ -341,5 +374,4 @@ def test_path_segment_validators_reject_unsafe_inputs(
         method(*args)
     assert exc_info.value.code == "ARG_INVALID"
     assert portal.gets == [] and portal.posts == [] and portal.deletes == []
-
 

--- a/test/provider/test_status.py
+++ b/test/provider/test_status.py
@@ -118,6 +118,45 @@ def test_status_extracts_provider_id_from_flat_whoami_shape(
     assert snapshot.provider_id == "flat-1"
 
 
+def test_status_surfaces_discord_incentive_eligibility(
+    fake_signer: LocalKeypairSigner, tmp_token_store: TokenStore
+) -> None:
+    portal = _Portal(
+        me_body={
+            "miner_id": "m-1",
+            "miner_hotkey": fake_signer.ss58_address,
+            "discord_id": "5477543105",
+        },
+        executors=[],
+    )
+    metagraph = _stub_metagraph_factory(hotkeys=[], weights=[])
+    client = _client(portal, tmp_token_store, fake_signer)
+    snapshot = client.status(metagraph_factory=metagraph)
+    assert snapshot.provider_id == "m-1"
+    assert snapshot.discord_connected is True
+    assert snapshot.extra_incentive_eligible is True
+    assert not any(w.startswith("discord:") for w in snapshot.warnings)
+
+
+def test_status_warns_when_discord_missing(
+    fake_signer: LocalKeypairSigner, tmp_token_store: TokenStore
+) -> None:
+    portal = _Portal(
+        me_body={
+            "miner_id": "m-1",
+            "miner_hotkey": fake_signer.ss58_address,
+            "discord_id": None,
+        },
+        executors=[],
+    )
+    metagraph = _stub_metagraph_factory(hotkeys=[], weights=[])
+    client = _client(portal, tmp_token_store, fake_signer)
+    snapshot = client.status(metagraph_factory=metagraph)
+    assert snapshot.discord_connected is False
+    assert snapshot.extra_incentive_eligible is False
+    assert "discord: not connected; extra incentives are disabled" in snapshot.warnings
+
+
 def test_status_degrades_when_whoami_fails(
     fake_signer: LocalKeypairSigner, tmp_token_store: TokenStore
 ) -> None:


### PR DESCRIPTION
## Summary

- Add provider Discord eligibility fields to login, config, and status flows.
- Add `lium provider config set-password` and `lium provider config connect-discord` for browserless/provider-agent onboarding.
- Surface missing Discord as structured JSON warnings for agents, while keeping human output focused on the extra incentives next step.

## Why

Providers and agents need a clear path from first portal signup to Discord linking now that Discord is required for extra incentives.

## Testing

- `uv run pytest test/provider/test_cli_portal.py test/provider/test_cli_config.py test/provider/test_client_extended.py test/provider/test_status.py test/provider/test_cli_status.py`
- `git diff --check`