### PR TITLE
DAH-2245, show spot/secure tier per node in lium ls

### DIFF
--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -41,6 +41,17 @@ def _money(v: Optional[float]) -> str:
     return f"{v:>6.2f}" if v is not None else "—"
 
 
+def _tier_display(exe: ExecutorInfo) -> str:
+    """Render tier with a risk-signalling colour: spot (reclaimable, no fee withheld)
+    in warning, secure in success, unknown as a dash."""
+    tier = (exe.tier or "").strip().lower()
+    if tier == "spot":
+        return console.get_styled("spot", "warning")
+    if tier == "secure":
+        return console.get_styled("secure", "success")
+    return "—"
+
+
 def _intish(x: Any) -> Optional[int]:
     """Convert to int safely."""
     try:
@@ -122,6 +133,7 @@ def _add_table_columns(t: Table) -> None:
     t.add_column("", justify="right", width=3, no_wrap=True, style="dim")
     t.add_column("Id", justify="left", ratio=8, min_width=24, overflow="fold")
     t.add_column("Config", justify="left", width=12, no_wrap=True)
+    t.add_column("Tier", justify="left", width=8, no_wrap=True)
     t.add_column("Max CUDA", justify="right", width=10, no_wrap=True)
     t.add_column("$/GPU·h", justify="right", width=8, no_wrap=True)
     t.add_column("Location", justify="left", ratio=4, min_width=10, overflow="fold")
@@ -168,6 +180,7 @@ def compact_executor(exe: ExecutorInfo, is_pareto: bool, index: int) -> Dict[str
         "docker_in_docker": exe.docker_in_docker,
         "is_pareto": is_pareto,
         "max_cuda_version": exe.max_cuda_version,
+        "tier": exe.tier,
     }
 
 
@@ -247,6 +260,7 @@ def build_executors_table(
             str(idx),
             huid_display,
             _cfg(exe),
+            _tier_display(exe),
             cuda_display,
             console.get_styled(_money(exe.price_per_gpu), 'success'),
             _country_name(exe.location),

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -216,6 +216,7 @@ class Lium:
             effective_upload_speed_mbps=executor_dict.get("effective_upload_speed_mbps"),
             effective_download_speed_mbps=executor_dict.get("effective_download_speed_mbps"),
             max_cuda_version=executor_dict.get("max_cuda_version"),
+            tier=executor_dict.get("tier"),
         )
 
     def list_ssh_keys(self) -> List[SSHKey]:

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -23,6 +23,7 @@ class ExecutorInfo:
     effective_upload_speed_mbps: Optional[float] = None
     effective_download_speed_mbps: Optional[float] = None
     max_cuda_version: Optional[float] = None
+    tier: Optional[str] = None  # "spot" or "secure"; reclaim/penalty risk signal
 
     @property
     def driver_version(self) -> str:

--- a/test/test_ls_tier.py
+++ b/test/test_ls_tier.py
@@ -1,0 +1,69 @@
+"""Tests for spot/secure tier surfacing in ``lium ls`` (SDK mapping + display)."""
+
+from __future__ import annotations
+
+from lium.sdk import Config, Lium
+from lium.cli.ls import display
+
+
+def _make_executor_dict(executor_id: str, tier) -> dict:
+    """Minimal executor dict as returned by the /executors endpoint."""
+    return {
+        "id": executor_id,
+        "machine_name": "NVIDIA H100 SXM 8x",
+        "executor_ip_address": "1.2.3.4",
+        "price_per_gpu": 2.5,
+        "status": "available",
+        "location": {"country": "US"},
+        "specs": {
+            "gpu": {
+                "count": 8,
+                "details": [{"name": "H100", "capacity": 81920, "pcie_speed": 16}],
+                "driver": "535.104.05",
+            },
+            "ram": {"total": 2097152},
+            "hard_disk": {"total": 10485760},
+            "sysbox_runtime": False,
+        },
+        "tier": tier,
+    }
+
+
+def _map(executor_dict: dict):
+    """Run the executor dict through the SDK mapping layer."""
+    client = Lium(Config(api_key="test-key"))
+    return client._dict_to_executor_info(executor_dict)
+
+
+def test_dict_to_executor_info_maps_tier():
+    """Tier from the API payload is carried onto ExecutorInfo."""
+    assert _map(_make_executor_dict("e1", "spot")).tier == "spot"
+    assert _map(_make_executor_dict("e2", "secure")).tier == "secure"
+
+
+def test_dict_to_executor_info_tier_absent_is_none():
+    """Missing tier key maps to None (no crash, no assumed value)."""
+    d = _make_executor_dict("e3", None)
+    del d["tier"]
+    assert _map(d).tier is None
+
+
+def test_tier_display_renders_spot_and_secure():
+    """_tier_display surfaces the tier word; unknown renders as a dash."""
+    assert "spot" in display._tier_display(_map(_make_executor_dict("e1", "spot")))
+    assert "secure" in display._tier_display(_map(_make_executor_dict("e2", "secure")))
+    assert display._tier_display(_map(_make_executor_dict("e3", None))) == "—"
+
+
+def test_table_has_tier_column():
+    """The ls table exposes a Tier column."""
+    executors = [_map(_make_executor_dict("e1", "spot"))]
+    table, *_ = display.build_executors_table(executors, show_pareto=False)
+    headers = [c.header for c in table.columns]
+    assert "Tier" in headers
+
+
+def test_compact_executor_includes_tier():
+    """JSON view (lium ls --output json) exposes tier for agents."""
+    exe = _map(_make_executor_dict("e1", "spot"))
+    assert display.compact_executor(exe, is_pareto=False, index=1)["tier"] == "spot"


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2245](https://app.notion.com/p/Show-spot-secure-tier-per-node-in-lium-CLI-SDK-lium-ls-387b8bfdbde98198a718ddc4d9547702)

---

## Problem

`GET /api/executors` already returns each node's `tier` (`spot` / `secure`), but `lium ls` dropped it: `ExecutorInfo` had no `tier` field and the SDK mapper never read it, so the column was absent from both the table and the JSON output.

As a result renters and AI agents can't judge reclaim/penalty risk before renting. Secure nodes withhold 48h of rental fees on reclaim; spot nodes don't — but this risk signal was invisible. (Reported by renter "Max" in Discord, 21 Jun 2026: GPU reclaimed mid-run, agent "didn't find any tags related to spot or secure".)

CLI-only fix — no backend/data change needed.

## Solution

Carry the existing API `tier` field through all three layers: SDK model → mapper → display.

## Changes

- `lium/sdk/models.py` — add optional `tier: Optional[str]` to `ExecutorInfo`.
- `lium/sdk/client.py` — map `tier=executor_dict.get("tier")` in `_dict_to_executor_info()`.
- `lium/cli/ls/display.py` — new `Tier` column in `build_executors_table()` (`spot` highlighted as warning, `secure` as success, unknown as `—`), plus `tier` added to `compact_executor()` so `lium ls --output json` exposes it for agents.
- `test/test_ls_tier.py` — tests for mapping, display rendering, table column, and JSON field.

> Note: the task's plan also mentioned mirroring `tier` in the standalone `lium-sdk` repo. That repo is now a deprecated redirect stub (`v0.0.x` → `lium.io`) with no source, so there is nothing to mirror — the SDK lives in this repo.

## Deployment Steps

Use GitHub Action (`release.yml`). Requires a version bump in `pyproject.toml` + `lium/__about__.py` before release — not included in this PR.

## Review Request

- [x] Just code review

## Other PRs

None.

## Risks

- Low. Additive change: a new optional field (default `None`) and one extra table column. No existing call site or response contract changes.
- Table width grows by one column (~8 chars); could affect very narrow terminals.

## Test Cases

### Test Case 1 — tier surfaced in table

**Actions**: run `lium ls` against an environment with both spot and secure nodes.
**Expected Output**: a `Tier` column showing `spot` / `secure`, matching the `tier` field in `/api/executors`.

### Test Case 2 — JSON output (agent path)

**Actions**: `lium ls --output json | jq '.[].tier'`
**Expected Output**: each node object includes a `tier` value.

### Test Case 3 — unit tests

**Actions**: `pytest test/test_ls_tier.py`
**Expected Output**: 5 passing tests (mapping, spot/secure/unknown rendering, table column, JSON field).

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
