### PR TITLE
feat(DAH-2254): surface GPU splitting in lium CLI/SDK

### DIFF
--- a/lium/cli/ls/actions.py
+++ b/lium/cli/ls/actions.py
@@ -26,6 +26,7 @@ class GetExecutorsAction:
                 lon=lon,
                 max_distance_miles=max_distance,
                 min_cuda_version=min_cuda_version,
+                widen_for_splitting=True,
             )
             return ActionResult(
                 ok=True,

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -36,7 +36,7 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download")
 
 @click.command("ls")
 @click.option("--gpu", "gpu_type", shell_complete=get_gpu_completions, help="Filter by GPU type, e.g. A100")
-@click.option("--count", "gpu_count", type=int, help="Exact GPU count to match (e.g., 1, 8)")
+@click.option("--count", "gpu_count", type=int, help="Renter-intent GPU count (widens to splittable nodes where min <= N <= available)")
 @click.option("--min-cuda", "min_cuda_version", type=float, help="Minimum CUDA version, e.g. 12.4 (NVIDIA drivers are backward compatible)")
 @click.option("--lat", type=float, help="Latitude for distance filtering")
 @click.option("--lon", type=float, help="Longitude for distance filtering")

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -22,7 +22,10 @@ def _mid_ellipsize(s: str, width: int = 28) -> str:
 
 def _cfg(exe: ExecutorInfo) -> str:
     """Format GPU configuration string."""
-    return f"{exe.gpu_count}×{exe.gpu_type}"
+    base = f"{exe.gpu_count}×{exe.gpu_type}"
+    if exe.min_gpu_count_for_rental is not None:
+        base += f" ↯ from {exe.min_gpu_count_for_rental}"
+    return base
 
 
 def _country_name(loc: Optional[Dict]) -> str:
@@ -181,6 +184,7 @@ def compact_executor(exe: ExecutorInfo, is_pareto: bool, index: int) -> Dict[str
         "is_pareto": is_pareto,
         "max_cuda_version": exe.max_cuda_version,
         "tier": exe.tier,
+        "min_gpu_count_for_rental": exe.min_gpu_count_for_rental,
     }
 
 

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -72,6 +72,21 @@ class AlphaQuote:
     netuid: int            # the API's ``netuid`` — drives the transfer
 
 
+def _is_splittable_for_count(ex: "ExecutorInfo", wanted: int) -> bool:
+    """Return True if *ex* is a splittable node that can serve *wanted* GPUs.
+
+    PREDICATE PARITY: must match matchesGpuCountFilter in
+    lium-io-frontend/src/contexts/PodFiltersProvider.tsx.  Shared fixture:
+    lium/test/fixtures/splittable_executors.json mirrored in
+    lium-io-frontend/src/contexts/__fixtures__/splittable-executors.json.
+    """
+    minc = ex.min_gpu_count_for_rental  # None-safe per CLAUDE.md
+    avail = ex.available_gpu_count
+    if minc is None or avail is None:
+        return False
+    return minc <= wanted <= avail
+
+
 # Main SDK Class
 class Lium:
     """Clean Unix-style SDK for Lium."""
@@ -217,6 +232,8 @@ class Lium:
             effective_download_speed_mbps=executor_dict.get("effective_download_speed_mbps"),
             max_cuda_version=executor_dict.get("max_cuda_version"),
             tier=executor_dict.get("tier"),
+            min_gpu_count_for_rental=executor_dict.get("min_gpu_count_for_rental"),
+            available_gpu_count=executor_dict.get("available_gpu_count"),
         )
 
     def list_ssh_keys(self) -> List[SSHKey]:
@@ -486,6 +503,7 @@ class Lium:
         lon: Optional[float] = None,
         max_distance_miles: Optional[int] = None,
         min_cuda_version: Optional[float] = None,
+        widen_for_splitting: bool = False,
     ) -> List[ExecutorInfo]:
         """List available nodes.
 
@@ -498,6 +516,9 @@ class Lium:
             min_cuda_version: Optional minimum CUDA version to require (e.g. ``12.4``). Nodes whose
                 ``max_cuda_version`` is ``None`` or below this threshold are excluded. NVIDIA drivers are
                 backward compatible, so a node with a higher driver CUDA version satisfies the requirement.
+            widen_for_splitting: When ``True`` and ``gpu_count`` is set, also include splittable nodes
+                where ``min_gpu_count_for_rental <= gpu_count <= available_gpu_count``.  Defaults to
+                ``False`` so all existing callers (including ``@machine``) retain strict equality semantics.
 
         Returns:
             A list of :class:`ExecutorInfo` objects that satisfy the filters.
@@ -512,8 +533,12 @@ class Lium:
                 # If no match found, use the input as-is (might be already a full name)
                 params["machine_names"] = gpu_type
         if gpu_count:
-            params["gpu_count_gte"] = gpu_count
-            params["gpu_count_lte"] = gpu_count
+            # When widening for splitting we omit the server-side gpu_count_gte/lte so the
+            # backend returns the full candidate set; client-side filtering below selects
+            # both native-count matches and splittable nodes.
+            if not widen_for_splitting:
+                params["gpu_count_gte"] = gpu_count
+                params["gpu_count_lte"] = gpu_count
         if lat is not None and lon is not None:
             params["lat"] = lat
             params["lon"] = lon
@@ -525,6 +550,15 @@ class Lium:
         data = self._request("GET", "/executors", params=params).json()
         executors = [self._dict_to_executor_info(d) for d in data]
         executors = [e for e in executors if e]  # Filter None values
+
+        if gpu_count is not None:
+            if widen_for_splitting:
+                executors = [
+                    e for e in executors
+                    if e.available_gpu_count == gpu_count or _is_splittable_for_count(e, gpu_count)
+                ]
+            else:
+                executors = [e for e in executors if e.available_gpu_count == gpu_count]
 
         if min_cuda_version is not None:
             executors = [

--- a/lium/sdk/decorators.py
+++ b/lium/sdk/decorators.py
@@ -41,6 +41,12 @@ def machine(
 
             try:
                 # Step 1: Find executor matching machine type
+                # NOTE (DAH-2254): @machine intentionally calls sdk.ls() with no gpu_count
+                # kwarg and filters post-fetch via substring match on executor.machine_name
+                # (see line below). The widen_for_splitting kwarg therefore never fires
+                # from this path — @machine retains strict "exact machine_name substring"
+                # semantics regardless of CLI widen behavior. If you ever add gpu_count=...
+                # to this call, decide explicitly whether widen_for_splitting should be True.
                 executors = sdk.ls()
                 matching_executor = None
                 for executor in executors:

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -24,6 +24,8 @@ class ExecutorInfo:
     effective_download_speed_mbps: Optional[float] = None
     max_cuda_version: Optional[float] = None
     tier: Optional[str] = None  # "spot" or "secure"; reclaim/penalty risk signal
+    min_gpu_count_for_rental: Optional[int] = None
+    available_gpu_count: Optional[int] = None
 
     @property
     def driver_version(self) -> str:

--- a/test/fixtures/splittable_executors.json
+++ b/test/fixtures/splittable_executors.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "exec-split-min1",
+    "huid": "split-min1",
+    "machine_name": "8xH200",
+    "gpu_type": "H200",
+    "gpu_count": 8,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": 1,
+    "price_per_gpu": 2.5,
+    "price_per_hour": 20.0,
+    "status": "available"
+  },
+  {
+    "id": "exec-split-min4",
+    "huid": "split-min4",
+    "machine_name": "8xH200",
+    "gpu_type": "H200",
+    "gpu_count": 8,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": 4,
+    "price_per_gpu": 2.5,
+    "price_per_hour": 20.0,
+    "status": "available"
+  },
+  {
+    "id": "exec-full",
+    "huid": "full",
+    "machine_name": "8xH200",
+    "gpu_type": "H200",
+    "gpu_count": 8,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": null,
+    "price_per_gpu": 2.5,
+    "price_per_hour": 20.0,
+    "status": "available"
+  },
+  {
+    "id": "exec-native1",
+    "huid": "native1",
+    "machine_name": "1xH100",
+    "gpu_type": "H100",
+    "gpu_count": 1,
+    "available_gpu_count": 1,
+    "min_gpu_count_for_rental": null,
+    "price_per_gpu": 3.0,
+    "price_per_hour": 3.0,
+    "status": "available"
+  }
+]

--- a/test/test_client_ls_widen.py
+++ b/test/test_client_ls_widen.py
@@ -1,0 +1,132 @@
+"""Unit tests for ``Lium.ls()`` widen_for_splitting behaviour (DAH-2254)."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import pathlib
+
+from lium.sdk import Config, Lium
+from lium.cli.ls.display import _cfg, compact_executor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIXTURE_PATH = pathlib.Path(__file__).parent / "fixtures" / "splittable_executors.json"
+
+
+def _load_fixture_rows() -> list[dict]:
+    """Load the shared fixture and augment each row with the minimal API fields
+    that ``_dict_to_executor_info`` needs (specs, location, executor_ip_address)."""
+    rows = json.loads(_FIXTURE_PATH.read_text())
+    augmented = []
+    for row in rows:
+        d = dict(row)
+        # Add mandatory API envelope fields that the fixture omits for brevity
+        d.setdefault("executor_ip_address", "1.2.3.4")
+        d.setdefault("location", {"country": "US"})
+        d.setdefault("specs", {
+            "gpu": {
+                "count": d.get("gpu_count", 1),
+                "details": [{"name": d.get("gpu_type", "H200"), "capacity": 81920, "pcie_speed": 16}],
+                "driver": "535.104.05",
+            },
+            "ram": {"total": 2097152},
+            "hard_disk": {"total": 10485760},
+            "sysbox_runtime": False,
+        })
+        d.setdefault("effective_upload_speed_mbps", 500.0)
+        d.setdefault("effective_download_speed_mbps", 1000.0)
+        augmented.append(d)
+    return augmented
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _client_with_fixture(monkeypatch) -> tuple[Lium, list]:
+    """Return a Lium client whose _request always returns the augmented fixture rows."""
+    client = Lium(Config(api_key="test-key"))
+    rows = _load_fixture_rows()
+
+    def fake_request(method, endpoint, **kwargs):
+        return _Response(rows)
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    return client, rows
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_ls_widen_true_includes_splittable(monkeypatch):
+    """widen_for_splitting=True, gpu_count=2: exec-split-min1 included; others excluded."""
+    client, _ = _client_with_fixture(monkeypatch)
+    result = client.ls(gpu_count=2, widen_for_splitting=True)
+    ids = [e.id for e in result]
+
+    assert "exec-split-min1" in ids, f"exec-split-min1 missing from {ids}"
+    assert "exec-split-min4" not in ids, "exec-split-min4 wrongly included (min=4 > 2)"
+    assert "exec-full" not in ids, "exec-full wrongly included (non-splittable, available=8 != 2)"
+    assert "exec-native1" not in ids, "exec-native1 wrongly included (available=1 != 2)"
+
+
+def test_ls_widen_false_excludes_splittable(monkeypatch):
+    """widen_for_splitting=False (default), gpu_count=2: no rows match available_gpu_count==2."""
+    client, _ = _client_with_fixture(monkeypatch)
+    result = client.ls(gpu_count=2, widen_for_splitting=False)
+    ids = [e.id for e in result]
+
+    # None of the fixture rows have available_gpu_count == 2
+    assert ids == [], f"Expected empty list with strict filter, got {ids}"
+
+
+def test_ls_widen_default_is_false():
+    """The default value of widen_for_splitting must be False (Gate D)."""
+    param = inspect.signature(Lium.ls).parameters["widen_for_splitting"]
+    assert param.default is False, (
+        f"widen_for_splitting default must be False, got {param.default!r}"
+    )
+
+
+def test_compact_executor_includes_min_gpu_count_for_rental(monkeypatch):
+    """compact_executor dict must include min_gpu_count_for_rental (CLI-AC #3)."""
+    client, _ = _client_with_fixture(monkeypatch)
+    result = client.ls(widen_for_splitting=False)
+    # Find exec-split-min1 and exec-full
+    by_id = {e.id: e for e in result}
+
+    # exec-split-min1 has min_gpu_count_for_rental=1
+    exe_split = by_id.get("exec-split-min1")
+    assert exe_split is not None, "exec-split-min1 missing from unfiltered ls()"
+    d_split = compact_executor(exe_split, is_pareto=False, index=1)
+    assert "min_gpu_count_for_rental" in d_split, "key missing from compact_executor"
+    assert d_split["min_gpu_count_for_rental"] == 1
+
+    # exec-full has min_gpu_count_for_rental=None
+    exe_full = by_id.get("exec-full")
+    assert exe_full is not None, "exec-full missing from unfiltered ls()"
+    d_full = compact_executor(exe_full, is_pareto=False, index=2)
+    assert "min_gpu_count_for_rental" in d_full
+    assert d_full["min_gpu_count_for_rental"] is None
+
+
+def test_cfg_marker_for_splittable(monkeypatch):
+    """_cfg() appends '↯ from N' for splittable rows; non-splittable rows have no '↯'."""
+    client, _ = _client_with_fixture(monkeypatch)
+    result = client.ls(widen_for_splitting=False)
+    by_id = {e.id: e for e in result}
+
+    exe_split = by_id["exec-split-min1"]
+    assert "↯ from 1" in _cfg(exe_split), f"_cfg output: {_cfg(exe_split)!r}"
+
+    exe_full = by_id["exec-full"]
+    assert "↯" not in _cfg(exe_full), f"_cfg output for non-splittable: {_cfg(exe_full)!r}"


### PR DESCRIPTION
## DAH-2254 — Surface GPU splitting in lium CLI/SDK

### Summary
- `ExecutorInfo` Pydantic model gains `min_gpu_count_for_rental: int | None` and `available_gpu_count: int | None`. Both pre-existing on the backend payload — this PR just deserializes them.
- `Client.ls(widen_for_splitting: bool = False)` — opt-in widen. When True with `gpu_count=N` set, also returns splittable nodes where `min_gpu_count_for_rental ≤ N ≤ available_gpu_count`. Default OFF preserves SDK semver — third-party agent code that calls `Lium().ls(gpu_count=1)` keeps strict semantics.
- `lium ls --count N` (the user-facing CLI) passes `widen_for_splitting=True` so the marketplace UI and the CLI agree.
- `@machine("XxY")` decorator unchanged — it calls `sdk.ls()` with no kwargs at \`decorators.py:49\`, so the widen path never fires. A comment block at \`decorators.py:43-48\` documents this for future editors.
- Rich-table Config column gains `↯ from N` suffix on splittable rows (mirrors the existing `(DinD)` suffix pattern).
- `lium ls --format json` exposes `min_gpu_count_for_rental` so AI-agent consumers can decide programmatically.
- Version bump 0.0.24 → 0.0.25, matched in `pyproject.toml` + `lium/__about__.py` (release workflow cross-checks).

### Files
- `lium/sdk/models.py` — two new optional fields on `ExecutorInfo`
- `lium/sdk/client.py` — `_is_splittable_for_count` predicate helper (reciprocal-parity comment with frontend) + `widen_for_splitting` kwarg + payload deserialization in `_dict_to_executor_info`
- `lium/sdk/decorators.py` — clarifying comment above `sdk.ls()` call
- `lium/cli/ls/actions.py` — CLI passes `widen_for_splitting=True`
- `lium/cli/ls/command.py` — `--count` help text updated
- `lium/cli/ls/display.py` — Rich-table marker + JSON field
- `pyproject.toml`, `lium/__about__.py` — version bump
- `test/fixtures/splittable_executors.json` (new) — shared fixture (byte-identical with frontend repo)
- `test/test_client_ls_widen.py` (new) — 5 tests covering widen=True/False, default-off invariant, JSON field, Rich-table marker

### Acceptance criteria
- [x] CLI-AC #1 — `ExecutorInfo.min_gpu_count_for_rental` + `available_gpu_count` populated from API
- [x] CLI-AC #2 — `lium ls` table marks splittable rows with \`↯ from N\`
- [x] CLI-AC #3 — `lium ls --format json` includes `min_gpu_count_for_rental`
- [x] CLI-AC #4 — `lium ls --count N` widens to splittable; positive test covers widen=True/False
- [x] CLI-AC #5 — `@machine` decorator stays strict (no kwargs to `sdk.ls()`; default-off invariant asserted by `inspect.signature` test)
- [x] CLI-AC #6 — version matched: `pyproject.toml:7` and `lium/__about__.py:3` both at \`0.0.25\`

### Test plan
- [x] \`pytest test/test_client_ls_widen.py\` — 5/5 passing
- [x] \`python3 -c \"import inspect; from lium.sdk.client import Client; assert inspect.signature(Client.ls).parameters['widen_for_splitting'].default is False\"\` — Gate D OK
- [x] Source grep confirms \`widen_for_splitting: bool = False\` at \`lium/sdk/client.py:506\`
- [ ] Manual smoke: \`lium ls\` against staging, verify marker on a known splittable node; `lium ls --count 1` returns native 1xGPU + splittable bigger nodes with min ≤ 1; `lium ls --format json | jq '.[0].min_gpu_count_for_rental'` returns the value.

### Companion PR
Datura-ai/lium-io-frontend#204 — \`feat/2254-gpu-splitting-filter\` surfaces the same signal in the marketplace UI. The frontend's \`matchesGpuCountFilter\` predicate and this PR's \`_is_splittable_for_count\` predicate share a byte-identical JSON fixture; reciprocal code comments at \`PodFiltersProvider.tsx\` and \`client.py\` link them.

### Source artifacts
- Spec: \`.omc/specs/deep-interview-dah-2254-gpu-splitting.md\` (deep-interview final ambiguity 12.5%)
- Plan: \`.omc/plans/dah-2254-gpu-splitting.md\` (Critic-APPROVED consensus, 14/14 ACs traced)

### Notes for reviewer
- `Client.ls()` default OFF is deliberate. SDK consumers that call `Lium().ls(gpu_count=1)` programmatically (AI agents per spec) get the same result-set as before this PR. Only `lium ls` opts in; only the CLI passes `widen_for_splitting=True`.
- If you ever add `gpu_count=...` to the `sdk.ls()` call in `decorators.py`, decide explicitly about `widen_for_splitting` — the comment block flags this.
- The shared fixture path is `test/fixtures/splittable_executors.json` (mirrored at `src/contexts/__fixtures__/splittable-executors.json` in the frontend repo). Any change to one must be made byte-for-byte to the other; Gate C diff catches drift.