### PR TITLE
chore: bump version to 0.0.24

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.23"
+__version__ = "0.0.24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.23"
+version = "0.0.24"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1236,7 +1236,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.23"
+version = "0.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bump version `0.0.23` → `0.0.24` to enable a new release.

`v0.0.23` is already published (PyPI + GitHub release), so a release run must target a fresh version. This bumps all three places the release workflow validates/uses:

- `pyproject.toml` — `version`
- `lium/__about__.py` — `__version__`
- `uv.lock` — pinned `lium-io` version (kept in sync so `uv sync --frozen` in the macOS binary build does not fail)

## Why

The release workflow (`release.yml`) validates that the requested version matches `pyproject.toml` and `lium/__about__.py`, and PyPI refuses to overwrite an existing version. Required before running `release.yml` for 0.0.24 (which ships DAH-2245 — spot/secure tier in `lium ls`).

## Changes

- Version `0.0.23` → `0.0.24` in `pyproject.toml`, `lium/__about__.py`, `uv.lock`.

## Deployment Steps

After merge: run the **Build and Publish Python Package** workflow with `version=0.0.24`, `release_mode=full-release`.

## Risks

- None. Version-string-only change.

## Test Cases

- `uv lock` regenerates cleanly with only the version line changed (verified).
