### PR TITLE
DAH-2506 - Add browse-filter parity to the SDK and CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
         path: dist/
         retention-days: 7
 
-  validate-binary-targets:
-    name: Validate binary target matrix
+  test:
+    name: Test suite
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,8 +64,11 @@ jobs:
     - name: Install pytest
       run: python -m pip install --upgrade pip pytest
 
-    - name: Verify installer and workflow target coverage
-      run: pytest test/test_release_binary_targets.py
+    - name: Install test dependencies
+      run: python -m pip install -e .
+
+    - name: Run the test suite
+      run: pytest test/
 
   build-linux-binary:
     name: Build Linux binary (${{ matrix.asset_name }})

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.29"
+__version__ = "0.0.30"

--- a/lium/cli/ls/actions.py
+++ b/lium/cli/ls/actions.py
@@ -26,6 +26,7 @@ class GetExecutorsAction:
                 lon=lon,
                 max_distance_miles=max_distance,
                 min_cuda_version=min_cuda_version,
+                widen_for_splitting=True,
             )
             return ActionResult(
                 ok=True,

--- a/lium/cli/ls/actions.py
+++ b/lium/cli/ls/actions.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from lium.cli.actions import ActionResult
 
 
@@ -11,22 +9,26 @@ class GetExecutorsAction:
 
         """
         lium = ctx["lium"]
-        gpu_type = ctx.get("gpu_type")
-        gpu_count = ctx.get("gpu_count")
-        lat = ctx.get("lat")
-        lon = ctx.get("lon")
-        max_distance = ctx.get("max_distance")
-        min_cuda_version = ctx.get("min_cuda_version")
 
         try:
             executors = lium.ls(
-                gpu_type=gpu_type,
-                gpu_count=gpu_count,
-                lat=lat,
-                lon=lon,
-                max_distance_miles=max_distance,
-                min_cuda_version=min_cuda_version,
+                gpu_type=ctx.get("gpu_type"),
+                gpu_count=ctx.get("gpu_count"),
+                lat=ctx.get("lat"),
+                lon=ctx.get("lon"),
+                max_distance_miles=ctx.get("max_distance"),
+                min_cuda_version=ctx.get("min_cuda_version"),
                 widen_for_splitting=True,
+                tier=ctx.get("tier"),
+                min_reliability=ctx.get("min_reliability"),
+                include_unscored=ctx.get("include_unscored", True),
+                min_uptime_minutes=ctx.get("min_uptime_minutes"),
+                min_vram_gb=ctx.get("min_vram_gb"),
+                min_vram_total_gb=ctx.get("min_vram_total_gb"),
+                min_ports=ctx.get("min_ports"),
+                countries=ctx.get("countries"),
+                max_price_total=ctx.get("max_price_total"),
+                max_price_per_gpu=ctx.get("max_price_per_gpu"),
             )
             return ActionResult(
                 ok=True,

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -1,7 +1,7 @@
 """List (ls) command implementation."""
 
 import json
-from typing import Optional, List
+from typing import Optional, List, Tuple
 import click
 
 from lium.sdk import Lium, ExecutorInfo
@@ -18,14 +18,8 @@ from . import validation, display
 from .actions import GetExecutorsAction
 
 
-def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download") -> List[ExecutorInfo]:
-    """Load and store nodes without displaying them."""
-    lium = Lium()
-    executors = lium.ls(gpu_type=gpu_type)
-
-    if not executors:
-        return []
-
+def store_sorted_executors(executors: List[ExecutorInfo]) -> List[ExecutorInfo]:
+    """Pareto-sort *executors* and remember them for index-based access in ``lium up``."""
     pareto_flags = calculate_pareto_frontier(executors)
     executors_with_pareto = list(zip(executors, pareto_flags))
 
@@ -44,6 +38,16 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download")
 @click.option("--gpu", "gpu_type", shell_complete=get_gpu_completions, help="Filter by GPU type, e.g. A100")
 @click.option("--count", "gpu_count", type=int, help="Renter-intent GPU count (widens to splittable nodes where min <= N <= available)")
 @click.option("--min-cuda", "min_cuda_version", type=float, help="Minimum CUDA version, e.g. 12.4 (NVIDIA drivers are backward compatible)")
+@click.option("--tier", type=click.Choice(["any", "secure", "spot"]), default=None, help="Only nodes of this tier (spot nodes are cheaper but reclaimable)")
+@click.option("--min-reliability", type=float, help="Minimum provider reliability score, 0-100")
+@click.option("--scored-only", is_flag=True, help="With --min-reliability, also drop nodes that have no score yet")
+@click.option("--min-uptime", "min_uptime_days", type=float, help="Minimum current uptime, in days")
+@click.option("--min-vram", "min_vram_gb", type=float, help="Minimum VRAM per GPU, in GB")
+@click.option("--min-vram-total", "min_vram_total_gb", type=float, help="Minimum VRAM across the whole node, in GB")
+@click.option("--max-price", "max_price_total", type=float, help="Maximum total $/hour (prices the split --count would rent)")
+@click.option("--max-price-gpu", "max_price_per_gpu", type=float, help="Maximum $/GPU-hour, matching the $/GPU·h column")
+@click.option("--country", "countries", multiple=True, help="ISO country code, e.g. US. Repeat for several countries")
+@click.option("--ports", "min_ports", type=int, help="Minimum number of open ports")
 @click.option("--lat", type=float, help="Latitude for distance filtering")
 @click.option("--lon", type=float, help="Longitude for distance filtering")
 @click.option("--max-distance", "max_distance", type=int, help="Maximum distance in miles from --lat/--lon")
@@ -72,8 +76,33 @@ def ls_command(
     limit: Optional[int],
     output_format: str,
     min_cuda_version: Optional[float],
+    tier: Optional[str],
+    min_reliability: Optional[float],
+    scored_only: bool,
+    min_uptime_days: Optional[float],
+    min_vram_gb: Optional[float],
+    min_vram_total_gb: Optional[float],
+    max_price_total: Optional[float],
+    max_price_per_gpu: Optional[float],
+    countries: Tuple[str, ...],
+    min_ports: Optional[int],
 ):
-    """List available GPU nodes."""
+    """\b
+    List available GPU nodes.
+    \b
+    Hardware filters:
+      --gpu, --count, --min-vram, --min-vram-total, --min-cuda, --ports
+    \b
+    Price filters:
+      --max-price       total $/hour, the number you pay
+      --max-price-gpu   $/GPU-hour, the $/GPU·h column
+    \b
+    Trust filters:
+      --tier, --min-reliability, --scored-only, --min-uptime
+    \b
+    Location filters:
+      --country, --lat/--lon, --max-distance
+    """
 
     _, error = validation.validate(limit, lat, lon, max_distance, min_cuda_version)
     if error:
@@ -89,6 +118,16 @@ def ls_command(
         "lon": lon,
         "max_distance": max_distance,
         "min_cuda_version": min_cuda_version,
+        "tier": tier,
+        "min_reliability": min_reliability,
+        "include_unscored": not scored_only,
+        "min_uptime_minutes": int(min_uptime_days * 1440) if min_uptime_days else None,
+        "min_vram_gb": min_vram_gb,
+        "min_vram_total_gb": min_vram_total_gb,
+        "min_ports": min_ports,
+        "countries": list(countries) or None,
+        "max_price_total": max_price_total,
+        "max_price_per_gpu": max_price_per_gpu,
     }
 
     action = GetExecutorsAction()
@@ -112,8 +151,8 @@ def ls_command(
             ui.error(f"All {gpu_type} GPUs are currently rented out")
             ui.info(f"Tip: {ui.styled('lium ls', 'success')}")
         else:
-            ui.error("All GPUs are currently rented out")
-            ui.info("Check back later or contact support if this persists")
+            ui.error("No nodes match those filters")
+            ui.info("Check back later or loosen the filters")
         return
 
 

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -42,7 +42,7 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download")
 
 @click.command("ls")
 @click.option("--gpu", "gpu_type", shell_complete=get_gpu_completions, help="Filter by GPU type, e.g. A100")
-@click.option("--count", "gpu_count", type=int, help="Exact GPU count to match (e.g., 1, 8)")
+@click.option("--count", "gpu_count", type=int, help="Renter-intent GPU count (widens to splittable nodes where min <= N <= available)")
 @click.option("--min-cuda", "min_cuda_version", type=float, help="Minimum CUDA version, e.g. 12.4 (NVIDIA drivers are backward compatible)")
 @click.option("--lat", type=float, help="Latitude for distance filtering")
 @click.option("--lon", type=float, help="Longitude for distance filtering")

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -22,7 +22,10 @@ def _mid_ellipsize(s: str, width: int = 28) -> str:
 
 def _cfg(exe: ExecutorInfo) -> str:
     """Format GPU configuration string."""
-    return f"{exe.gpu_count}×{exe.gpu_type}"
+    base = f"{exe.gpu_count}×{exe.gpu_type}"
+    if exe.min_gpu_count_for_rental is not None:
+        base += f" ↯ from {exe.min_gpu_count_for_rental}"
+    return base
 
 
 def _country_name(loc: Optional[Dict]) -> str:
@@ -192,6 +195,7 @@ def compact_executor(exe: ExecutorInfo, is_pareto: bool, index: int) -> Dict[str
         "is_pareto": is_pareto,
         "max_cuda_version": exe.max_cuda_version,
         "tier": exe.tier,
+        "min_gpu_count_for_rental": exe.min_gpu_count_for_rental,
     }
 
 

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -122,8 +122,10 @@ _SORT_KEY_FUNCS: Dict[str, Callable[[ExecutorInfo], Any]] = {
     "loc": lambda e: _country_name(e.location),
     "id": lambda e: e.huid,
     "gpu": lambda e: (e.gpu_type, e.gpu_count),
-    "download": lambda e: -(e.specs.get("network", {}).get("download_speed", 0) or 0),
-    "upload": lambda e: -(e.specs.get("network", {}).get("upload_speed", 0) or 0),
+    # Sort on the backend-authoritative effective speeds, the same numbers the table
+    # prints. These used to read the raw specs value, which the table does not show.
+    "download": lambda e: -e.download_speed,
+    "upload": lambda e: -e.upload_speed,
 }
 
 # Aliases let a caller sort by the field name `--format json` emits.
@@ -150,6 +152,7 @@ def _add_table_columns(t: Table) -> None:
     t.add_column("Tier", justify="left", width=8, no_wrap=True)
     t.add_column("Max CUDA", justify="right", width=10, no_wrap=True)
     t.add_column("$/GPU·h", justify="right", width=8, no_wrap=True)
+    t.add_column("$/h", justify="right", width=8, no_wrap=True)
     t.add_column("Location", justify="left", ratio=4, min_width=10, overflow="fold")
     t.add_column("VRAM (Gb)", justify="right", width=11, no_wrap=True)
     t.add_column("RAM (Gb)", justify="right", width=10, no_wrap=True)
@@ -191,6 +194,9 @@ def compact_executor(exe: ExecutorInfo, is_pareto: bool, index: int) -> Dict[str
         "upload_mbps": _intish(s["Upload"]),
         "download_mbps": _intish(s["Download"]),
         "available_ports": _intish(s["Ports"]),
+        "available_gpu_count": exe.available_gpu_count,
+        "reliability_score": exe.reliability_score,
+        "uptime_in_minutes": exe.uptime_in_minutes,
         "docker_in_docker": exe.docker_in_docker,
         "is_pareto": is_pareto,
         "max_cuda_version": exe.max_cuda_version,
@@ -285,6 +291,7 @@ def build_executors_table(
             _tier_display(exe),
             cuda_display,
             console.get_styled(_money(exe.price_per_gpu), 'success'),
+            console.get_styled(_money(exe.price_per_hour), 'success'),
             _country_name(exe.location),
             s["VRAM"],
             s["RAM"],

--- a/lium/cli/provider/_render.py
+++ b/lium/cli/provider/_render.py
@@ -510,13 +510,11 @@ def _render_generic_rows(items: list[Mapping[str, Any]]) -> None:
     for k in items[0].keys():
         if k not in keys:
             keys.append(k)
-    # Push complex (dict/list) keys to the back so they get pruned by the cap.
-    keys.sort(
-        key=lambda k: (
-            isinstance(items[0].get(k), (dict, list, tuple)),
-            keys.index(k),
-        )
-    )
+    # Push complex (dict/list) keys to the back so they get pruned by the cap. list.sort()
+    # is stable, so insertion order survives inside each group on its own — the previous
+    # `keys.index(k)` tie-breaker was both redundant and a crash, because list.sort()
+    # empties the list while it runs.
+    keys.sort(key=lambda k: isinstance(items[0].get(k), (dict, list, tuple)))
     keys = keys[:6]
 
     table = _new_table()

--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -20,6 +20,7 @@ class ResolveExecutorAction:
         count: Optional[int] = ctx.get("count")
         country: Optional[str] = ctx.get("country")
         ports: Optional[int] = ctx.get("ports")
+        min_cuda_version: Optional[float] = ctx.get("min_cuda_version")
 
         try:
             if executor_id:
@@ -41,20 +42,18 @@ class ResolveExecutorAction:
                         error=f"Node {executor.huid} has insufficient ports (available: {available}, required: {ports})"
                     )
             else:
-                executors = lium.ls(gpu_type=gpu)
-
-                if count:
-                    executors = [e for e in executors if e.gpu_count == count]
-                if country:
-                    executors = [
-                        e for e in executors
-                        if e.location and e.location.get('country_code', '').upper() == country.upper()
-                    ]
-                if ports:
-                    executors = [
-                        e for e in executors
-                        if e.available_port_count and e.available_port_count >= ports
-                    ]
+                # One filtered call, the same one `lium ls` makes. The old hand-rolled
+                # block compared gpu_count while ls compares available_gpu_count widened
+                # for splitting, so `lium ls --count N` and `lium up --count N` could
+                # offer disjoint candidate sets.
+                executors = lium.ls(
+                    gpu_type=gpu,
+                    gpu_count=count,
+                    widen_for_splitting=True,
+                    min_cuda_version=min_cuda_version,
+                    countries=[country] if country else None,
+                    min_ports=ports,
+                )
 
                 if not executors:
                     filters = []
@@ -66,11 +65,14 @@ class ResolveExecutorAction:
                         filters.append(f"country={country}")
                     if ports:
                         filters.append(f"min ports={ports}")
+                    if min_cuda_version:
+                        filters.append(f"min CUDA={min_cuda_version}")
                     filter_desc = ', '.join(filters) if filters else "specified filters"
                     return ActionResult(ok=False, data={}, error=f"No nodes available with {filter_desc}")
 
-                from lium.cli.ls.command import ls_store_executor
-                ls_store_executor(gpu_type=gpu)
+                # Remember the candidates we already have instead of re-fetching them.
+                from lium.cli.ls.command import store_sorted_executors
+                store_sorted_executors(executors)
 
                 pareto_flags = calculate_pareto_frontier(executors)
                 pareto_executors = [e for e, is_pareto in zip(executors, pareto_flags) if is_pareto]
@@ -177,11 +179,14 @@ class RentPodAction:
         ports: Optional[int] = ctx.get("ports")
         ssh_name: Optional[str] = ctx.get("ssh_name")
         enable_volume_encryption: bool | None = ctx.get("enable_volume_encryption")
+        count: Optional[int] = ctx.get("count")
 
         try:
             if not name:
                 name = executor.huid
 
+            # Without this the API rents every available GPU, so `up --count 1` on a
+            # splittable 8-GPU node would hand over — and bill — all eight.
             pod_info = lium.up(
                 executor_id=executor.id,
                 name=name,
@@ -191,6 +196,7 @@ class RentPodAction:
                 ports=ports,
                 ssh_name=ssh_name,
                 enable_volume_encryption=enable_volume_encryption,
+                gpu_count=count,
             )
 
             pod_id = pod_info.get('id') or pod_info.get('name', '')

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -36,6 +36,7 @@ from .actions import (
 @click.option("--count", "-c", type=int, help="Number of GPUs per pod")
 @click.option("--country", help="Filter nodes by ISO country code (e.g., US, FR)")
 @click.option("--ports", "-p", type=int, help="Minimum number of available ports required")
+@click.option("--min-cuda", "min_cuda_version", type=float, help="Minimum CUDA version, e.g. 12.4 (NVIDIA drivers are backward compatible)")
 @click.option("--ttl", help="Auto-terminate after duration (e.g., 6h, 45m, 2d)")
 @click.option("--until", help="Auto-terminate at time in local timezone (e.g., 'today 23:00', 'tomorrow 01:00', '2025-10-20 15:30')")
 @click.option("--jupyter", is_flag=True, help="Install Jupyter Notebook (automatically selects available port)")
@@ -63,6 +64,7 @@ def up_command(
     count: Optional[int],
     country: Optional[str],
     ports: Optional[int],
+    min_cuda_version: Optional[float],
     ttl: Optional[str],
     until: Optional[str],
     jupyter: bool,
@@ -197,7 +199,8 @@ def up_command(
             "gpu": gpu,
             "count": count,
             "country": country,
-            "ports": ports
+            "ports": ports,
+            "min_cuda_version": min_cuda_version,
         })
     )
 
@@ -277,10 +280,14 @@ def up_command(
             pass
 
     if not yes:
+        # Price what is actually being rented. On a splittable node `--count` takes a
+        # slice, so quoting the whole node here would overstate the bill.
+        rented_gpus = count or executor.available_gpu_count or executor.gpu_count
+        rented_price = executor.price_per_gpu * rented_gpus
         confirm_msg = (
             f"Acquire pod on {executor.huid} "
-            f"({executor.gpu_count}×{executor.gpu_type}) "
-            f"at ${executor.price_per_hour:.2f}/h?"
+            f"({rented_gpus}×{executor.gpu_type}) "
+            f"at ${rented_price:.2f}/h?"
         )
         if not ui.confirm(confirm_msg):
             return
@@ -313,6 +320,7 @@ def up_command(
             "ports": ports,
             "ssh_name": ssh_name,
             "enable_volume_encryption": volume_encryption,
+            "count": count,
         })
     )
 

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -72,6 +72,21 @@ class AlphaQuote:
     netuid: int            # the API's ``netuid`` — drives the transfer
 
 
+def _is_splittable_for_count(ex: "ExecutorInfo", wanted: int) -> bool:
+    """Return True if *ex* is a splittable node that can serve *wanted* GPUs.
+
+    PREDICATE PARITY: must match matchesGpuCountFilter in
+    lium-io-frontend/src/contexts/PodFiltersProvider.tsx.  Shared fixture:
+    lium/test/fixtures/splittable_executors.json mirrored in
+    lium-io-frontend/src/contexts/__fixtures__/splittable-executors.json.
+    """
+    minc = ex.min_gpu_count_for_rental  # None-safe per CLAUDE.md
+    avail = ex.available_gpu_count
+    if minc is None or avail is None:
+        return False
+    return minc <= wanted <= avail
+
+
 # Main SDK Class
 class Lium:
     """Clean Unix-style SDK for Lium."""
@@ -217,6 +232,8 @@ class Lium:
             effective_download_speed_mbps=executor_dict.get("effective_download_speed_mbps"),
             max_cuda_version=executor_dict.get("max_cuda_version"),
             tier=executor_dict.get("tier"),
+            min_gpu_count_for_rental=executor_dict.get("min_gpu_count_for_rental"),
+            available_gpu_count=executor_dict.get("available_gpu_count"),
         )
 
     def list_ssh_keys(self) -> List[SSHKey]:
@@ -491,6 +508,7 @@ class Lium:
         lon: Optional[float] = None,
         max_distance_miles: Optional[int] = None,
         min_cuda_version: Optional[float] = None,
+        widen_for_splitting: bool = False,
     ) -> List[ExecutorInfo]:
         """List available nodes.
 
@@ -503,6 +521,9 @@ class Lium:
             min_cuda_version: Optional minimum CUDA version to require (e.g. ``12.4``). Nodes whose
                 ``max_cuda_version`` is ``None`` or below this threshold are excluded. NVIDIA drivers are
                 backward compatible, so a node with a higher driver CUDA version satisfies the requirement.
+            widen_for_splitting: When ``True`` and ``gpu_count`` is set, also include splittable nodes
+                where ``min_gpu_count_for_rental <= gpu_count <= available_gpu_count``.  Defaults to
+                ``False`` so all existing callers (including ``@machine``) retain strict equality semantics.
 
         Returns:
             A list of :class:`ExecutorInfo` objects that satisfy the filters.
@@ -517,8 +538,12 @@ class Lium:
                 # If no match found, use the input as-is (might be already a full name)
                 params["machine_names"] = gpu_type
         if gpu_count:
-            params["gpu_count_gte"] = gpu_count
-            params["gpu_count_lte"] = gpu_count
+            # When widening for splitting we omit the server-side gpu_count_gte/lte so the
+            # backend returns the full candidate set; client-side filtering below selects
+            # both native-count matches and splittable nodes.
+            if not widen_for_splitting:
+                params["gpu_count_gte"] = gpu_count
+                params["gpu_count_lte"] = gpu_count
         if lat is not None and lon is not None:
             params["lat"] = lat
             params["lon"] = lon
@@ -530,6 +555,15 @@ class Lium:
         data = self._request("GET", "/executors", params=params).json()
         executors = [self._dict_to_executor_info(d) for d in data]
         executors = [e for e in executors if e]  # Filter None values
+
+        if gpu_count is not None:
+            if widen_for_splitting:
+                executors = [
+                    e for e in executors
+                    if e.available_gpu_count == gpu_count or _is_splittable_for_count(e, gpu_count)
+                ]
+            else:
+                executors = [e for e in executors if e.available_gpu_count == gpu_count]
 
         if min_cuda_version is not None:
             executors = [

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -23,6 +23,18 @@ from dotenv import load_dotenv
 from lium.__about__ import __version__ as fallback_version
 
 from .config import Config
+# Re-exported so `from lium.sdk.client import _is_splittable_for_count` keeps working.
+from .filters import (
+    _is_splittable_for_count,
+    matches_countries,
+    matches_max_price,
+    matches_min_ports,
+    matches_min_reliability,
+    matches_min_uptime,
+    matches_min_vram,
+    matches_min_vram_total,
+    matches_tier,
+)
 from .exceptions import (
     LiumAuthError,
     LiumError,
@@ -70,21 +82,6 @@ class AlphaQuote:
     alpha_amount: Decimal  # the API's ``converted`` (raw Decimal; floored by the caller)
     rate: Decimal          # the API's ``rate`` = USD per alpha
     netuid: int            # the API's ``netuid`` — drives the transfer
-
-
-def _is_splittable_for_count(ex: "ExecutorInfo", wanted: int) -> bool:
-    """Return True if *ex* is a splittable node that can serve *wanted* GPUs.
-
-    PREDICATE PARITY: must match matchesGpuCountFilter in
-    lium-io-frontend/src/contexts/PodFiltersProvider.tsx.  Shared fixture:
-    lium/test/fixtures/splittable_executors.json mirrored in
-    lium-io-frontend/src/contexts/__fixtures__/splittable-executors.json.
-    """
-    minc = ex.min_gpu_count_for_rental  # None-safe per CLAUDE.md
-    avail = ex.available_gpu_count
-    if minc is None or avail is None:
-        return False
-    return minc <= wanted <= avail
 
 
 # Main SDK Class
@@ -212,7 +209,11 @@ class Lium:
                     gpu_type = extract_gpu_type(gpu_name)
 
         price_per_gpu = executor_dict.get("price_per_gpu") or 0
-        price_per_hour = price_per_gpu * gpu_count
+        # Price what is rentable, not what is installed. A partially-rented node prints its
+        # $/h in `lium ls` and is compared against --max-price; using the physical GPU count
+        # would make those two numbers disagree — the exact mismatch DAH-2506 fixes on the web.
+        available_gpu_count = executor_dict.get("available_gpu_count")
+        price_per_hour = price_per_gpu * (available_gpu_count if available_gpu_count is not None else gpu_count)
 
         return ExecutorInfo(
             id=executor_dict.get("id", ""),
@@ -233,7 +234,9 @@ class Lium:
             max_cuda_version=executor_dict.get("max_cuda_version"),
             tier=executor_dict.get("tier"),
             min_gpu_count_for_rental=executor_dict.get("min_gpu_count_for_rental"),
-            available_gpu_count=executor_dict.get("available_gpu_count"),
+            available_gpu_count=available_gpu_count,
+            reliability_score=executor_dict.get("reliability_score"),
+            uptime_in_minutes=executor_dict.get("uptime_in_minutes"),
         )
 
     def list_ssh_keys(self) -> List[SSHKey]:
@@ -336,6 +339,7 @@ class Lium:
         ssh_keys: Optional[List[str]] = None,
         ssh_name: Optional[str] = None,
         enable_volume_encryption: bool | None = True,
+        gpu_count: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Start a new pod on a specific node.
 
@@ -358,6 +362,9 @@ class Lium:
             enable_volume_encryption: Whether to request encryption for the local
                 pod volume. Enabled by default. The image must support Lium volume
                 encryption.
+            gpu_count: How many GPUs to rent on a splittable node. Omit to rent every
+                available GPU. Passing fewer than the node's ``min_gpu_count_for_rental``,
+                or more than it has free, is rejected by the API.
 
         Returns:
             Pod metadata as returned by the rent API (id, name, status, ssh command, etc.).
@@ -389,6 +396,7 @@ class Lium:
             "user_public_key": ssh_material,
             "initial_port_count": ports,
             "enable_volume_encryption": enable_volume_encryption,
+            "gpu_count": gpu_count,
         }
 
         response = self._request("POST", f"/executors/{executor_info.id}/rent", json=payload).json()
@@ -509,12 +517,22 @@ class Lium:
         max_distance_miles: Optional[int] = None,
         min_cuda_version: Optional[float] = None,
         widen_for_splitting: bool = False,
+        tier: Optional[str] = None,
+        min_reliability: Optional[float] = None,
+        include_unscored: bool = True,
+        min_uptime_minutes: Optional[int] = None,
+        min_vram_gb: Optional[float] = None,
+        min_vram_total_gb: Optional[float] = None,
+        min_ports: Optional[int] = None,
+        countries: Optional[List[str]] = None,
+        max_price_total: Optional[float] = None,
+        max_price_per_gpu: Optional[float] = None,
     ) -> List[ExecutorInfo]:
         """List available nodes.
 
         Args:
             gpu_type: Optional GPU filter such as ``"A100"`` or ``"H200"``.
-            gpu_count: Exact GPU count to match (defaults to 8, pass ``None`` to disable).
+            gpu_count: Exact GPU count to match (defaults to ``None``, meaning any count).
             lat: Optional latitude for geospatial filtering. Must be used together with ``lon`` and ``max_distance_miles``.
             lon: Optional longitude for geospatial filtering. Must be used together with ``lat`` and ``max_distance_miles``.
             max_distance_miles: Optional radius (in miles) for geospatial filtering. Must be used together with ``lat`` and ``lon``.
@@ -524,6 +542,20 @@ class Lium:
             widen_for_splitting: When ``True`` and ``gpu_count`` is set, also include splittable nodes
                 where ``min_gpu_count_for_rental <= gpu_count <= available_gpu_count``.  Defaults to
                 ``False`` so all existing callers (including ``@machine``) retain strict equality semantics.
+            tier: Optional ``"secure"`` or ``"spot"``. ``None`` or ``"any"`` keeps every tier.
+            min_reliability: Optional minimum 0-100 provider reliability score.
+            include_unscored: When ``True`` (the default), nodes with no reliability score yet are kept
+                even if ``min_reliability`` is set — a missing score means "too new to measure", not "bad".
+            min_uptime_minutes: Optional minimum current uptime, in minutes.
+            min_vram_gb: Optional minimum VRAM per GPU, in GiB.
+            min_vram_total_gb: Optional minimum VRAM across the whole node, in GiB.
+            min_ports: Optional minimum number of open ports. Nodes with an unknown port count are
+                excluded once this is set.
+            countries: Optional list of ISO country codes, matched case-insensitively.
+            max_price_total: Optional maximum $/hour for the whole rental. When ``gpu_count`` is set and
+                the node is splittable, this prices the split the caller would actually rent, not the
+                whole node.
+            max_price_per_gpu: Optional maximum $/GPU-hour.
 
         Returns:
             A list of :class:`ExecutorInfo` objects that satisfy the filters.
@@ -571,7 +603,18 @@ class Lium:
                 if e.max_cuda_version is not None and e.max_cuda_version >= min_cuda_version
             ]
 
-        return executors
+        return [
+            e for e in executors
+            if matches_tier(e, tier)
+            and matches_min_reliability(e, min_reliability, include_unscored)
+            and matches_min_uptime(e, min_uptime_minutes)
+            and matches_min_vram(e, min_vram_gb)
+            and matches_min_vram_total(e, min_vram_total_gb)
+            and matches_min_ports(e, min_ports)
+            and matches_countries(e, countries)
+            and matches_max_price(e, max_price_total, "total", gpu_count)
+            and matches_max_price(e, max_price_per_gpu, "gpu", gpu_count)
+        ]
 
     def ps(self) -> List[PodInfo]:
         """List active pods.

--- a/lium/sdk/decorators.py
+++ b/lium/sdk/decorators.py
@@ -41,6 +41,12 @@ def machine(
 
             try:
                 # Step 1: Find executor matching machine type
+                # NOTE (DAH-2254): @machine intentionally calls sdk.ls() with no gpu_count
+                # kwarg and filters post-fetch via substring match on executor.machine_name
+                # (see line below). The widen_for_splitting kwarg therefore never fires
+                # from this path — @machine retains strict "exact machine_name substring"
+                # semantics regardless of CLI widen behavior. If you ever add gpu_count=...
+                # to this call, decide explicitly whether widen_for_splitting should be True.
                 executors = sdk.ls()
                 matching_executor = None
                 for executor in executors:

--- a/lium/sdk/filters.py
+++ b/lium/sdk/filters.py
@@ -1,0 +1,125 @@
+"""Client-side node filters shared by the SDK and the CLI.
+
+The web browse page runs the same predicates in
+``lium-io-frontend/src/contexts/browseFilterPredicates.ts``. The three subtle ones —
+max price (both modes), tier, and minimum reliability — are held to a byte-mirrored
+fixture: ``lium/test/fixtures/filter_executors.json`` mirrors
+``lium-io-frontend/src/contexts/__fixtures__/filter-executors.json``, and both sides
+assert the same accepted-ID sets.
+"""
+
+from typing import TYPE_CHECKING, Optional, Sequence
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .models import ExecutorInfo
+
+def _is_splittable_for_count(ex: "ExecutorInfo", wanted: int) -> bool:
+    """Return True if *ex* is a splittable node that can serve *wanted* GPUs.
+
+    PREDICATE PARITY: must match matchesGpuCountFilter in
+    lium-io-frontend/src/contexts/gpuCountFilter.ts.  Shared fixture:
+    lium/test/fixtures/splittable_executors.json mirrored in
+    lium-io-frontend/src/contexts/__fixtures__/splittable-executors.json.
+    """
+    minc = ex.min_gpu_count_for_rental  # None-safe per CLAUDE.md
+    avail = ex.available_gpu_count
+    if minc is None or avail is None:
+        return False
+    return minc <= wanted <= avail
+
+
+def display_gpu_count(ex: "ExecutorInfo", wanted: Optional[int]) -> int:
+    """How many GPUs the caller would actually rent, which is what they get priced on.
+
+    Mirrors computeDisplayGpuCount in
+    lium-io-frontend/src/modules/pod/browse-pod/displayGpuCount.ts.
+    """
+    # No fallback to gpu_count: computeDisplayGpuCount returns available_gpu_count
+    # outright, and a fallback only this side has would be a silent parity break.
+    avail = ex.available_gpu_count or 0
+    if wanted and _is_splittable_for_count(ex, wanted):
+        return wanted
+    return avail
+
+
+# PREDICATE PARITY: matchesTier in lium-io-frontend/src/contexts/browseFilterPredicates.ts.
+def matches_tier(ex: "ExecutorInfo", tier: Optional[str]) -> bool:
+    if not tier or tier == "any":
+        return True
+    return ex.tier == tier
+
+
+# PREDICATE PARITY: matchesMinReliability in
+# lium-io-frontend/src/contexts/browseFilterPredicates.ts.
+#
+# A missing reliability score means "not enough data yet", not "unreliable", so those
+# nodes are kept unless the caller passes include_unscored=False.
+def matches_min_reliability(
+    ex: "ExecutorInfo",
+    minimum: Optional[float],
+    include_unscored: bool = True,
+) -> bool:
+    if not minimum:
+        return True
+    if ex.reliability_score is None:
+        return include_unscored
+    return ex.reliability_score >= minimum
+
+
+# PREDICATE PARITY: matchesMaxPrice in
+# lium-io-frontend/src/contexts/browseFilterPredicates.ts.
+#
+# "total" compares the price the caller would actually pay for the split they asked for,
+# not the whole-node price — a $2.50/GPU node rentable one GPU at a time must survive a
+# $5 total budget.
+def matches_max_price(
+    ex: "ExecutorInfo",
+    limit: Optional[float],
+    mode: str = "total",
+    wanted_gpu_count: Optional[int] = None,
+) -> bool:
+    if not limit:
+        return True
+    if mode == "gpu":
+        return (ex.price_per_gpu or 0) <= limit
+    return (ex.price_per_gpu or 0) * display_gpu_count(ex, wanted_gpu_count) <= limit
+
+
+def matches_min_uptime(ex: "ExecutorInfo", minimum_minutes: Optional[int]) -> bool:
+    if not minimum_minutes:
+        return True
+    if ex.uptime_in_minutes is None:
+        return False
+    return ex.uptime_in_minutes >= minimum_minutes
+
+
+def matches_min_vram(ex: "ExecutorInfo", minimum_gb: Optional[float]) -> bool:
+    if not minimum_gb:
+        return True
+    vram = ex.vram_gb
+    return vram is not None and vram >= minimum_gb
+
+
+def matches_min_vram_total(ex: "ExecutorInfo", minimum_gb: Optional[float]) -> bool:
+    if not minimum_gb:
+        return True
+    vram = ex.vram_total_gb
+    return vram is not None and vram >= minimum_gb
+
+
+def matches_min_ports(ex: "ExecutorInfo", minimum: Optional[int]) -> bool:
+    if not minimum:
+        return True
+    if ex.available_port_count is None:
+        return False
+    return ex.available_port_count >= minimum
+
+
+def matches_countries(ex: "ExecutorInfo", codes: Optional[Sequence[str]]) -> bool:
+    """ISO country codes, matching what the web filter stores and ``lium up --country`` takes."""
+    if not codes:
+        return True
+    code = (ex.location or {}).get("country_code") or ""
+    if not code:
+        return False
+    return code.upper() in {c.upper() for c in codes}

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -24,6 +24,8 @@ class ExecutorInfo:
     effective_download_speed_mbps: Optional[float] = None
     max_cuda_version: Optional[float] = None
     tier: Optional[str] = None  # "spot" or "secure"; reclaim/penalty risk signal
+    min_gpu_count_for_rental: Optional[int] = None
+    available_gpu_count: Optional[int] = None
 
     @property
     def driver_version(self) -> str:

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -26,6 +26,31 @@ class ExecutorInfo:
     tier: Optional[str] = None  # "spot" or "secure"; reclaim/penalty risk signal
     min_gpu_count_for_rental: Optional[int] = None
     available_gpu_count: Optional[int] = None
+    # Blended 0-100 provider reliability score. None means "not enough data yet", not
+    # "unreliable" — filters keep those nodes unless the caller opts out.
+    reliability_score: Optional[float] = None
+    uptime_in_minutes: Optional[int] = None
+
+    @property
+    def vram_gb(self) -> Optional[float]:
+        """VRAM of a single GPU in GiB (capacity is reported in MiB)."""
+        details = self.specs.get('gpu', {}).get('details', []) if self.specs else []
+        capacity = details[0].get('capacity') if details else None
+        if not capacity:
+            return None
+        return capacity / 1024
+
+    @property
+    def vram_total_gb(self) -> Optional[float]:
+        """VRAM of the whole node in GiB. SN51 nodes are homogeneous, so per-GPU × count."""
+        # Mirrors getNodeVramMb in lium-io-frontend/src/modules/pod/browse-pod/gpuVram.ts,
+        # which returns null on a missing or non-positive count and does not fall back
+        # to the physical GPU count.
+        per_gpu = self.vram_gb
+        count = self.available_gpu_count
+        if per_gpu is None or not count or count < 0:
+            return None
+        return per_gpu * count
 
     @property
     def driver_version(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.29"
+version = "0.0.30"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/test/fixtures/filter_executors.json
+++ b/test/fixtures/filter_executors.json
@@ -1,0 +1,210 @@
+[
+  {
+    "id": "split-cheap",
+    "machine_name": "NVIDIA H100 SXM 8x",
+    "gpu_count": 8,
+    "tier": "secure",
+    "reliability_score": 99,
+    "uptime_in_minutes": 43200,
+    "price_per_gpu": 2.5,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": 1,
+    "location": { "country": "United States", "country_code": "US" },
+    "specs": {
+      "available_port_count": 32,
+      "gpu": { "count": 8, "details": [{ "name": "H100", "capacity": 81920 }] }
+    }
+  },
+  {
+    "id": "full-mid",
+    "machine_name": "NVIDIA H100 SXM 8x",
+    "gpu_count": 8,
+    "tier": "secure",
+    "reliability_score": 95,
+    "uptime_in_minutes": 10080,
+    "price_per_gpu": 4.0,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": null,
+    "location": { "country": "United States", "country_code": "US" },
+    "specs": {
+      "available_port_count": 8,
+      "gpu": { "count": 8, "details": [{ "name": "H100", "capacity": 81920 }] }
+    }
+  },
+  {
+    "id": "unscored-single",
+    "machine_name": "NVIDIA RTX A5000 1x",
+    "gpu_count": 1,
+    "tier": "spot",
+    "reliability_score": null,
+    "uptime_in_minutes": 1440,
+    "price_per_gpu": 1.0,
+    "available_gpu_count": 1,
+    "min_gpu_count_for_rental": null,
+    "location": { "country": "Germany", "country_code": "DE" },
+    "specs": {
+      "available_port_count": 100,
+      "gpu": { "count": 1, "details": [{ "name": "A5000", "capacity": 24576 }] }
+    }
+  },
+  {
+    "id": "spot-cheap-noports",
+    "machine_name": "NVIDIA RTX A5000 2x",
+    "gpu_count": 2,
+    "tier": "spot",
+    "reliability_score": 88,
+    "uptime_in_minutes": 720,
+    "price_per_gpu": 0.5,
+    "available_gpu_count": 2,
+    "min_gpu_count_for_rental": null,
+    "location": { "country": "France", "country_code": "FR" },
+    "specs": {
+      "available_port_count": null,
+      "gpu": { "count": 2, "details": [{ "name": "A5000", "capacity": 24576 }] }
+    }
+  },
+  {
+    "id": "secure-noports",
+    "machine_name": "NVIDIA L40S 4x",
+    "gpu_count": 4,
+    "tier": "secure",
+    "reliability_score": 92,
+    "uptime_in_minutes": 129600,
+    "price_per_gpu": 3.0,
+    "available_gpu_count": 4,
+    "min_gpu_count_for_rental": null,
+    "location": { "country": "Germany", "country_code": "DE" },
+    "specs": {
+      "available_port_count": null,
+      "gpu": { "count": 4, "details": [{ "name": "L40S", "capacity": 49152 }] }
+    }
+  },
+  {
+    "id": "split-bigvram",
+    "machine_name": "NVIDIA H200 SXM 8x",
+    "gpu_count": 8,
+    "tier": "secure",
+    "reliability_score": 97,
+    "uptime_in_minutes": 100000,
+    "price_per_gpu": 6.0,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": 2,
+    "location": { "country": "Japan", "country_code": "JP" },
+    "specs": {
+      "available_port_count": 16,
+      "gpu": { "count": 8, "details": [{ "name": "H200", "capacity": 144384 }] }
+    }
+  },
+  {
+    "id": "tierless",
+    "machine_name": "NVIDIA L40S 4x",
+    "gpu_count": 4,
+    "tier": null,
+    "reliability_score": 90,
+    "uptime_in_minutes": 4320,
+    "price_per_gpu": 2.0,
+    "available_gpu_count": 4,
+    "min_gpu_count_for_rental": null,
+    "location": { "country": "United States", "country_code": "US" },
+    "specs": {
+      "available_port_count": 8,
+      "gpu": { "count": 4, "details": [{ "name": "L40S", "capacity": 49152 }] }
+    }
+  },
+  {
+    "id": "low-reliability",
+    "machine_name": "NVIDIA RTX A5000 2x",
+    "gpu_count": 2,
+    "tier": "spot",
+    "reliability_score": 40,
+    "uptime_in_minutes": 60,
+    "price_per_gpu": 1.5,
+    "available_gpu_count": 2,
+    "min_gpu_count_for_rental": null,
+    "location": { "country": "India", "country_code": "IN" },
+    "specs": {
+      "available_port_count": 4,
+      "gpu": { "count": 2, "details": [{ "name": "A5000", "capacity": 24576 }] }
+    }
+  },
+  {
+    "id": "unscored-pricey",
+    "machine_name": "NVIDIA H100 SXM 8x",
+    "gpu_count": 8,
+    "tier": "secure",
+    "reliability_score": null,
+    "uptime_in_minutes": 200000,
+    "price_per_gpu": 10.0,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": null,
+    "location": { "country": "United States", "country_code": "US" },
+    "specs": {
+      "available_port_count": 64,
+      "gpu": { "count": 8, "details": [{ "name": "H100", "capacity": 81920 }] }
+    }
+  },
+  {
+    "id": "split-mid",
+    "machine_name": "NVIDIA H100 SXM 4x",
+    "gpu_count": 4,
+    "tier": "spot",
+    "reliability_score": 95,
+    "uptime_in_minutes": 20160,
+    "price_per_gpu": 3.5,
+    "available_gpu_count": 4,
+    "min_gpu_count_for_rental": 2,
+    "location": { "country": "Germany", "country_code": "DE" },
+    "specs": {
+      "available_port_count": 32,
+      "gpu": { "count": 4, "details": [{ "name": "H100", "capacity": 81920 }] }
+    }
+  },
+  {
+    "id": "single-cheap",
+    "machine_name": "NVIDIA RTX A5000 1x",
+    "gpu_count": 1,
+    "tier": "secure",
+    "reliability_score": 99.5,
+    "uptime_in_minutes": 43200,
+    "price_per_gpu": 0.8,
+    "available_gpu_count": 1,
+    "min_gpu_count_for_rental": null,
+    "location": { "country": "France", "country_code": "FR" },
+    "specs": {
+      "available_port_count": 12,
+      "gpu": { "count": 1, "details": [{ "name": "A5000", "capacity": 24576 }] }
+    }
+  },
+  {
+    "id": "no-location",
+    "machine_name": "NVIDIA H100 SXM 8x",
+    "gpu_count": 8,
+    "tier": "secure",
+    "reliability_score": 93,
+    "uptime_in_minutes": 5760,
+    "price_per_gpu": 5.0,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": null,
+    "location": null,
+    "specs": {
+      "available_port_count": 8,
+      "gpu": { "count": 8, "details": [{ "name": "H100", "capacity": 81920 }] }
+    }
+  },
+  {
+    "id": "fully-rented",
+    "machine_name": "NVIDIA RTX A5000 8x",
+    "gpu_count": 8,
+    "tier": null,
+    "reliability_score": 10,
+    "uptime_in_minutes": 5,
+    "price_per_gpu": 9.0,
+    "available_gpu_count": 0,
+    "min_gpu_count_for_rental": null,
+    "location": { "country": "Brazil", "country_code": "BR" },
+    "specs": {
+      "available_port_count": 0,
+      "gpu": { "count": 8, "details": [{ "name": "A5000", "capacity": 24576 }] }
+    }
+  }
+]

--- a/test/fixtures/splittable_executors.json
+++ b/test/fixtures/splittable_executors.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "exec-split-min1",
+    "huid": "split-min1",
+    "machine_name": "8xH200",
+    "gpu_type": "H200",
+    "gpu_count": 8,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": 1,
+    "price_per_gpu": 2.5,
+    "price_per_hour": 20.0,
+    "status": "available"
+  },
+  {
+    "id": "exec-split-min4",
+    "huid": "split-min4",
+    "machine_name": "8xH200",
+    "gpu_type": "H200",
+    "gpu_count": 8,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": 4,
+    "price_per_gpu": 2.5,
+    "price_per_hour": 20.0,
+    "status": "available"
+  },
+  {
+    "id": "exec-full",
+    "huid": "full",
+    "machine_name": "8xH200",
+    "gpu_type": "H200",
+    "gpu_count": 8,
+    "available_gpu_count": 8,
+    "min_gpu_count_for_rental": null,
+    "price_per_gpu": 2.5,
+    "price_per_hour": 20.0,
+    "status": "available"
+  },
+  {
+    "id": "exec-native1",
+    "huid": "native1",
+    "machine_name": "1xH100",
+    "gpu_type": "H100",
+    "gpu_count": 1,
+    "available_gpu_count": 1,
+    "min_gpu_count_for_rental": null,
+    "price_per_gpu": 3.0,
+    "price_per_hour": 3.0,
+    "status": "available"
+  }
+]

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -41,6 +41,12 @@ def _executor(huid: str, price_per_hour: float, download: int) -> SimpleNamespac
         docker_in_docker=False,
         max_cuda_version=12.4,
         tier="secure",
+        # Optional ExecutorInfo fields the ls table reads. They default to None on the
+        # real model, so the stand-in has to carry them or the table raises.
+        available_gpu_count=1,
+        min_gpu_count_for_rental=None,
+        reliability_score=None,
+        uptime_in_minutes=None,
     )
 
 

--- a/test/test_client_ls_widen.py
+++ b/test/test_client_ls_widen.py
@@ -1,0 +1,132 @@
+"""Unit tests for ``Lium.ls()`` widen_for_splitting behaviour (DAH-2254)."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import pathlib
+
+from lium.sdk import Config, Lium
+from lium.cli.ls.display import _cfg, compact_executor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIXTURE_PATH = pathlib.Path(__file__).parent / "fixtures" / "splittable_executors.json"
+
+
+def _load_fixture_rows() -> list[dict]:
+    """Load the shared fixture and augment each row with the minimal API fields
+    that ``_dict_to_executor_info`` needs (specs, location, executor_ip_address)."""
+    rows = json.loads(_FIXTURE_PATH.read_text())
+    augmented = []
+    for row in rows:
+        d = dict(row)
+        # Add mandatory API envelope fields that the fixture omits for brevity
+        d.setdefault("executor_ip_address", "1.2.3.4")
+        d.setdefault("location", {"country": "US"})
+        d.setdefault("specs", {
+            "gpu": {
+                "count": d.get("gpu_count", 1),
+                "details": [{"name": d.get("gpu_type", "H200"), "capacity": 81920, "pcie_speed": 16}],
+                "driver": "535.104.05",
+            },
+            "ram": {"total": 2097152},
+            "hard_disk": {"total": 10485760},
+            "sysbox_runtime": False,
+        })
+        d.setdefault("effective_upload_speed_mbps", 500.0)
+        d.setdefault("effective_download_speed_mbps", 1000.0)
+        augmented.append(d)
+    return augmented
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _client_with_fixture(monkeypatch) -> tuple[Lium, list]:
+    """Return a Lium client whose _request always returns the augmented fixture rows."""
+    client = Lium(Config(api_key="test-key"))
+    rows = _load_fixture_rows()
+
+    def fake_request(method, endpoint, **kwargs):
+        return _Response(rows)
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    return client, rows
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_ls_widen_true_includes_splittable(monkeypatch):
+    """widen_for_splitting=True, gpu_count=2: exec-split-min1 included; others excluded."""
+    client, _ = _client_with_fixture(monkeypatch)
+    result = client.ls(gpu_count=2, widen_for_splitting=True)
+    ids = [e.id for e in result]
+
+    assert "exec-split-min1" in ids, f"exec-split-min1 missing from {ids}"
+    assert "exec-split-min4" not in ids, "exec-split-min4 wrongly included (min=4 > 2)"
+    assert "exec-full" not in ids, "exec-full wrongly included (non-splittable, available=8 != 2)"
+    assert "exec-native1" not in ids, "exec-native1 wrongly included (available=1 != 2)"
+
+
+def test_ls_widen_false_excludes_splittable(monkeypatch):
+    """widen_for_splitting=False (default), gpu_count=2: no rows match available_gpu_count==2."""
+    client, _ = _client_with_fixture(monkeypatch)
+    result = client.ls(gpu_count=2, widen_for_splitting=False)
+    ids = [e.id for e in result]
+
+    # None of the fixture rows have available_gpu_count == 2
+    assert ids == [], f"Expected empty list with strict filter, got {ids}"
+
+
+def test_ls_widen_default_is_false():
+    """The default value of widen_for_splitting must be False (Gate D)."""
+    param = inspect.signature(Lium.ls).parameters["widen_for_splitting"]
+    assert param.default is False, (
+        f"widen_for_splitting default must be False, got {param.default!r}"
+    )
+
+
+def test_compact_executor_includes_min_gpu_count_for_rental(monkeypatch):
+    """compact_executor dict must include min_gpu_count_for_rental (CLI-AC #3)."""
+    client, _ = _client_with_fixture(monkeypatch)
+    result = client.ls(widen_for_splitting=False)
+    # Find exec-split-min1 and exec-full
+    by_id = {e.id: e for e in result}
+
+    # exec-split-min1 has min_gpu_count_for_rental=1
+    exe_split = by_id.get("exec-split-min1")
+    assert exe_split is not None, "exec-split-min1 missing from unfiltered ls()"
+    d_split = compact_executor(exe_split, is_pareto=False, index=1)
+    assert "min_gpu_count_for_rental" in d_split, "key missing from compact_executor"
+    assert d_split["min_gpu_count_for_rental"] == 1
+
+    # exec-full has min_gpu_count_for_rental=None
+    exe_full = by_id.get("exec-full")
+    assert exe_full is not None, "exec-full missing from unfiltered ls()"
+    d_full = compact_executor(exe_full, is_pareto=False, index=2)
+    assert "min_gpu_count_for_rental" in d_full
+    assert d_full["min_gpu_count_for_rental"] is None
+
+
+def test_cfg_marker_for_splittable(monkeypatch):
+    """_cfg() appends '↯ from N' for splittable rows; non-splittable rows have no '↯'."""
+    client, _ = _client_with_fixture(monkeypatch)
+    result = client.ls(widen_for_splitting=False)
+    by_id = {e.id: e for e in result}
+
+    exe_split = by_id["exec-split-min1"]
+    assert "↯ from 1" in _cfg(exe_split), f"_cfg output: {_cfg(exe_split)!r}"
+
+    exe_full = by_id["exec-full"]
+    assert "↯" not in _cfg(exe_full), f"_cfg output for non-splittable: {_cfg(exe_full)!r}"

--- a/test/test_filter_parity.py
+++ b/test/test_filter_parity.py
@@ -1,0 +1,531 @@
+"""Parity and behaviour tests for the DAH-2506 node filters.
+
+The accepted-ID sets asserted here are the same ones
+``lium-io-frontend/src/contexts/browseFilterPredicates.test.ts`` asserts against the
+mirrored fixture, so a predicate that drifts on one side fails on the other.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from lium.sdk import Config, Lium
+from lium.sdk import filters
+from lium.cli.ls.display import _add_table_columns, _sort_key_factory, compact_executor
+
+_FIXTURE_PATH = pathlib.Path(__file__).parent / "fixtures" / "filter_executors.json"
+
+
+def _rows() -> list[dict]:
+    """The mirrored fixture, plus the API envelope fields it omits for brevity."""
+    rows = json.loads(_FIXTURE_PATH.read_text())
+    augmented = []
+    for row in rows:
+        d = dict(row)
+        d.setdefault("executor_ip_address", "1.2.3.4")
+        d.setdefault("status", "available")
+        augmented.append(d)
+    return augmented
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _client(monkeypatch) -> Lium:
+    client = Lium(Config(api_key="test-key"))
+    rows = _rows()
+    monkeypatch.setattr(client, "_request", lambda method, endpoint, **kwargs: _Response(rows))
+    return client
+
+
+def _ids(client, **kwargs) -> list[str]:
+    return [e.id for e in client.ls(**kwargs)]
+
+
+ALL_IDS = [
+    "split-cheap",
+    "full-mid",
+    "unscored-single",
+    "spot-cheap-noports",
+    "secure-noports",
+    "split-bigvram",
+    "tierless",
+    "low-reliability",
+    "unscored-pricey",
+    "split-mid",
+    "single-cheap",
+    "no-location",
+    "fully-rented",
+]
+
+
+# ---------------------------------------------------------------------------
+# Mapping (US-010)
+# ---------------------------------------------------------------------------
+
+
+def test_new_fields_are_mapped(monkeypatch):
+    """_dict_to_executor_info drops unknown keys, so the new fields must be mapped explicitly."""
+    by_id = {e.id: e for e in _client(monkeypatch).ls()}
+
+    assert by_id["split-cheap"].reliability_score == 99
+    assert by_id["split-cheap"].uptime_in_minutes == 43200
+    assert by_id["unscored-single"].reliability_score is None
+
+
+def test_absent_fields_map_to_none():
+    """A payload without the new keys yields None, not a crash or a default."""
+    client = Lium(Config(api_key="test-key"))
+    executor = client._dict_to_executor_info(
+        {
+            "id": "bare",
+            "machine_name": "NVIDIA H100 SXM 8x",
+            "executor_ip_address": "1.2.3.4",
+            "price_per_gpu": 1.0,
+            "specs": {"gpu": {"count": 8, "details": [{"name": "H100", "capacity": 81920}]}},
+        }
+    )
+
+    assert executor.reliability_score is None
+    assert executor.uptime_in_minutes is None
+
+
+def test_vram_properties(monkeypatch):
+    """vram_gb / vram_total_gb derive from the first GPU's capacity in MiB."""
+    by_id = {e.id: e for e in _client(monkeypatch).ls()}
+
+    assert by_id["split-cheap"].vram_gb == 80
+    assert by_id["split-cheap"].vram_total_gb == 640
+    assert by_id["single-cheap"].vram_gb == 24
+    assert by_id["single-cheap"].vram_total_gb == 24
+
+
+# ---------------------------------------------------------------------------
+# PREDICATE PARITY — the three subtle predicates (US-013)
+# ---------------------------------------------------------------------------
+
+
+def test_parity_tier(monkeypatch):
+    client = _client(monkeypatch)
+
+    assert _ids(client, tier="any") == ALL_IDS
+    assert _ids(client, tier="secure") == [
+        "split-cheap",
+        "full-mid",
+        "secure-noports",
+        "split-bigvram",
+        "unscored-pricey",
+        "single-cheap",
+        "no-location",
+    ]
+    assert _ids(client, tier="spot") == [
+        "unscored-single",
+        "spot-cheap-noports",
+        "low-reliability",
+        "split-mid",
+    ]
+
+
+def test_parity_min_reliability_keeps_unscored_by_default(monkeypatch):
+    """A missing score means "too new to measure", so those nodes survive by default."""
+    client = _client(monkeypatch)
+
+    assert _ids(client, min_reliability=90) == [
+        "split-cheap",
+        "full-mid",
+        "unscored-single",
+        "secure-noports",
+        "split-bigvram",
+        "tierless",
+        "unscored-pricey",
+        "split-mid",
+        "single-cheap",
+        "no-location",
+    ]
+
+
+def test_parity_min_reliability_scored_only(monkeypatch):
+    client = _client(monkeypatch)
+
+    assert _ids(client, min_reliability=90, include_unscored=False) == [
+        "split-cheap",
+        "full-mid",
+        "secure-noports",
+        "split-bigvram",
+        "tierless",
+        "split-mid",
+        "single-cheap",
+        "no-location",
+    ]
+    assert _ids(client, min_reliability=95, include_unscored=False) == [
+        "split-cheap",
+        "full-mid",
+        "split-bigvram",
+        "split-mid",
+        "single-cheap",
+    ]
+
+
+def test_parity_max_price_per_gpu(monkeypatch):
+    client = _client(monkeypatch)
+
+    assert _ids(client, max_price_per_gpu=2.5) == [
+        "split-cheap",
+        "unscored-single",
+        "spot-cheap-noports",
+        "tierless",
+        "low-reliability",
+        "single-cheap",
+    ]
+
+
+def test_parity_max_price_total_whole_node(monkeypatch):
+    """With no --count, total mode prices the whole node."""
+    client = _client(monkeypatch)
+
+    assert _ids(client, max_price_total=5) == [
+        "unscored-single",
+        "spot-cheap-noports",
+        "low-reliability",
+        "single-cheap",
+        # A node with nothing left to rent costs nothing, so it clears every budget.
+        # Degenerate, but both implementations must agree on it.
+        "fully-rented",
+    ]
+
+
+def test_parity_max_price_total_prices_the_split(monkeypatch):
+    """The bug this rework exists to fix: a $2.50/GPU node rentable one GPU at a time
+    must survive a $5 budget, because $2.50 is what the renter would actually pay."""
+    client = _client(monkeypatch)
+
+    ids = _ids(client, gpu_count=1, widen_for_splitting=True, max_price_total=5)
+
+    assert "split-cheap" in ids
+    assert "full-mid" not in ids  # $4/GPU × 8 = $32 and it cannot be split
+
+
+def test_parity_max_price_total_with_a_wanted_count(monkeypatch):
+    """Exact twin of "total mode with a 1x selection" in browseFilterPredicates.test.ts.
+
+    Applies the price predicate ALONE, because Lium.ls cannot express that — routing
+    through ls would also apply the GPU-count filter and compare a different set.
+    """
+    executors = _client(monkeypatch).ls()
+
+    accepted = [e.id for e in executors if filters.matches_max_price(e, 5, "total", 1)]
+
+    assert accepted == [
+        "split-cheap",
+        "unscored-single",
+        "spot-cheap-noports",
+        "low-reliability",
+        "single-cheap",
+        "fully-rented",
+    ]
+
+
+def test_a_node_with_no_free_gpus_is_priced_at_zero(monkeypatch):
+    """$9/GPU × 8 physical GPUs would be $72. Availability, not the card count, sets it."""
+    fully_rented = {e.id: e for e in _client(monkeypatch).ls()}["fully-rented"]
+
+    assert filters.display_gpu_count(fully_rented, None) == 0
+    assert filters.matches_max_price(fully_rented, 5, "total") is True
+    assert filters.matches_max_price(fully_rented, 5, "gpu") is False
+    assert fully_rented.vram_total_gb is None
+
+
+def test_price_modes_disagree_for_a_whole_node_machine(monkeypatch):
+    """$4/GPU × 8 GPUs passes a $5 per-GPU limit and fails a $5 total limit."""
+    client = _client(monkeypatch)
+
+    assert "full-mid" in _ids(client, max_price_per_gpu=5)
+    assert "full-mid" not in _ids(client, max_price_total=5)
+
+
+# ---------------------------------------------------------------------------
+# The remaining predicates (US-010/US-011)
+# ---------------------------------------------------------------------------
+
+
+def test_min_uptime(monkeypatch):
+    client = _client(monkeypatch)
+
+    assert _ids(client, min_uptime_minutes=7 * 1440) == [
+        "split-cheap",
+        "full-mid",
+        "secure-noports",
+        "split-bigvram",
+        "unscored-pricey",
+        "split-mid",
+        "single-cheap",
+    ]
+
+
+def test_min_vram_and_total(monkeypatch):
+    client = _client(monkeypatch)
+
+    assert _ids(client, min_vram_gb=141) == ["split-bigvram"]
+    assert _ids(client, min_vram_total_gb=640) == [
+        "split-cheap",
+        "full-mid",
+        "split-bigvram",
+        "unscored-pricey",
+        "no-location",
+    ]
+
+
+def test_min_ports_excludes_unknown_port_counts(monkeypatch):
+    """An unknown port count cannot satisfy a minimum, so those nodes drop out."""
+    client = _client(monkeypatch)
+
+    ids = _ids(client, min_ports=8)
+
+    assert "spot-cheap-noports" not in ids
+    assert "secure-noports" not in ids
+    assert _ids(client, min_ports=32) == ["split-cheap", "unscored-single", "unscored-pricey", "split-mid"]
+
+
+def test_countries_are_case_insensitive_iso_codes(monkeypatch):
+    client = _client(monkeypatch)
+
+    assert _ids(client, countries=["us"]) == ["split-cheap", "full-mid", "tierless", "unscored-pricey"]
+    assert _ids(client, countries=["DE", "FR"]) == [
+        "unscored-single",
+        "spot-cheap-noports",
+        "secure-noports",
+        "split-mid",
+        "single-cheap",
+    ]
+    assert "no-location" not in _ids(client, countries=["US"])
+
+
+def test_bare_ls_is_unfiltered(monkeypatch):
+    """Backward compatibility: every new argument defaults to "do not filter"."""
+    assert _ids(_client(monkeypatch)) == ALL_IDS
+
+
+# ---------------------------------------------------------------------------
+# CLI surface (US-011)
+# ---------------------------------------------------------------------------
+
+
+def test_compact_executor_exposes_the_filter_fields(monkeypatch):
+    """`lium ls --format json` must expose what the filters act on."""
+    executor = {e.id: e for e in _client(monkeypatch).ls()}["split-cheap"]
+
+    payload = compact_executor(executor, is_pareto=False, index=1)
+
+    assert payload["available_gpu_count"] == 8
+    assert payload["reliability_score"] == 99
+    assert payload["uptime_in_minutes"] == 43200
+
+
+def test_sort_download_uses_effective_speed():
+    """Regression: a duplicate "download" key used to shadow this with a raw specs value."""
+
+    class _Exe:
+        def __init__(self, download, raw):
+            self.effective_download_speed_mbps = download
+            self.specs = {"network": {"download_speed": raw}}
+
+        @property
+        def download_speed(self):
+            return self.effective_download_speed_mbps or 0.0
+
+    key = _sort_key_factory("download")
+    fast_effective = _Exe(download=1000, raw=1)
+    slow_effective = _Exe(download=10, raw=9999)
+
+    assert key(fast_effective) < key(slow_effective)
+
+
+def test_table_shows_both_price_columns():
+    """--sort price_total has to sort a number the table actually prints."""
+    from rich.table import Table
+
+    table = Table()
+    _add_table_columns(table)
+    headers = [column.header for column in table.columns]
+
+    assert "$/GPU·h" in headers
+    assert "$/h" in headers
+
+
+# ---------------------------------------------------------------------------
+# ls / up agreement (US-012)
+# ---------------------------------------------------------------------------
+
+
+def test_up_and_ls_select_from_the_same_candidate_set(monkeypatch):
+    """`lium up --count N` used to compare gpu_count while `lium ls --count N` compared
+    available_gpu_count widened for splitting, so the two could be disjoint."""
+    from lium.cli.up.actions import ResolveExecutorAction
+
+    client = _client(monkeypatch)
+    monkeypatch.setattr("lium.cli.ls.command.store_sorted_executors", lambda executors: executors)
+
+    ls_ids = _ids(client, gpu_count=2, widen_for_splitting=True)
+    assert ls_ids, "fixture must offer at least one 2-GPU candidate"
+
+    captured: dict = {}
+    original_ls = client.ls
+
+    def recording_ls(**kwargs):
+        result = original_ls(**kwargs)
+        captured["ids"] = [e.id for e in result]
+        return result
+
+    monkeypatch.setattr(client, "ls", recording_ls)
+
+    result = ResolveExecutorAction().execute({"lium": client, "count": 2})
+
+    assert result.ok, result.error
+    assert captured["ids"] == ls_ids
+    assert result.data["executor"].id in ls_ids
+
+
+# ---------------------------------------------------------------------------
+# CLI flag wiring (US-011) — a renamed ctx key turns a flag into a silent no-op,
+# so assert the values that actually reach the SDK.
+# ---------------------------------------------------------------------------
+
+
+def _invoke_ls(monkeypatch, args: list[str]) -> dict:
+    """Run `lium ls <args>` against a stub SDK and return the kwargs it received."""
+    from click.testing import CliRunner
+    from lium.cli.ls import command as ls_module
+
+    captured: dict = {}
+
+    class _StubLium:
+        def ls(self, **kwargs):
+            captured.update(kwargs)
+            return []
+
+    monkeypatch.setattr(ls_module, "Lium", lambda *args, **kwargs: _StubLium())
+
+    result = CliRunner().invoke(ls_module.ls_command, [*args, "--format", "json"])
+    assert result.exit_code == 0, result.output
+
+    return captured
+
+
+def test_ls_flags_reach_the_sdk(monkeypatch):
+    captured = _invoke_ls(
+        monkeypatch,
+        [
+            "--tier", "spot",
+            "--min-reliability", "90",
+            "--min-vram", "80",
+            "--min-vram-total", "640",
+            "--max-price", "12.5",
+            "--max-price-gpu", "3",
+            "--ports", "32",
+            "--min-cuda", "12.4",
+        ],
+    )
+
+    assert captured["tier"] == "spot"
+    assert captured["min_reliability"] == 90
+    assert captured["min_vram_gb"] == 80
+    assert captured["min_vram_total_gb"] == 640
+    assert captured["max_price_total"] == 12.5
+    assert captured["max_price_per_gpu"] == 3
+    assert captured["min_ports"] == 32
+    assert captured["min_cuda_version"] == 12.4
+
+
+def test_ls_min_uptime_is_converted_from_days_to_minutes(monkeypatch):
+    assert _invoke_ls(monkeypatch, ["--min-uptime", "7"])["min_uptime_minutes"] == 7 * 1440
+
+
+def test_ls_scored_only_flips_include_unscored(monkeypatch):
+    assert _invoke_ls(monkeypatch, ["--min-reliability", "90"])["include_unscored"] is True
+    assert _invoke_ls(monkeypatch, ["--min-reliability", "90", "--scored-only"])["include_unscored"] is False
+
+
+def test_ls_country_is_repeatable(monkeypatch):
+    assert _invoke_ls(monkeypatch, ["--country", "US", "--country", "DE"])["countries"] == ["US", "DE"]
+    # No --country at all must mean "do not filter", not "match the empty list".
+    assert _invoke_ls(monkeypatch, [])["countries"] is None
+
+
+# ---------------------------------------------------------------------------
+# `lium up` rents what was asked for (US-012)
+# ---------------------------------------------------------------------------
+
+
+def test_up_rents_only_the_requested_gpu_count(monkeypatch):
+    """The API rents every available GPU when the payload omits gpu_count, so
+    `up --count 1` on a splittable 8-GPU node would hand over — and bill — all eight."""
+    from lium.cli.up.actions import RentPodAction
+
+    captured: dict = {}
+
+    class _StubLium:
+        def up(self, **kwargs):
+            captured.update(kwargs)
+            return {"id": "pod-1"}
+
+    executor = _client(monkeypatch).ls()[0]  # split-cheap: 8 available, rentable from 1
+    result = RentPodAction().execute(
+        {"lium": _StubLium(), "executor": executor, "template": None, "name": "p", "count": 1}
+    )
+
+    assert result.ok, result.error
+    assert captured["gpu_count"] == 1
+
+
+def test_up_without_a_count_rents_the_whole_node(monkeypatch):
+    """No --count means "give me the node", which the API expresses as gpu_count=None."""
+    from lium.cli.up.actions import RentPodAction
+
+    captured: dict = {}
+
+    class _StubLium:
+        def up(self, **kwargs):
+            captured.update(kwargs)
+            return {"id": "pod-1"}
+
+    executor = _client(monkeypatch).ls()[0]
+    RentPodAction().execute({"lium": _StubLium(), "executor": executor, "template": None, "name": "p"})
+
+    assert captured["gpu_count"] is None
+
+
+def test_sdk_up_sends_gpu_count_in_the_rent_payload(monkeypatch):
+    """Guards the whole chain: a missing payload key is what causes the overbilling."""
+    client = Lium(Config(api_key="test-key"))
+    captured: dict = {}
+
+    def fake_request(method, endpoint, **kwargs):
+        if endpoint.endswith("/rent"):
+            captured.update(kwargs.get("json") or {})
+            return _Response({"id": "pod-1"})
+        return _Response({})
+
+    monkeypatch.setattr(client, "_request", fake_request)
+    monkeypatch.setattr(client, "get_executor", lambda executor_id: _client(monkeypatch).ls()[0])
+    monkeypatch.setattr(client, "_ensure_ssh_keys_registered", lambda *args, **kwargs: None)
+
+    client.up(executor_id="split-cheap", template_id="tpl-1", ssh_keys=["ssh-rsa AAAA"], gpu_count=2)
+
+    assert captured["gpu_count"] == 2
+
+
+def test_total_price_column_agrees_with_the_max_price_filter(monkeypatch):
+    """The $/h column and --max-price must quote the same number, which is what the
+    renter would actually pay — not price_per_gpu × every physically installed GPU."""
+    by_id = {e.id: e for e in _client(monkeypatch).ls()}
+
+    # 8 installed, 0 free, $9/GPU. The physical count would print $72.00 while the filter
+    # compared $0.00.
+    assert by_id["fully-rented"].price_per_hour == 0
+    assert by_id["split-cheap"].price_per_hour == 20.0


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2506](https://www.notion.so/DAH-2506)

Give the `lium` SDK and CLI the same node filters the web browse page gained in DAH-2506, and hold the two implementations to a shared fixture so they cannot drift apart.

## Problem

The web browse page and the CLI answered the same question differently. `lium ls` could not filter on tier, reliability, uptime, VRAM, open ports or country at all, and its price filter compared against a different GPU count than the price it printed. A renter who found a node in the browser could not reproduce that result from the CLI.

There was also a live billing hazard in the selection path. `lium up` widens its search to splittable nodes, but the rent payload carried no `gpu_count`, and the backend defaults to the whole node when the field is absent (`gpu_count = payload.gpu_count or len(available_gpus)`, priced as `price_per_gpu * gpu_count`). On a splittable 8-GPU node, `lium up --count 1` would rent and bill all eight.

## Solution

- New `lium/sdk/filters.py` holds one predicate per dimension, mirroring `browseFilterPredicates.ts` in the frontend one-for-one.
- Both sides are held to a **byte-identical fixture**. `test/fixtures/filter_executors.json` and the frontend's `src/contexts/__fixtures__/filter-executors.json` are the same file, and both test suites assert the same accepted-ID sets for the same inputs. A change on one side that is not mirrored fails the other side's tests.
- `Lium.up` now sends `gpu_count`, the CLI threads `--count` into it, and the confirmation prompt states the split before the rental is created.

## Changes

- **`lium/sdk/filters.py`** (new) — `display_gpu_count` plus predicates for tier, reliability, price, uptime, VRAM per GPU, total VRAM, ports and country. `_is_splittable_for_count` moved here from `client.py` and re-exported there, so existing imports keep working.
- **`ExecutorInfo`** gains `reliability_score` and `uptime_in_minutes`, plus `vram_gb` / `vram_total_gb` properties mirroring the frontend's `getNodeVramMb`. `_dict_to_executor_info` maps the two new fields — it drops unknown keys, so this is required, not cosmetic.
- **`Lium.ls`** gains ten keyword arguments applied client-side; the docstring's "defaults to 8" claim is corrected.
- **`lium ls`** gains nine flags with grouped help, a `$/h` column beside `$/GPU·h`, and `available_gpu_count` / `reliability_score` / `uptime_in_minutes` in `--format json`. A duplicate `download` sort key is removed — it shadowed the effective speed with a raw specs value.
- **`lium up`** selects through a single widened `Lium.ls()` call instead of hand-rolled comparisons, and gains `--min-cuda`.
- **`price_per_hour`** is now derived from `available_gpu_count` rather than the physical `gpu_count`, so the printed `$/h` agrees with what `--max-price` compares.
- **`lium/cli/provider/_render.py`** — fixed a crash: `keys.index(k)` was called from inside `keys.sort()`, and `list.sort()` empties the list while it runs, so it raised `ValueError`. This broke 5 existing tests. Out of scope for the ticket, but CI now runs the full suite and would have landed red without it.
- **`.github/workflows/ci.yml`** — the job runs `pytest test/` instead of a single file. Note for whoever merges: the job is renamed from `validate-binary-targets` to `test`, so branch protection needs updating if the old name is a required check.
- Version bumped to `0.0.28` in both `pyproject.toml` and `lium/__about__.py`.

## Deployment Steps

Use GitHub Action. Publishing to PyPI is a manual `workflow_dispatch` as usual — this PR does not release.

## Review Request

- [ ] Just code review
- [ ] QA – local test on reviewer side

## Other PRs

- Stacks on #93 (DAH-2254). Until #93 merges, its two commits appear in this diff; the diff shrinks to the DAH-2506 commits on its own once #93 lands.
- The frontend half is Datura-ai/lium-io-frontend#226. It carries the other half of the shared fixture.
- The regenerated SDK reference is a separate lium-docs PR that **must merge after this one** — the docs drift gate clones `lium@main`, so merging it first would fail lium-docs deploys.

## Risks

- **Billing.** The `gpu_count` fix changes what `lium up` actually rents. It is covered by tests asserting the exact rent payload, but it is the part of this PR worth the most review attention.
- The parity contract only holds while the fixture stays identical on both sides. There is no CI job spanning the two repos — the guard is that both suites assert the same sets over the same bytes.
- `merge` was used rather than `rebase` to bring `main` in, deliberately, so the DAH-2254 commits this branch stacks on are not rewritten. The merge conflicts were all additive: `main` added an `enable_volume_encryption` parameter exactly where this branch added `gpu_count`, and both survive.

## Test Cases

### Test Case 1 — Splitting bills the requested count

**Actions** `lium up --count 1` against a splittable 8-GPU node.

**Expected Output** The rent payload carries `gpu_count: 1` and the confirmation prompt states the split. Before this change the backend defaulted to all 8 GPUs and billed accordingly.

### Test Case 2 — CLI and web agree

**Actions** Apply the same filter combination on the browse page and via `lium ls` flags.

**Expected Output** The same node set. This is asserted in CI on both sides against the shared fixture.

### Test Case 3 — Printed price matches the price filter

**Actions** `lium ls --max-price-total N` on a partly-rented node.

**Expected Output** The `$/h` column never disagrees with the filter — both use the rentable count.

**Automated:** `pytest test/` — 367 passed, including 30 new parity tests. The fixture was confirmed byte-identical to the frontend copy.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
