### PR TITLE
DAH-2556: make the CLI report failures to non-interactive callers

### DIFF
--- a/lium/cli/commands/exec.py
+++ b/lium/cli/commands/exec.py
@@ -1,9 +1,10 @@
 """Execute commands on pods using Lium SDK."""
 from __future__ import annotations
 
+import json
 import os
 import sys
-from typing import Optional, List, Tuple
+from typing import Any, Dict, Optional, List, Tuple
 from pathlib import Path
 
 import click
@@ -15,22 +16,44 @@ from ..utils import console, handle_errors, loading_status, parse_targets
 
 
 def _format_output(pod: PodInfo, result: dict, show_header: bool = True) -> None:
-    """Format and display execution output."""
+    """Format and display execution output.
+
+    Output is printed the same way whether the command succeeded or not: the log
+    a caller needs to diagnose a failure is exactly the log a failing command
+    produced, so dropping it on failure blinds the caller at the worst moment.
+    """
     if show_header:
         console.info(f"\n── {pod.huid} ──")
-    
-    if result.get("success"):
-        if result.get("stdout"):
-            print(result["stdout"], end="")
-        if result.get("stderr"):
-            print(f"[{console.theme.get('warning', 'yellow')}]{result['stderr']}[/]", end="")
-    else:
+
+    if result.get("stdout"):
+        print(result["stdout"], end="")
+    if result.get("stderr"):
+        print(f"[{console.theme.get('warning', 'yellow')}]{result['stderr']}[/]", end="")
+
+    if not result.get("success"):
         if result.get("error"):
             console.error(f"Error: {result['error']}")
         else:
             console.error(f"Command failed (exit code: {result.get('exit_code', 'unknown')})")
-            if result.get("stderr"):
-                console.error(f"{result['stderr']}", end="")
+
+
+def _exit_code_of(result: dict) -> int:
+    """Remote exit code, with a generic failure code when the SDK reports none."""
+    if result.get("success"):
+        return 0
+    code = result.get("exit_code")
+    return code if isinstance(code, int) and code != 0 else 1
+
+
+def _json_result(pod: PodInfo, result: dict) -> Dict[str, Any]:
+    """Machine-readable view of one pod's execution."""
+    return {
+        "pod": pod.huid,
+        "stdout": result.get("stdout") or "",
+        "stderr": result.get("stderr") or "",
+        "exit_code": _exit_code_of(result),
+        "error": result.get("error"),
+    }
 
 
 @click.command("exec")
@@ -38,8 +61,18 @@ def _format_output(pod: PodInfo, result: dict, show_header: bool = True) -> None
 @click.argument("command", required=False)
 @click.option("--script", "-s", type=click.Path(exists=True), help="Execute a script file")
 @click.option("--env", "-e", multiple=True, help="Set environment variables (KEY=VALUE)")
+@click.option(
+    "--json", "json_output", is_flag=True,
+    help="Print machine-readable JSON (stdout, stderr, exit_code) instead of raw output",
+)
 @handle_errors
-def exec_command(targets: str, command: Optional[str], script: Optional[str], env: Tuple[str]):
+def exec_command(
+    targets: str,
+    command: Optional[str],
+    script: Optional[str],
+    env: Tuple[str],
+    json_output: bool,
+):
     """Execute commands on GPU pods.
     
     \b
@@ -59,15 +92,20 @@ def exec_command(targets: str, command: Optional[str], script: Optional[str], en
       lium exec all "df -h"                    # Run on all pods
       lium exec 1 --script setup.sh            # Run script on pod
       lium exec 1 -e API_KEY=xyz "python app.py"  # With env vars
+      lium exec 1 --json "python train.py"     # Machine-readable result
+
+    \b
+    The process exits with the remote command's exit code, so
+    'lium exec <pod> "cmd" && next-step' behaves the way a caller expects.
     """
     # Validate inputs
     if not command and not script:
         console.error("Error: Either COMMAND or --script must be provided")
-        return
-    
+        raise SystemExit(2)
+
     if command and script:
         console.error("Error: Cannot use both COMMAND and --script")
-        return
+        raise SystemExit(2)
     
     # Load script if provided
     if script:
@@ -76,54 +114,69 @@ def exec_command(targets: str, command: Optional[str], script: Optional[str], en
                 command = f.read()
         except Exception as e:
             console.error(f"Error reading script: {e}")
-            return
-    
+            raise SystemExit(2)
+
     # Parse environment variables
     env_dict = {}
     for env_var in env:
         if '=' not in env_var:
             console.error(f"Error: Invalid env format '{env_var}' (use KEY=VALUE)")
-            return
+            raise SystemExit(2)
         key, value = env_var.split('=', 1)
         env_dict[key] = value
-    
+
     # Get pods and resolve targets
     lium = Lium()
     with loading_status("Loading pods", ""):
         all_pods = lium.ps()
-    
+
     selected_pods = parse_targets(targets, all_pods)
-    
+
     if not selected_pods:
         console.error(f"No pods match targets: {targets}")
-        return
-    
+        raise SystemExit(2)
+
     # Show what we're executing
-    if len(selected_pods) == 1:
-        pod = selected_pods[0]
-        console.info(f"Executing on {console.get_styled(pod.huid, 'pod_id')}")
-    else:
-        console.info(f"Executing on {len(selected_pods)} pods")
-    
-    if env_dict:
-        console.dim(f"Environment: {', '.join(f'{k}={v}' for k, v in env_dict.items())}")
-    
+    if not json_output:
+        if len(selected_pods) == 1:
+            pod = selected_pods[0]
+            console.info(f"Executing on {console.get_styled(pod.huid, 'pod_id')}")
+        else:
+            console.info(f"Executing on {len(selected_pods)} pods")
+
+        if env_dict:
+            console.dim(f"Environment: {', '.join(f'{k}={v}' for k, v in env_dict.items())}")
+
     # Execute on pods
     if len(selected_pods) == 1:
         # Single pod - stream output
         pod = selected_pods[0]
         try:
             result = lium.exec(pod, command=command, env=env_dict)
-            _format_output(pod, result, show_header=False)
         except Exception as e:
             console.error(f"Failed: {e}")
+            raise SystemExit(1)
+
+        if json_output:
+            click.echo(json.dumps(_json_result(pod, result), sort_keys=True))
+        else:
+            _format_output(pod, result, show_header=False)
+        raise SystemExit(_exit_code_of(result))
     else:
         # Multiple pods - use parallel execution
         results = lium.exec_all(selected_pods, command=command, env=env_dict)
-        
-        for pod, result in zip(selected_pods, results):
-            _format_output(pod, result)
-        
-        # Summary
-        success_count = sum(1 for r in results if r.get("success"))
-        console.dim(f"\nCompleted: {success_count}/{len(results)} successful")
+
+        if json_output:
+            click.echo(json.dumps(
+                [_json_result(pod, r) for pod, r in zip(selected_pods, results)],
+                sort_keys=True,
+            ))
+        else:
+            for pod, result in zip(selected_pods, results):
+                _format_output(pod, result)
+
+            success_count = sum(1 for r in results if r.get("success"))
+            console.dim(f"\nCompleted: {success_count}/{len(results)} successful")
+
+        # Any pod failing fails the whole invocation, like a shell pipeline would.
+        raise SystemExit(max(_exit_code_of(r) for r in results))

--- a/lium/cli/commands/exec.py
+++ b/lium/cli/commands/exec.py
@@ -4,56 +4,139 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import Any, Dict, Optional, List, Tuple
-from pathlib import Path
+from dataclasses import asdict, dataclass
+from typing import Mapping, Optional, Tuple
 
 import click
-from rich.text import Text
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from lium.sdk import Lium, PodInfo
-from ..utils import console, handle_errors, loading_status, parse_targets
+from ..utils import (
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    _emit_json_error,
+    console,
+    handle_errors,
+    loading_status,
+    parse_targets,
+)
 
 
-def _format_output(pod: PodInfo, result: dict, show_header: bool = True) -> None:
-    """Format and display execution output.
+@dataclass(frozen=True)
+class PodExecution:
+    """What one pod printed and how its command ended."""
 
-    Output is printed the same way whether the command succeeded or not: the log
-    a caller needs to diagnose a failure is exactly the log a failing command
-    produced, so dropping it on failure blinds the caller at the worst moment.
+    pod: str
+    stdout: str
+    stderr: str
+    exit_code: int
+    error: str | None
+
+    @classmethod
+    def from_sdk_result(cls, pod: PodInfo, result: Mapping[str, object]) -> "PodExecution":
+        # The SDK omits exit_code only when it could not run the command at all.
+        exit_code = result.get("exit_code", EXIT_GENERAL_ERROR)
+        return cls(
+            pod=pod.huid,
+            stdout=str(result.get("stdout") or ""),
+            stderr=str(result.get("stderr") or ""),
+            exit_code=int(exit_code) if isinstance(exit_code, int) else EXIT_GENERAL_ERROR,
+            error=str(result["error"]) if result.get("error") else None,
+        )
+
+    @property
+    def succeeded(self) -> bool:
+        return self.exit_code == 0
+
+
+def print_execution_for_a_human(execution: PodExecution, show_pod_header: bool) -> None:
+    """Print output the same way whether the command succeeded or not.
+
+    The log a caller needs to diagnose a failure is exactly the log a failing
+    command produced, so dropping it on failure blinds the caller at the worst
+    moment.
     """
-    if show_header:
-        console.info(f"\n── {pod.huid} ──")
+    if show_pod_header:
+        console.info(f"\n── {execution.pod} ──")
 
-    if result.get("stdout"):
-        print(result["stdout"], end="")
-    if result.get("stderr"):
-        print(f"[{console.theme.get('warning', 'yellow')}]{result['stderr']}[/]", end="")
+    if execution.stdout:
+        print(execution.stdout, end="")
+    if execution.stderr:
+        print(f"[{console.theme.get('warning', 'yellow')}]{execution.stderr}[/]", end="")
 
-    if not result.get("success"):
-        if result.get("error"):
-            console.error(f"Error: {result['error']}")
+    if not execution.succeeded:
+        if execution.error:
+            console.error(f"Error: {execution.error}")
         else:
-            console.error(f"Command failed (exit code: {result.get('exit_code', 'unknown')})")
+            console.error(f"Command failed (exit code: {execution.exit_code})")
 
 
-def _exit_code_of(result: dict) -> int:
-    """Remote exit code, with a generic failure code when the SDK reports none."""
-    if result.get("success"):
-        return 0
-    code = result.get("exit_code")
-    return code if isinstance(code, int) and code != 0 else 1
+def resolve_command_to_run(command: Optional[str], script: Optional[str]) -> str:
+    """The command text to run remotely, from either COMMAND or --script."""
+    if not command and not script:
+        console.error("Error: Either COMMAND or --script must be provided")
+        raise SystemExit(EXIT_CONFIGURATION_ERROR)
+
+    if command and script:
+        console.error("Error: Cannot use both COMMAND and --script")
+        raise SystemExit(EXIT_CONFIGURATION_ERROR)
+
+    if command:
+        return command
+
+    try:
+        return Path(script).read_text()
+    except OSError as e:
+        console.error(f"Error reading script: {e}")
+        raise SystemExit(EXIT_CONFIGURATION_ERROR)
 
 
-def _json_result(pod: PodInfo, result: dict) -> Dict[str, Any]:
-    """Machine-readable view of one pod's execution."""
-    return {
-        "pod": pod.huid,
-        "stdout": result.get("stdout") or "",
-        "stderr": result.get("stderr") or "",
-        "exit_code": _exit_code_of(result),
-        "error": result.get("error"),
-    }
+def parse_environment_variables(env: Tuple[str, ...]) -> dict[str, str]:
+    """KEY=VALUE pairs from -e, rejecting anything that is not a pair."""
+    env_dict: dict[str, str] = {}
+    for env_var in env:
+        if "=" not in env_var:
+            console.error(f"Error: Invalid env format '{env_var}' (use KEY=VALUE)")
+            raise SystemExit(EXIT_CONFIGURATION_ERROR)
+        key, value = env_var.split("=", 1)
+        env_dict[key] = value
+    return env_dict
+
+
+def resolve_pods_or_exit(lium: Lium, targets: str, json_output: bool) -> list[PodInfo]:
+    """Pods matching TARGETS. A target that matches nothing is a hard failure."""
+    with loading_status("Loading pods", ""):
+        all_pods = lium.ps()
+
+    selected_pods = parse_targets(targets, all_pods)
+    if selected_pods:
+        return selected_pods
+
+    message = f"No pods match targets: {targets}"
+    if json_output:
+        _emit_json_error("pod_not_found", message, EXIT_POD_NOT_FOUND)
+    console.error(message)
+    raise SystemExit(EXIT_POD_NOT_FOUND)
+
+
+def report_executions(executions: list[PodExecution], json_output: bool) -> None:
+    """Render every pod's result, then leave the exit code to the caller."""
+    if json_output:
+        payload = {
+            "ok": all(execution.succeeded for execution in executions),
+            "results": [asdict(execution) for execution in executions],
+        }
+        click.echo(json.dumps(payload, sort_keys=True))
+        return
+
+    show_pod_header = len(executions) > 1
+    for execution in executions:
+        print_execution_for_a_human(execution, show_pod_header=show_pod_header)
+
+    if show_pod_header:
+        succeeded = sum(1 for execution in executions if execution.succeeded)
+        console.dim(f"\nCompleted: {succeeded}/{len(executions)} successful")
 
 
 @click.command("exec")
@@ -98,85 +181,31 @@ def exec_command(
     The process exits with the remote command's exit code, so
     'lium exec <pod> "cmd" && next-step' behaves the way a caller expects.
     """
-    # Validate inputs
-    if not command and not script:
-        console.error("Error: Either COMMAND or --script must be provided")
-        raise SystemExit(2)
+    command_to_run = resolve_command_to_run(command, script)
+    env_dict = parse_environment_variables(env)
 
-    if command and script:
-        console.error("Error: Cannot use both COMMAND and --script")
-        raise SystemExit(2)
-    
-    # Load script if provided
-    if script:
-        try:
-            with open(script, 'r') as f:
-                command = f.read()
-        except Exception as e:
-            console.error(f"Error reading script: {e}")
-            raise SystemExit(2)
-
-    # Parse environment variables
-    env_dict = {}
-    for env_var in env:
-        if '=' not in env_var:
-            console.error(f"Error: Invalid env format '{env_var}' (use KEY=VALUE)")
-            raise SystemExit(2)
-        key, value = env_var.split('=', 1)
-        env_dict[key] = value
-
-    # Get pods and resolve targets
     lium = Lium()
-    with loading_status("Loading pods", ""):
-        all_pods = lium.ps()
+    selected_pods = resolve_pods_or_exit(lium, targets, json_output)
 
-    selected_pods = parse_targets(targets, all_pods)
-
-    if not selected_pods:
-        console.error(f"No pods match targets: {targets}")
-        raise SystemExit(2)
-
-    # Show what we're executing
     if not json_output:
         if len(selected_pods) == 1:
-            pod = selected_pods[0]
-            console.info(f"Executing on {console.get_styled(pod.huid, 'pod_id')}")
+            console.info(f"Executing on {console.get_styled(selected_pods[0].huid, 'pod_id')}")
         else:
             console.info(f"Executing on {len(selected_pods)} pods")
 
         if env_dict:
             console.dim(f"Environment: {', '.join(f'{k}={v}' for k, v in env_dict.items())}")
 
-    # Execute on pods
     if len(selected_pods) == 1:
-        # Single pod - stream output
-        pod = selected_pods[0]
-        try:
-            result = lium.exec(pod, command=command, env=env_dict)
-        except Exception as e:
-            console.error(f"Failed: {e}")
-            raise SystemExit(1)
-
-        if json_output:
-            click.echo(json.dumps(_json_result(pod, result), sort_keys=True))
-        else:
-            _format_output(pod, result, show_header=False)
-        raise SystemExit(_exit_code_of(result))
+        results = [lium.exec(selected_pods[0], command=command_to_run, env=env_dict)]
     else:
-        # Multiple pods - use parallel execution
-        results = lium.exec_all(selected_pods, command=command, env=env_dict)
+        results = lium.exec_all(selected_pods, command=command_to_run, env=env_dict)
 
-        if json_output:
-            click.echo(json.dumps(
-                [_json_result(pod, r) for pod, r in zip(selected_pods, results)],
-                sort_keys=True,
-            ))
-        else:
-            for pod, result in zip(selected_pods, results):
-                _format_output(pod, result)
+    executions = [
+        PodExecution.from_sdk_result(pod, result)
+        for pod, result in zip(selected_pods, results)
+    ]
+    report_executions(executions, json_output)
 
-            success_count = sum(1 for r in results if r.get("success"))
-            console.dim(f"\nCompleted: {success_count}/{len(results)} successful")
-
-        # Any pod failing fails the whole invocation, like a shell pipeline would.
-        raise SystemExit(max(_exit_code_of(r) for r in results))
+    # Any pod failing fails the whole invocation, like a shell pipeline would.
+    raise SystemExit(max(execution.exit_code for execution in executions))

--- a/lium/cli/commands/exec.py
+++ b/lium/cli/commands/exec.py
@@ -1,10 +1,12 @@
 """Execute commands on pods using Lium SDK."""
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sys
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Mapping, Optional, Tuple
 
 import click
@@ -15,7 +17,7 @@ from ..utils import (
     EXIT_CONFIGURATION_ERROR,
     EXIT_GENERAL_ERROR,
     EXIT_POD_NOT_FOUND,
-    _emit_json_error,
+    CliFailure,
     console,
     handle_errors,
     loading_status,
@@ -63,7 +65,9 @@ def print_execution_for_a_human(execution: PodExecution, show_pod_header: bool) 
     if execution.stdout:
         print(execution.stdout, end="")
     if execution.stderr:
-        print(f"[{console.theme.get('warning', 'yellow')}]{execution.stderr}[/]", end="")
+        # Real stderr, unstyled: a caller reading the stream must not have to
+        # strip Rich markup out of the command's own output.
+        click.echo(execution.stderr, err=True, nl=False)
 
     if not execution.succeeded:
         if execution.error:
@@ -75,12 +79,18 @@ def print_execution_for_a_human(execution: PodExecution, show_pod_header: bool) 
 def resolve_command_to_run(command: Optional[str], script: Optional[str]) -> str:
     """The command text to run remotely, from either COMMAND or --script."""
     if not command and not script:
-        console.error("Error: Either COMMAND or --script must be provided")
-        raise SystemExit(EXIT_CONFIGURATION_ERROR)
+        raise CliFailure(
+            "missing_command",
+            "Either COMMAND or --script must be provided",
+            EXIT_CONFIGURATION_ERROR,
+        )
 
     if command and script:
-        console.error("Error: Cannot use both COMMAND and --script")
-        raise SystemExit(EXIT_CONFIGURATION_ERROR)
+        raise CliFailure(
+            "conflicting_command",
+            "Cannot use both COMMAND and --script",
+            EXIT_CONFIGURATION_ERROR,
+        )
 
     if command:
         return command
@@ -88,8 +98,7 @@ def resolve_command_to_run(command: Optional[str], script: Optional[str]) -> str
     try:
         return Path(script).read_text()
     except OSError as e:
-        console.error(f"Error reading script: {e}")
-        raise SystemExit(EXIT_CONFIGURATION_ERROR)
+        raise CliFailure("unreadable_script", f"Error reading script: {e}", EXIT_CONFIGURATION_ERROR)
 
 
 def parse_environment_variables(env: Tuple[str, ...]) -> dict[str, str]:
@@ -97,27 +106,31 @@ def parse_environment_variables(env: Tuple[str, ...]) -> dict[str, str]:
     env_dict: dict[str, str] = {}
     for env_var in env:
         if "=" not in env_var:
-            console.error(f"Error: Invalid env format '{env_var}' (use KEY=VALUE)")
-            raise SystemExit(EXIT_CONFIGURATION_ERROR)
+            raise CliFailure(
+                "invalid_env",
+                f"Invalid env format '{env_var}' (use KEY=VALUE)",
+                EXIT_CONFIGURATION_ERROR,
+            )
         key, value = env_var.split("=", 1)
         env_dict[key] = value
     return env_dict
 
 
-def resolve_pods_or_exit(lium: Lium, targets: str, json_output: bool) -> list[PodInfo]:
-    """Pods matching TARGETS. A target that matches nothing is a hard failure."""
-    with loading_status("Loading pods", ""):
+def resolve_pods_or_fail(lium: Lium, targets: str, show_progress: bool) -> list[PodInfo]:
+    """Pods matching TARGETS. A target that matches nothing is a hard failure.
+
+    The progress spinner writes to stdout, which belongs to the JSON consumer.
+    """
+    with loading_status("Loading pods", "") if show_progress else contextlib.nullcontext():
         all_pods = lium.ps()
 
     selected_pods = parse_targets(targets, all_pods)
     if selected_pods:
         return selected_pods
 
-    message = f"No pods match targets: {targets}"
-    if json_output:
-        _emit_json_error("pod_not_found", message, EXIT_POD_NOT_FOUND)
-    console.error(message)
-    raise SystemExit(EXIT_POD_NOT_FOUND)
+    raise CliFailure(
+        "pod_not_found", f"No pods match targets: {targets}", EXIT_POD_NOT_FOUND
+    )
 
 
 def report_executions(executions: list[PodExecution], json_output: bool) -> None:
@@ -142,7 +155,7 @@ def report_executions(executions: list[PodExecution], json_output: bool) -> None
 @click.command("exec")
 @click.argument("targets")
 @click.argument("command", required=False)
-@click.option("--script", "-s", type=click.Path(exists=True), help="Execute a script file")
+@click.option("--script", "-s", help="Execute a script file")
 @click.option("--env", "-e", multiple=True, help="Set environment variables (KEY=VALUE)")
 @click.option(
     "--json", "json_output", is_flag=True,
@@ -185,7 +198,7 @@ def exec_command(
     env_dict = parse_environment_variables(env)
 
     lium = Lium()
-    selected_pods = resolve_pods_or_exit(lium, targets, json_output)
+    selected_pods = resolve_pods_or_fail(lium, targets, show_progress=not json_output)
 
     if not json_output:
         if len(selected_pods) == 1:

--- a/lium/cli/commands/exec.py
+++ b/lium/cli/commands/exec.py
@@ -24,6 +24,10 @@ from ..utils import (
     parse_targets,
 )
 
+# The remote command failed but said nothing about how. Its own status space, not
+# the lium process exit table.
+UNKNOWN_REMOTE_FAILURE = 1
+
 
 @dataclass(frozen=True)
 class PodExecution:
@@ -38,12 +42,12 @@ class PodExecution:
     @classmethod
     def from_sdk_result(cls, pod: PodInfo, result: Mapping[str, object]) -> "PodExecution":
         # The SDK omits exit_code only when it could not run the command at all.
-        exit_code = result.get("exit_code", EXIT_GENERAL_ERROR)
+        exit_code = result.get("exit_code")
         return cls(
             pod=pod.huid,
             stdout=str(result.get("stdout") or ""),
             stderr=str(result.get("stderr") or ""),
-            exit_code=int(exit_code) if isinstance(exit_code, int) else EXIT_GENERAL_ERROR,
+            exit_code=exit_code if isinstance(exit_code, int) else UNKNOWN_REMOTE_FAILURE,
             error=str(result["error"]) if result.get("error") else None,
         )
 

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -6,7 +6,13 @@ import click
 
 from lium.sdk import Lium, ExecutorInfo
 from lium.cli import ui
-from lium.cli.utils import handle_errors, store_executor_selection, calculate_pareto_frontier
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    calculate_pareto_frontier,
+    handle_errors,
+    store_executor_selection,
+)
 from lium.cli.completion import get_gpu_completions
 from . import validation, display
 from .actions import GetExecutorsAction
@@ -69,16 +75,9 @@ def ls_command(
 ):
     """List available GPU nodes."""
 
-    # Validate
-    # No --sort means "default view": stars first. An explicit --sort is an
-    # instruction, so it must outrank them.
-    pareto_first = sort_by is None
-    sort_by = sort_by or "download"
-
-    _, error = validation.validate(sort_by, limit, lat, lon, max_distance, min_cuda_version)
+    _, error = validation.validate(limit, lat, lon, max_distance, min_cuda_version)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
@@ -120,7 +119,7 @@ def ls_command(
 
     if output_format == "json":
         sorted_executors, pareto_flags = display.sort_executors(
-            executors, sort_by=sort_by, limit=limit, pareto_first=pareto_first
+            executors, sort_by=sort_by, limit=limit
         )
         payload = [
             display.compact_executor(exe, is_pareto, idx)
@@ -135,7 +134,6 @@ def ls_command(
         executors,
         sort_by=sort_by,
         limit=limit,
-        pareto_first=pareto_first,
     )
 
     # Display

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -3,6 +3,7 @@
 import json
 from typing import Optional, List
 import click
+from click.core import ParameterSource
 
 from lium.sdk import Lium, ExecutorInfo
 from lium.cli import ui
@@ -44,9 +45,12 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download")
 @click.option(
     "--sort",
     "sort_by",
-    type=click.Choice(["download", "upload", "price_gpu", "price_total", "loc", "id", "gpu"]),
+    type=click.Choice([
+        "download", "upload", "price_gpu", "price_total", "loc", "id", "gpu",
+        "price_per_gpu_hour", "price_per_hour",
+    ]),
     default="download",
-    help="Sort result by the chosen field.",
+    help="Sort result by the chosen field. An explicit --sort wins over the ★ optimal ordering.",
 )
 @click.option("--limit", type=int, default=None, help="Limit number of rows shown.")
 @click.option(
@@ -112,9 +116,12 @@ def ls_command(
             ui.info("Check back later or contact support if this persists")
         return
 
+    # An explicit --sort is an instruction, not a hint: don't let ★ outrank it.
+    pareto_first = click.get_current_context().get_parameter_source("sort_by") == ParameterSource.DEFAULT
+
     if output_format == "json":
         sorted_executors, pareto_flags = display.sort_executors(
-            executors, sort_by=sort_by, limit=limit
+            executors, sort_by=sort_by, limit=limit, pareto_first=pareto_first
         )
         payload = [
             display.compact_executor(exe, is_pareto, idx)
@@ -128,7 +135,8 @@ def ls_command(
     table, sorted_executors, header, tip = display.build_executors_table(
         executors,
         sort_by=sort_by,
-        limit=limit
+        limit=limit,
+        pareto_first=pareto_first,
     )
 
     # Display

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -3,7 +3,6 @@
 import json
 from typing import Optional, List
 import click
-from click.core import ParameterSource
 
 from lium.sdk import Lium, ExecutorInfo
 from lium.cli import ui
@@ -45,11 +44,8 @@ def ls_store_executor(gpu_type: Optional[str] = None, sort_by: str = "download")
 @click.option(
     "--sort",
     "sort_by",
-    type=click.Choice([
-        "download", "upload", "price_gpu", "price_total", "loc", "id", "gpu",
-        "price_per_gpu_hour", "price_per_hour",
-    ]),
-    default="download",
+    type=click.Choice(display.SORT_KEYS + list(display.SORT_KEY_ALIASES)),
+    default=None,
     help="Sort result by the chosen field. An explicit --sort wins over the ★ optimal ordering.",
 )
 @click.option("--limit", type=int, default=None, help="Limit number of rows shown.")
@@ -66,7 +62,7 @@ def ls_command(
     lat: Optional[float],
     lon: Optional[float],
     max_distance: Optional[int],
-    sort_by: str,
+    sort_by: Optional[str],
     limit: Optional[int],
     output_format: str,
     min_cuda_version: Optional[float],
@@ -74,6 +70,11 @@ def ls_command(
     """List available GPU nodes."""
 
     # Validate
+    # No --sort means "default view": stars first. An explicit --sort is an
+    # instruction, so it must outrank them.
+    pareto_first = sort_by is None
+    sort_by = sort_by or "download"
+
     _, error = validation.validate(sort_by, limit, lat, lon, max_distance, min_cuda_version)
     if error:
         ui.error(error)
@@ -116,8 +117,6 @@ def ls_command(
             ui.info("Check back later or contact support if this persists")
         return
 
-    # An explicit --sort is an instruction, not a hint: don't let ★ outrank it.
-    pareto_first = click.get_current_context().get_parameter_source("sort_by") == ParameterSource.DEFAULT
 
     if output_format == "json":
         sorted_executors, pareto_flags = display.sort_executors(

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -116,9 +116,12 @@ def _specs_row(executor: ExecutorInfo) -> Dict[str, str]:
 def _sort_key_factory(name: str) -> Callable[[ExecutorInfo], Any]:
     """Get sort key function by name."""
     mapping = {
-        "download": lambda e: -e.download_speed,
+        # Aliases match the field names `--format json` emits, so a caller can
+        # sort by the same name it reads back.
         "price_gpu": lambda e: e.price_per_gpu or 0.0,
+        "price_per_gpu_hour": lambda e: e.price_per_gpu or 0.0,
         "price_total": lambda e: e.price_per_hour or 0.0,
+        "price_per_hour": lambda e: e.price_per_hour or 0.0,
         "loc": lambda e: _country_name(e.location),
         "id": lambda e: e.huid,
         "gpu": lambda e: (e.gpu_type, e.gpu_count),
@@ -189,15 +192,22 @@ def sort_executors(
     sort_by: str = "download",
     limit: Optional[int] = None,
     show_pareto: bool = True,
+    pareto_first: bool = True,
 ) -> tuple[List[ExecutorInfo], List[bool]]:
-    """Apply Pareto-aware sort and limit. Returns (sorted_executors, pareto_flags)."""
+    """Apply Pareto-aware sort and limit. Returns (sorted_executors, pareto_flags).
+
+    ``pareto_first`` floats starred nodes to the top, which is the right default
+    for a human skimming the table. Pass ``False`` when the caller asked for an
+    explicit order: otherwise the star outranks the sort key and "cheapest
+    first" returns the most expensive node.
+    """
     if not executors:
         return [], []
 
     pareto_flags = calculate_pareto_frontier(executors) if show_pareto else [False] * len(executors)
     pairs = list(zip(executors, pareto_flags))
 
-    if show_pareto:
+    if show_pareto and pareto_first:
         pairs.sort(key=lambda x: (not x[1], _sort_key_factory(sort_by)(x[0])))
     else:
         pairs.sort(key=lambda x: _sort_key_factory(sort_by)(x[0]))
@@ -212,7 +222,8 @@ def build_executors_table(
     executors: List[ExecutorInfo],
     sort_by: str = "download",
     limit: Optional[int] = None,
-    show_pareto: bool = True
+    show_pareto: bool = True,
+    pareto_first: bool = True,
 ) -> tuple[Table, List[ExecutorInfo], str, str]:
     """Build executors table, returns (table, sorted_executors, header, tip)."""
 
@@ -220,7 +231,8 @@ def build_executors_table(
         return None, [], "", ""
 
     sorted_executors, pareto_flags = sort_executors(
-        executors, sort_by=sort_by, limit=limit, show_pareto=show_pareto
+        executors, sort_by=sort_by, limit=limit, show_pareto=show_pareto,
+        pareto_first=pareto_first,
     )
 
     # Count Pareto-optimal in shown results

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -113,28 +113,30 @@ def _specs_row(executor: ExecutorInfo) -> Dict[str, str]:
     }
 
 
+_SORT_KEY_FUNCS: Dict[str, Callable[[ExecutorInfo], Any]] = {
+    "price_gpu": lambda e: e.price_per_gpu or 0.0,
+    "price_total": lambda e: e.price_per_hour or 0.0,
+    "loc": lambda e: _country_name(e.location),
+    "id": lambda e: e.huid,
+    "gpu": lambda e: (e.gpu_type, e.gpu_count),
+    "download": lambda e: -(e.specs.get("network", {}).get("download_speed", 0) or 0),
+    "upload": lambda e: -(e.specs.get("network", {}).get("upload_speed", 0) or 0),
+}
+
+# Aliases let a caller sort by the field name `--format json` emits.
 SORT_KEY_ALIASES = {
     "price_per_gpu_hour": "price_gpu",
     "price_per_hour": "price_total",
 }
 
-SORT_KEYS = ["download", "upload", "price_gpu", "price_total", "loc", "id", "gpu"]
+DEFAULT_SORT_KEY = "download"
+SORT_KEYS = list(_SORT_KEY_FUNCS)
 
 
 def _sort_key_factory(name: str) -> Callable[[ExecutorInfo], Any]:
     """Get sort key function by name."""
-    # Aliases let a caller sort by the field name `--format json` emits.
     name = SORT_KEY_ALIASES.get(name, name)
-    mapping = {
-        "price_gpu": lambda e: e.price_per_gpu or 0.0,
-        "price_total": lambda e: e.price_per_hour or 0.0,
-        "loc": lambda e: _country_name(e.location),
-        "id": lambda e: e.huid,
-        "gpu": lambda e: (e.gpu_type, e.gpu_count),
-        "download": lambda e: -(e.specs.get("network", {}).get("download_speed", 0) or 0),
-        "upload": lambda e: -(e.specs.get("network", {}).get("upload_speed", 0) or 0),
-    }
-    return mapping.get(name, mapping["download"])
+    return _SORT_KEY_FUNCS.get(name, _SORT_KEY_FUNCS[DEFAULT_SORT_KEY])
 
 
 def _add_table_columns(t: Table) -> None:
@@ -195,24 +197,23 @@ def compact_executor(exe: ExecutorInfo, is_pareto: bool, index: int) -> Dict[str
 
 def sort_executors(
     executors: List[ExecutorInfo],
-    sort_by: str = "download",
+    sort_by: Optional[str] = None,
     limit: Optional[int] = None,
     show_pareto: bool = True,
-    pareto_first: bool = True,
 ) -> tuple[List[ExecutorInfo], List[bool]]:
     """Apply Pareto-aware sort and limit. Returns (sorted_executors, pareto_flags).
 
-    ``pareto_first`` floats starred nodes to the top, which is the right default
-    for a human skimming the table. Pass ``False`` when the caller asked for an
-    explicit order: otherwise the star outranks the sort key and "cheapest
-    first" returns the most expensive node.
+    ``sort_by=None`` is the default view a human skims, where starred nodes float
+    to the top. An explicit key is an instruction and outranks the star —
+    otherwise "cheapest first" returns the most expensive node.
     """
     if not executors:
         return [], []
 
+    pareto_first = sort_by is None
     pareto_flags = calculate_pareto_frontier(executors) if show_pareto else [False] * len(executors)
     pairs = list(zip(executors, pareto_flags))
-    sort_key = _sort_key_factory(sort_by)
+    sort_key = _sort_key_factory(sort_by or DEFAULT_SORT_KEY)
 
     if pareto_first:
         pairs.sort(key=lambda x: (not x[1], sort_key(x[0])))
@@ -227,10 +228,9 @@ def sort_executors(
 
 def build_executors_table(
     executors: List[ExecutorInfo],
-    sort_by: str = "download",
+    sort_by: Optional[str] = None,
     limit: Optional[int] = None,
     show_pareto: bool = True,
-    pareto_first: bool = True,
 ) -> tuple[Table, List[ExecutorInfo], str, str]:
     """Build executors table, returns (table, sorted_executors, header, tip)."""
 
@@ -238,8 +238,7 @@ def build_executors_table(
         return None, [], "", ""
 
     sorted_executors, pareto_flags = sort_executors(
-        executors, sort_by=sort_by, limit=limit, show_pareto=show_pareto,
-        pareto_first=pareto_first,
+        executors, sort_by=sort_by, limit=limit, show_pareto=show_pareto
     )
 
     # Count Pareto-optimal in shown results

--- a/lium/cli/ls/display.py
+++ b/lium/cli/ls/display.py
@@ -113,15 +113,21 @@ def _specs_row(executor: ExecutorInfo) -> Dict[str, str]:
     }
 
 
+SORT_KEY_ALIASES = {
+    "price_per_gpu_hour": "price_gpu",
+    "price_per_hour": "price_total",
+}
+
+SORT_KEYS = ["download", "upload", "price_gpu", "price_total", "loc", "id", "gpu"]
+
+
 def _sort_key_factory(name: str) -> Callable[[ExecutorInfo], Any]:
     """Get sort key function by name."""
+    # Aliases let a caller sort by the field name `--format json` emits.
+    name = SORT_KEY_ALIASES.get(name, name)
     mapping = {
-        # Aliases match the field names `--format json` emits, so a caller can
-        # sort by the same name it reads back.
         "price_gpu": lambda e: e.price_per_gpu or 0.0,
-        "price_per_gpu_hour": lambda e: e.price_per_gpu or 0.0,
         "price_total": lambda e: e.price_per_hour or 0.0,
-        "price_per_hour": lambda e: e.price_per_hour or 0.0,
         "loc": lambda e: _country_name(e.location),
         "id": lambda e: e.huid,
         "gpu": lambda e: (e.gpu_type, e.gpu_count),
@@ -206,11 +212,12 @@ def sort_executors(
 
     pareto_flags = calculate_pareto_frontier(executors) if show_pareto else [False] * len(executors)
     pairs = list(zip(executors, pareto_flags))
+    sort_key = _sort_key_factory(sort_by)
 
-    if show_pareto and pareto_first:
-        pairs.sort(key=lambda x: (not x[1], _sort_key_factory(sort_by)(x[0])))
+    if pareto_first:
+        pairs.sort(key=lambda x: (not x[1], sort_key(x[0])))
     else:
-        pairs.sort(key=lambda x: _sort_key_factory(sort_by)(x[0]))
+        pairs.sort(key=lambda x: sort_key(x[0]))
 
     if isinstance(limit, int) and limit > 0:
         pairs = pairs[:limit]

--- a/lium/cli/ls/validation.py
+++ b/lium/cli/ls/validation.py
@@ -11,10 +11,7 @@ def validate(
 ) -> tuple[bool, str | None]:
     """Validate ls command options, returns (is_valid, error_message)."""
 
-    # Validate sort_by
-    valid_sort_options = ["download", "upload", "price_gpu", "price_total", "loc", "id", "gpu"]
-    if sort_by not in valid_sort_options:
-        return False, f"Invalid sort option: {sort_by}"
+    # sort_by membership is enforced by click.Choice at parse time.
 
     # Validate limit
     if limit is not None and limit <= 0:

--- a/lium/cli/ls/validation.py
+++ b/lium/cli/ls/validation.py
@@ -2,7 +2,6 @@
 
 
 def validate(
-    sort_by: str,
     limit: int | None,
     lat: float | None,
     lon: float | None,
@@ -10,8 +9,6 @@ def validate(
     min_cuda_version: float | None = None,
 ) -> tuple[bool, str | None]:
     """Validate ls command options, returns (is_valid, error_message)."""
-
-    # sort_by membership is enforced by click.Choice at parse time.
 
     # Validate limit
     if limit is not None and limit <= 0:

--- a/lium/cli/rm/command.py
+++ b/lium/cli/rm/command.py
@@ -1,5 +1,6 @@
 """Remove (rm) command implementation."""
 
+import sys
 from typing import Optional
 import click
 
@@ -13,17 +14,29 @@ from .actions import RemovePodsAction, ScheduleRemovalAction
 @click.command("rm")
 @click.argument("targets", required=False)
 @click.option("--all", "-a", is_flag=True, help="Remove all active pods")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt")
 @click.option("--in", "in_duration", help="Schedule removal after duration")
 @click.option("--at", "at_time", help="Schedule removal at time")
 @handle_errors
-def rm_command(targets: Optional[str], all: bool, in_duration: Optional[str], at_time: Optional[str]):
-    """Remove (terminate) GPU pods."""
+def rm_command(
+    targets: Optional[str],
+    all: bool,
+    yes: bool,
+    in_duration: Optional[str],
+    at_time: Optional[str],
+):
+    """Remove (terminate) GPU pods.
+
+    \b
+    Removal is irreversible. Exits non-zero when nothing matched TARGETS, so a
+    typo cannot look like a successful teardown.
+    """
 
     # Validate
     valid, error = validation.validate(targets, all, in_duration, at_time)
     if not valid:
         ui.error(error)
-        return
+        raise SystemExit(2)
 
     # Load data
     lium = Lium()
@@ -37,9 +50,18 @@ def rm_command(targets: Optional[str], all: bool, in_duration: Optional[str], at
     parsed, error = parsing.parse(targets, all, all_pods, in_duration, at_time)
     if error:
         ui.error(error)
-        return
+        raise SystemExit(2)
 
     selected_pods = parsed.get("selected_pods")
+
+    if not selected_pods:
+        ui.error(f"No pods match targets: {targets}")
+        raise SystemExit(2)
+
+    # --all on a shared account can wipe a colleague's work, so it asks once.
+    if all and not yes and sys.stdin.isatty():
+        listed = ", ".join(pod.huid for pod in selected_pods)
+        click.confirm(f"Remove all {len(selected_pods)} pods ({listed})?", abort=True)
     termination_time = parsed.get("termination_time")
 
     # Execute
@@ -53,7 +75,14 @@ def rm_command(targets: Optional[str], all: bool, in_duration: Optional[str], at
 
     result = action.execute(ctx)
 
-    # Only error if anything failed
-    if not result.ok:
-        failed_huids = result.data.get("failed_huids", [])
+    failed_huids = result.data.get("failed_huids", []) if not result.ok else []
+    removed_huids = [pod.huid for pod in selected_pods if pod.huid not in failed_huids]
+
+    # Say what happened: silence is indistinguishable from having done nothing.
+    if removed_huids:
+        verb = "Scheduled removal for" if termination_time else "Removed"
+        ui.info(f"{verb} {len(removed_huids)} pod(s): {', '.join(removed_huids)}")
+
+    if failed_huids:
         ui.error(f"Failed to remove pods: {', '.join(failed_huids)}")
+        raise SystemExit(1)

--- a/lium/cli/rm/command.py
+++ b/lium/cli/rm/command.py
@@ -12,6 +12,7 @@ from lium.cli.utils import (
     EXIT_CONFIGURATION_ERROR,
     EXIT_GENERAL_ERROR,
     EXIT_POD_NOT_FOUND,
+    CliFailure,
     handle_errors,
 )
 from . import validation, parsing
@@ -26,7 +27,7 @@ class RemovalPlan:
     termination_time: Optional[datetime]
 
 
-def build_removal_plan_or_exit(
+def build_removal_plan(
     lium: Lium,
     targets: Optional[str],
     remove_all: bool,
@@ -36,21 +37,28 @@ def build_removal_plan_or_exit(
     """Resolve TARGETS into a plan. None means there was nothing to remove."""
     is_valid, error = validation.validate(targets, remove_all, in_duration, at_time)
     if not is_valid:
-        ui.error(error)
-        raise SystemExit(EXIT_CONFIGURATION_ERROR)
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     all_pods = ui.load("Loading pods", lambda: lium.ps())
     if not all_pods:
-        ui.warning("No active pods")
-        return None
+        # Removing everything from an empty account is a no-op, not a failure.
+        # Naming a pod that is not there is a failure — that is a typo, and it
+        # must not read like a successful teardown.
+        if remove_all:
+            ui.warning("No active pods")
+            return None
+        raise CliFailure(
+            "pod_not_found", f"{parsing.NO_MATCHING_PODS}: {targets}", EXIT_POD_NOT_FOUND
+        )
 
     parsed, error = parsing.parse(targets, remove_all, all_pods, in_duration, at_time)
     if error:
-        ui.error(error)
-        raise SystemExit(
+        raise CliFailure(
+            "pod_not_found" if error.startswith(parsing.NO_MATCHING_PODS) else "invalid_arguments",
+            error,
             EXIT_POD_NOT_FOUND
             if error.startswith(parsing.NO_MATCHING_PODS)
-            else EXIT_CONFIGURATION_ERROR
+            else EXIT_CONFIGURATION_ERROR,
         )
 
     return RemovalPlan(
@@ -90,7 +98,7 @@ def rm_command(
     typo cannot look like a successful teardown.
     """
     lium = Lium()
-    plan = build_removal_plan_or_exit(lium, targets, all, in_duration, at_time)
+    plan = build_removal_plan(lium, targets, all, in_duration, at_time)
     if plan is None:
         return
 
@@ -114,5 +122,8 @@ def rm_command(
         ui.success(f"{done_verb} {len(removed_huids)} pod(s): {', '.join(removed_huids)}")
 
     if failed_huids:
-        ui.error(f"Failed to remove pods: {', '.join(failed_huids)}")
-        raise SystemExit(EXIT_GENERAL_ERROR)
+        raise CliFailure(
+            "removal_failed",
+            f"Failed to remove pods: {', '.join(failed_huids)}",
+            EXIT_GENERAL_ERROR,
+        )

--- a/lium/cli/rm/command.py
+++ b/lium/cli/rm/command.py
@@ -1,14 +1,72 @@
 """Remove (rm) command implementation."""
 
 import sys
-from typing import Optional
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
 import click
 
-from lium.sdk import Lium
+from lium.sdk import Lium, PodInfo
 from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import (
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+)
 from . import validation, parsing
 from .actions import RemovePodsAction, ScheduleRemovalAction
+
+
+@dataclass(frozen=True)
+class RemovalPlan:
+    """Which pods to remove, and when — now if no time was given."""
+
+    pods: List[PodInfo]
+    termination_time: Optional[datetime]
+
+
+def build_removal_plan_or_exit(
+    lium: Lium,
+    targets: Optional[str],
+    remove_all: bool,
+    in_duration: Optional[str],
+    at_time: Optional[str],
+) -> Optional[RemovalPlan]:
+    """Resolve TARGETS into a plan. None means there was nothing to remove."""
+    is_valid, error = validation.validate(targets, remove_all, in_duration, at_time)
+    if not is_valid:
+        ui.error(error)
+        raise SystemExit(EXIT_CONFIGURATION_ERROR)
+
+    all_pods = ui.load("Loading pods", lambda: lium.ps())
+    if not all_pods:
+        ui.warning("No active pods")
+        return None
+
+    parsed, error = parsing.parse(targets, remove_all, all_pods, in_duration, at_time)
+    if error:
+        ui.error(error)
+        raise SystemExit(
+            EXIT_POD_NOT_FOUND
+            if error.startswith(parsing.NO_MATCHING_PODS)
+            else EXIT_CONFIGURATION_ERROR
+        )
+
+    return RemovalPlan(
+        pods=parsed["selected_pods"], termination_time=parsed.get("termination_time")
+    )
+
+
+def human_approved_removing_every_pod(pods: List[PodInfo]) -> bool:
+    """Ask before wiping the whole account — but only ask a human.
+
+    A piped caller has already said what it wants and cannot answer a prompt.
+    """
+    if not sys.stdin.isatty():
+        return True
+    listed = ", ".join(pod.huid for pod in pods)
+    return ui.confirm(f"Remove all {len(pods)} pods ({listed})?")
 
 
 @click.command("rm")
@@ -31,58 +89,30 @@ def rm_command(
     Removal is irreversible. Exits non-zero when nothing matched TARGETS, so a
     typo cannot look like a successful teardown.
     """
-
-    # Validate
-    valid, error = validation.validate(targets, all, in_duration, at_time)
-    if not valid:
-        ui.error(error)
-        raise SystemExit(2)
-
-    # Load data
     lium = Lium()
-    all_pods = ui.load("Loading pods", lambda: lium.ps())
-
-    if not all_pods:
-        ui.warning("No active pods")
+    plan = build_removal_plan_or_exit(lium, targets, all, in_duration, at_time)
+    if plan is None:
         return
 
-    # Parse
-    parsed, error = parsing.parse(targets, all, all_pods, in_duration, at_time)
-    if error:
-        ui.error(error)
-        raise SystemExit(2)
+    if all and not yes and not human_approved_removing_every_pod(plan.pods):
+        return
 
-    selected_pods = parsed.get("selected_pods")
-
-    if not selected_pods:
-        ui.error(f"No pods match targets: {targets}")
-        raise SystemExit(2)
-
-    # --all on a shared account can wipe a colleague's work, so it asks once.
-    if all and not yes and sys.stdin.isatty():
-        listed = ", ".join(pod.huid for pod in selected_pods)
-        click.confirm(f"Remove all {len(selected_pods)} pods ({listed})?", abort=True)
-    termination_time = parsed.get("termination_time")
-
-    # Execute
-    ctx = {"pods": selected_pods, "lium": lium}
-
-    if termination_time:
-        ctx["termination_time"] = termination_time.isoformat()
+    context = {"pods": plan.pods, "lium": lium}
+    if plan.termination_time:
+        context["termination_time"] = plan.termination_time.isoformat()
         action = ScheduleRemovalAction()
+        done_verb = "Scheduled removal for"
     else:
         action = RemovePodsAction()
+        done_verb = "Removed"
 
-    result = action.execute(ctx)
-
-    failed_huids = result.data.get("failed_huids", []) if not result.ok else []
-    removed_huids = [pod.huid for pod in selected_pods if pod.huid not in failed_huids]
+    failed_huids = action.execute(context).data["failed_huids"]
+    removed_huids = [pod.huid for pod in plan.pods if pod.huid not in failed_huids]
 
     # Say what happened: silence is indistinguishable from having done nothing.
     if removed_huids:
-        verb = "Scheduled removal for" if termination_time else "Removed"
-        ui.info(f"{verb} {len(removed_huids)} pod(s): {', '.join(removed_huids)}")
+        ui.success(f"{done_verb} {len(removed_huids)} pod(s): {', '.join(removed_huids)}")
 
     if failed_huids:
         ui.error(f"Failed to remove pods: {', '.join(failed_huids)}")
-        raise SystemExit(1)
+        raise SystemExit(EXIT_GENERAL_ERROR)

--- a/lium/cli/rm/command.py
+++ b/lium/cli/rm/command.py
@@ -73,20 +73,20 @@ def human_approved_removing_every_pod(pods: List[PodInfo]) -> bool:
     """
     if not sys.stdin.isatty():
         return True
-    listed = ", ".join(pod.huid for pod in pods)
-    return ui.confirm(f"Remove all {len(pods)} pods ({listed})?")
+    listed_huids = ", ".join(pod.huid for pod in pods)
+    return ui.confirm(f"Remove all {len(pods)} pods ({listed_huids})?")
 
 
 @click.command("rm")
 @click.argument("targets", required=False)
-@click.option("--all", "-a", is_flag=True, help="Remove all active pods")
+@click.option("--all", "-a", "remove_all", is_flag=True, help="Remove all active pods")
 @click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt")
 @click.option("--in", "in_duration", help="Schedule removal after duration")
 @click.option("--at", "at_time", help="Schedule removal at time")
 @handle_errors
 def rm_command(
     targets: Optional[str],
-    all: bool,
+    remove_all: bool,
     yes: bool,
     in_duration: Optional[str],
     at_time: Optional[str],
@@ -98,11 +98,11 @@ def rm_command(
     typo cannot look like a successful teardown.
     """
     lium = Lium()
-    plan = build_removal_plan(lium, targets, all, in_duration, at_time)
+    plan = build_removal_plan(lium, targets, remove_all, in_duration, at_time)
     if plan is None:
         return
 
-    if all and not yes and not human_approved_removing_every_pod(plan.pods):
+    if remove_all and not yes and not human_approved_removing_every_pod(plan.pods):
         return
 
     context = {"pods": plan.pods, "lium": lium}

--- a/lium/cli/rm/command.py
+++ b/lium/cli/rm/command.py
@@ -74,7 +74,12 @@ def human_approved_removing_every_pod(pods: List[PodInfo]) -> bool:
     if not sys.stdin.isatty():
         return True
     listed_huids = ", ".join(pod.huid for pod in pods)
-    return ui.confirm(f"Remove all {len(pods)} pods ({listed_huids})?")
+    try:
+        return ui.confirm(f"Remove all {len(pods)} pods ({listed_huids})?")
+    except EOFError:
+        # The terminal went away mid-prompt. No answer is not a yes.
+        ui.warning("\nNo answer — nothing removed")
+        return False
 
 
 @click.command("rm")

--- a/lium/cli/rm/parsing.py
+++ b/lium/cli/rm/parsing.py
@@ -7,6 +7,9 @@ from typing import List
 from lium.sdk import PodInfo
 from lium.cli.utils import parse_targets
 
+# Shared with the command layer, which maps this one error to a distinct exit code.
+NO_MATCHING_PODS = "No pods match targets"
+
 
 def parse_duration(duration_str: str) -> tuple[timedelta | None, str | None]:
     """Parse duration string like '6h', '45m', '2d', returns (timedelta, error_message)."""
@@ -117,7 +120,7 @@ def parse(
     elif targets:
         selected_pods = parse_targets(targets, all_pods)
         if not selected_pods:
-            return None, f"No pods match targets: {targets}"
+            return None, f"{NO_MATCHING_PODS}: {targets}"
     else:
         # No targets specified - will need interactive selection in command
         return None, "No targets specified"

--- a/lium/cli/ssh/command.py
+++ b/lium/cli/ssh/command.py
@@ -2,7 +2,7 @@
 
 import shutil
 import subprocess
-from typing import Tuple
+from typing import Optional, Tuple
 import click
 
 from lium.sdk import Lium, PodInfo
@@ -12,8 +12,13 @@ from . import validation, parsing
 from .actions import SshAction
 
 
-def get_ssh_method_and_pod(target: str) -> Tuple[str, PodInfo]:
-    """Helper function that check method for SSH."""
+# ssh(1) uses 255 for its own connection failures; anything else is the remote
+# shell's own exit status, which is not a failure of the lium command.
+SSH_CONNECTION_FAILED = 255
+
+
+def get_ssh_method_and_pod(target: str) -> Tuple[Optional[str], Optional[PodInfo]]:
+    """The ssh command line for a pod, or (None, None) when SSH is not possible."""
     if not shutil.which("ssh"):
         ui.error("Error: 'ssh' command not found. Please install an SSH client.")
         return None, None
@@ -40,17 +45,24 @@ def get_ssh_method_and_pod(target: str) -> Tuple[str, PodInfo]:
         return ssh_cmd, pod
 
 
-def ssh_to_pod(ssh_cmd: str, pod: PodInfo) -> None:
-    """Helper function to SSH to a pod."""
+def ssh_to_pod(ssh_cmd: str, pod: PodInfo) -> int:
+    """Open the session and return ssh's exit status.
+
+    The caller needs the status: a connection that never opened must not look
+    like a session the user closed.
+    """
     try:
         result = subprocess.run(ssh_cmd, shell=True, check=False)
 
-        if result.returncode != 0 and result.returncode != 255:
+        if result.returncode not in (0, SSH_CONNECTION_FAILED):
             ui.dim(f"\nSSH session ended with exit code {result.returncode}")
+        return result.returncode
     except KeyboardInterrupt:
         ui.warning("\nSSH session interrupted")
+        return 0
     except Exception as e:
         ui.error(f"Error executing SSH: {e}")
+        return SSH_CONNECTION_FAILED
 
 
 @click.command("ssh")

--- a/lium/cli/ssh/command.py
+++ b/lium/cli/ssh/command.py
@@ -2,26 +2,30 @@
 
 import shutil
 import subprocess
-from typing import Optional, Tuple
+from typing import Tuple
 import click
 
 from lium.sdk import Lium, PodInfo
 from lium.cli import ui
 from lium.cli.utils import handle_errors, parse_targets
+from lium.cli.utils import CliFailure, EXIT_POD_NOT_FOUND, EXIT_SSH_ERROR
 from . import validation, parsing
 from .actions import SshAction
 
 
 # ssh(1) uses 255 for its own connection failures; anything else is the remote
 # shell's own exit status, which is not a failure of the lium command.
-SSH_CONNECTION_FAILED = 255
+_SSH_CONNECTION_FAILED = 255
 
 
-def get_ssh_method_and_pod(target: str) -> Tuple[Optional[str], Optional[PodInfo]]:
-    """The ssh command line for a pod, or (None, None) when SSH is not possible."""
+def get_ssh_method_and_pod(target: str) -> Tuple[str, PodInfo]:
+    """The ssh command line for a pod. Raises when SSH is not possible."""
     if not shutil.which("ssh"):
-        ui.error("Error: 'ssh' command not found. Please install an SSH client.")
-        return None, None
+        raise CliFailure(
+            "ssh_client_missing",
+            "'ssh' command not found. Please install an SSH client.",
+            EXIT_SSH_ERROR,
+        )
 
     lium = Lium()
     all_pods = lium.ps()
@@ -30,11 +34,14 @@ def get_ssh_method_and_pod(target: str) -> Tuple[Optional[str], Optional[PodInfo
     pod = pods[0] if pods else None
 
     if not pod:
-        return None, None
+        raise CliFailure("pod_not_found", f"No pods match targets: {target}", EXIT_POD_NOT_FOUND)
 
     if not pod.ssh_cmd:
-        ui.error(f"No SSH connection available for pod '{pod.huid}'")
-        return None, None
+        raise CliFailure(
+            "ssh_unavailable",
+            f"No SSH connection available for pod '{pod.huid}'",
+            EXIT_SSH_ERROR,
+        )
 
     try:
         ssh_cmd = lium.ssh(pod)
@@ -45,24 +52,23 @@ def get_ssh_method_and_pod(target: str) -> Tuple[Optional[str], Optional[PodInfo
         return ssh_cmd, pod
 
 
-def ssh_to_pod(ssh_cmd: str, pod: PodInfo) -> int:
-    """Open the session and return ssh's exit status.
+def ssh_session_connected(ssh_cmd: str) -> bool:
+    """Open the session; False when the connection never opened.
 
-    The caller needs the status: a connection that never opened must not look
-    like a session the user closed.
+    A remote shell exiting non-zero is the user's business, not a failure of the
+    lium command — only ssh's own connection failure is.
     """
     try:
         result = subprocess.run(ssh_cmd, shell=True, check=False)
 
-        if result.returncode not in (0, SSH_CONNECTION_FAILED):
+        if result.returncode not in (0, _SSH_CONNECTION_FAILED):
             ui.dim(f"\nSSH session ended with exit code {result.returncode}")
-        return result.returncode
+        return result.returncode != _SSH_CONNECTION_FAILED
     except KeyboardInterrupt:
         ui.warning("\nSSH session interrupted")
-        return 0
+        return True
     except Exception as e:
-        ui.error(f"Error executing SSH: {e}")
-        return SSH_CONNECTION_FAILED
+        raise CliFailure("ssh_failed", f"Error executing SSH: {e}", EXIT_SSH_ERROR)
 
 
 @click.command("ssh")

--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -309,6 +309,10 @@ class PrepareSSHAction:
         try:
             from lium.cli.ssh.command import get_ssh_method_and_pod
             ssh_cmd, pod = get_ssh_method_and_pod(pod_name)
+            if not ssh_cmd or not pod:
+                return ActionResult(
+                    ok=False, data={}, error=f"No SSH connection available for pod '{pod_name}'"
+                )
             return ActionResult(ok=True, data={"ssh_cmd": ssh_cmd, "pod": pod})
 
         except Exception as e:

--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -309,10 +309,6 @@ class PrepareSSHAction:
         try:
             from lium.cli.ssh.command import get_ssh_method_and_pod
             ssh_cmd, pod = get_ssh_method_and_pod(pod_name)
-            if not ssh_cmd or not pod:
-                return ActionResult(
-                    ok=False, data={}, error=f"No SSH connection available for pod '{pod_name}'"
-                )
             return ActionResult(ok=True, data={"ssh_cmd": ssh_cmd, "pod": pod})
 
         except Exception as e:

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -415,5 +415,11 @@ def up_command(
     ssh_cmd = result.data["ssh_cmd"]
     pod = result.data["pod"]
 
-    from lium.cli.ssh.command import ssh_to_pod
-    ssh_to_pod(ssh_cmd, pod)
+    from lium.cli.ssh.command import SSH_CONNECTION_FAILED, ssh_to_pod
+
+    if ssh_to_pod(ssh_cmd, pod) == SSH_CONNECTION_FAILED:
+        raise CliFailure(
+            "ssh_connection_failed",
+            f"Pod {pod.huid} is running but the SSH connection failed",
+            EXIT_SSH_ERROR,
+        )

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -32,6 +32,7 @@ from .actions import (
 @click.option("--ttl", help="Auto-terminate after duration (e.g., 6h, 45m, 2d)")
 @click.option("--until", help="Auto-terminate at time in local timezone (e.g., 'today 23:00', 'tomorrow 01:00', '2025-10-20 15:30')")
 @click.option("--jupyter", is_flag=True, help="Install Jupyter Notebook (automatically selects available port)")
+@click.option("--no-ssh", "no_ssh", is_flag=True, help="Create the pod and return instead of opening an SSH session")
 @click.option("--image", help="Docker image to run (e.g., pytorch/pytorch:2.0, nvidia/cuda:12.0)")
 @click.option("--internal-ports", help="Internal ports to expose (comma-separated, e.g., 22,8000,8080)")
 @click.option("--dockerfile", type=click.Path(exists=True, dir_okay=False, readable=True), help="Path to a Dockerfile to build the pod image from (custom build; mutually exclusive with --image/--template_id)")
@@ -58,6 +59,7 @@ def up_command(
     ttl: Optional[str],
     until: Optional[str],
     jupyter: bool,
+    no_ssh: bool,
     image: Optional[str],
     internal_ports: Optional[str],
     dockerfile: Optional[str],
@@ -369,6 +371,13 @@ def up_command(
                 click.echo(line)
         except KeyboardInterrupt:
             ui.dim("\nStopped following logs")
+        return
+
+    # Always state what was created: a caller that only gets an SSH banner has
+    # no way to name the pod it is now paying for.
+    ui.info(f"Pod {ui.styled(pod.huid, 'pod_id')} ready  (name: {pod_name}, id: {pod_id})")
+
+    if no_ssh:
         return
 
     # Standard mode: SSH into the pod

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -180,10 +180,11 @@ def up_command(
         max_bytes = 64 * 1024
         size_bytes = len(dockerfile_content.encode("utf-8"))
         if size_bytes > max_bytes:
-            ui.error(
-                f"Dockerfile is too large ({size_bytes} bytes); max is {max_bytes} bytes (64 KiB)"
+            raise CliFailure(
+                "dockerfile_too_large",
+                f"Dockerfile is too large ({size_bytes} bytes); max is {max_bytes} bytes (64 KiB)",
+                EXIT_CONFIGURATION_ERROR,
             )
-            return
 
     lium = Lium(source="cli")
 

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -3,7 +3,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_GENERAL_ERROR,
+    EXIT_SSH_ERROR,
+    ensure_config,
+    handle_errors,
+)
 from lium.cli.completion import get_gpu_completions
 from . import validation, parsing
 from .actions import (
@@ -192,8 +198,7 @@ def up_command(
     )
 
     if not result.ok:
-        ui.error(result.error)
-        return
+        raise CliFailure("node_selection_failed", result.error, EXIT_GENERAL_ERROR)
 
     executor = result.data["executor"]
 
@@ -236,8 +241,7 @@ def up_command(
             })
         )
         if not result.ok:
-            ui.error(result.error)
-            return
+            raise CliFailure("template_failed", result.error, EXIT_GENERAL_ERROR)
         template = result.data["template"]
     else:
         action = ResolveTemplateAction()
@@ -247,8 +251,7 @@ def up_command(
             "executor": executor
         })
         if not result.ok:
-            ui.error(result.error)
-            return
+            raise CliFailure("template_failed", result.error, EXIT_GENERAL_ERROR)
         template = result.data["template"]
         # API-based estimate using resolved template ID
         try:
@@ -286,8 +289,7 @@ def up_command(
         )
 
         if not result.ok:
-            ui.error(result.error)
-            return
+            raise CliFailure("volume_failed", result.error, EXIT_GENERAL_ERROR)
 
         volume_id = result.data["volume_id"]
 
@@ -308,8 +310,7 @@ def up_command(
     )
 
     if not result.ok:
-        ui.error(result.error)
-        return
+        raise CliFailure("rent_failed", result.error, EXIT_GENERAL_ERROR)
 
     pod_id = result.data["pod_id"]
     pod_name = result.data["pod_name"]
@@ -324,8 +325,10 @@ def up_command(
     )
 
     if not result.ok:
-        ui.error(result.error)
-        return
+        # The pod is rented and already billing. Name it before failing, or the
+        # caller cannot clean up what it is now paying for.
+        ui.error(f"Pod {pod_name} (id: {pod_id}) was created but did not become ready")
+        raise CliFailure("pod_not_ready", result.error, EXIT_GENERAL_ERROR)
 
     pod = result.data["pod"]
 
@@ -341,7 +344,12 @@ def up_command(
         )
 
         if not result.ok:
-            ui.error(result.error)
+            ui.info(f"Pod {ui.styled(pod.huid, 'pod_id')} (name: {pod_name}, id: {pod_id})")
+            raise CliFailure(
+                "termination_not_scheduled",
+                f"Pod is running but auto-termination was NOT scheduled: {result.error}",
+                EXIT_GENERAL_ERROR,
+            )
 
     if jupyter:
         action = InstallJupyterAction()
@@ -355,7 +363,12 @@ def up_command(
         )
 
         if not result.ok:
-            ui.error(result.error)
+            ui.info(f"Pod {ui.styled(pod.huid, 'pod_id')} (name: {pod_name}, id: {pod_id})")
+            raise CliFailure(
+                "jupyter_install_failed",
+                f"Pod is running but Jupyter was NOT installed: {result.error}",
+                EXIT_GENERAL_ERROR,
+            )
 
     # Always state what was created: a caller that only gets an SSH banner or a
     # log stream has no way to name the pod it is now paying for.
@@ -390,8 +403,7 @@ def up_command(
     )
 
     if not result.ok:
-        ui.error(result.error)
-        return
+        raise CliFailure("ssh_unavailable", result.error, EXIT_SSH_ERROR)
 
     ssh_cmd = result.data["ssh_cmd"]
     pod = result.data["pod"]

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -338,6 +338,7 @@ def up_command(
         raise CliFailure("pod_not_ready", result.error, EXIT_GENERAL_ERROR)
 
     pod = result.data["pod"]
+    pod_label = f"Pod {ui.styled(pod.huid, 'pod_id')} (name: {pod_name}, id: {pod_id})"
 
     if termination_time:
         action = ScheduleTerminationAction()
@@ -351,7 +352,7 @@ def up_command(
         )
 
         if not result.ok:
-            ui.info(f"Pod {ui.styled(pod.huid, 'pod_id')} (name: {pod_name}, id: {pod_id})")
+            ui.info(pod_label)
             raise CliFailure(
                 "termination_not_scheduled",
                 f"Pod is running but auto-termination was NOT scheduled: {result.error}",
@@ -370,7 +371,7 @@ def up_command(
         )
 
         if not result.ok:
-            ui.info(f"Pod {ui.styled(pod.huid, 'pod_id')} (name: {pod_name}, id: {pod_id})")
+            ui.info(pod_label)
             raise CliFailure(
                 "jupyter_install_failed",
                 f"Pod is running but Jupyter was NOT installed: {result.error}",
@@ -379,7 +380,7 @@ def up_command(
 
     # Always state what was created: a caller that only gets an SSH banner or a
     # log stream has no way to name the pod it is now paying for.
-    ui.info(f"Pod {ui.styled(pod.huid, 'pod_id')} ready  (name: {pod_name}, id: {pod_id})")
+    ui.info(f"{pod_label} ready")
 
     if no_ssh:
         return
@@ -415,9 +416,9 @@ def up_command(
     ssh_cmd = result.data["ssh_cmd"]
     pod = result.data["pod"]
 
-    from lium.cli.ssh.command import SSH_CONNECTION_FAILED, ssh_to_pod
+    from lium.cli.ssh.command import ssh_session_connected
 
-    if ssh_to_pod(ssh_cmd, pod) == SSH_CONNECTION_FAILED:
+    if not ssh_session_connected(ssh_cmd):
         raise CliFailure(
             "ssh_connection_failed",
             f"Pod {pod.huid} is running but the SSH connection failed",

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -357,6 +357,13 @@ def up_command(
         if not result.ok:
             ui.error(result.error)
 
+    # Always state what was created: a caller that only gets an SSH banner or a
+    # log stream has no way to name the pod it is now paying for.
+    ui.info(f"Pod {ui.styled(pod.huid, 'pod_id')} ready  (name: {pod_name}, id: {pod_id})")
+
+    if no_ssh:
+        return
+
     # Docker-run mode: stream logs instead of SSH
     if docker_run_mode:
         from lium.cli.logs.actions import StreamLogsAction
@@ -371,13 +378,6 @@ def up_command(
                 click.echo(line)
         except KeyboardInterrupt:
             ui.dim("\nStopped following logs")
-        return
-
-    # Always state what was created: a caller that only gets an SSH banner has
-    # no way to name the pod it is now paying for.
-    ui.info(f"Pod {ui.styled(pod.huid, 'pod_id')} ready  (name: {pod_name}, id: {pod_id})")
-
-    if no_ssh:
         return
 
     # Standard mode: SSH into the pod

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -5,6 +5,7 @@ from lium.sdk import Lium
 from lium.cli import ui
 from lium.cli.utils import (
     CliFailure,
+    EXIT_CONFIGURATION_ERROR,
     EXIT_GENERAL_ERROR,
     EXIT_SSH_ERROR,
     ensure_config,
@@ -120,21 +121,18 @@ def up_command(
         executor_id, gpu, count, country, ttl, until, image, template_id, dockerfile
     )
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Parse env vars if provided
     env_dict = {}
     if env:
         env_dict, error = validation.parse_env_vars(env)
         if error:
-            ui.error(error)
-            return
+            raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     parsed, error = parsing.parse(ttl, until, volume)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     termination_time = parsed.get("termination_time")
     volume_id = parsed.get("volume_id")
@@ -160,20 +158,25 @@ def up_command(
             if supplied
         ]
         if unsupported:
-            ui.error(
+            raise CliFailure(
+                "invalid_arguments",
                 f"{', '.join(unsupported)} cannot be combined with --dockerfile "
-                "(the Dockerfile defines the image's env, entrypoint, command, and ports)"
+                "(the Dockerfile defines the image's env, entrypoint, command, and ports)",
+                EXIT_CONFIGURATION_ERROR,
             )
-            return
 
         try:
             dockerfile_content = Path(dockerfile).read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
-            ui.error(f"Could not read Dockerfile: {exc}")
-            return
+            raise CliFailure(
+                "unreadable_dockerfile",
+                f"Could not read Dockerfile: {exc}",
+                EXIT_CONFIGURATION_ERROR,
+            )
         if not dockerfile_content.strip():
-            ui.error("Dockerfile is empty")
-            return
+            raise CliFailure(
+                "empty_dockerfile", "Dockerfile is empty", EXIT_CONFIGURATION_ERROR
+            )
         max_bytes = 64 * 1024
         size_bytes = len(dockerfile_content.encode("utf-8"))
         if size_bytes > max_bytes:
@@ -225,8 +228,11 @@ def up_command(
                 if 22 not in ports_list:
                     ports_list.insert(0, 22)
             except ValueError:
-                ui.error("Invalid port format. Use comma-separated integers (e.g., 22,8000,8080)")
-                return
+                raise CliFailure(
+                    "invalid_ports",
+                    "Invalid port format. Use comma-separated integers (e.g., 22,8000,8080)",
+                    EXIT_CONFIGURATION_ERROR,
+                )
 
         action = CreateEphemeralTemplateAction()
         result = ui.load(

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -243,7 +243,18 @@ def timed_step_status(step: int = 0, total_steps: int = 0, message: str = ""):
         raise
 
 
-def _emit_json_error(code: str, message: str) -> None:
+# Exit codes published in docs/developers/cli/reference/index.md. Commands import
+# these rather than spelling the numbers, so the published table stays the one
+# source of truth.
+EXIT_GENERAL_ERROR = 1
+EXIT_CONFIGURATION_ERROR = 2
+EXIT_API_ERROR = 3
+EXIT_SSH_ERROR = 4
+EXIT_POD_NOT_FOUND = 5
+EXIT_PERMISSION_DENIED = 6
+
+
+def _emit_json_error(code: str, message: str, exit_code: int = EXIT_GENERAL_ERROR) -> None:
     """Print a machine-readable error envelope to stderr and exit non-zero.
 
     Keeps stdout clean for JSON consumers (agents): on success stdout carries
@@ -252,17 +263,20 @@ def _emit_json_error(code: str, message: str) -> None:
     """
     envelope = {"ok": False, "error": {"code": code, "message": message}}
     click.echo(json.dumps(envelope, sort_keys=True), err=True)
-    raise SystemExit(1)
+    raise SystemExit(exit_code)
 
 
 def handle_errors(func):
     """Decorator to handle CLI errors gracefully.
 
+    Every handled error exits non-zero. A caller chaining commands with ``&&``
+    can only see failure through the exit code, so reporting an error and then
+    exiting 0 tells it the command worked.
+
     When the wrapped command was invoked with ``--json`` (a ``json_output``
-    flag), errors are rendered as a JSON envelope on stderr and the process
-    exits non-zero, so machine consumers get parseable output instead of
-    Rich-formatted text on stdout. Otherwise the human-readable rendering is
-    preserved.
+    flag), errors are rendered as a JSON envelope on stderr, so machine
+    consumers get parseable output instead of Rich-formatted text on stdout.
+    Otherwise the human-readable rendering is preserved.
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -283,14 +297,17 @@ def handle_errors(func):
                 console.dim("Or set LIUM_API_KEY environment variable")
             else:
                 console.error(f"Error: {e}")
+            raise SystemExit(EXIT_CONFIGURATION_ERROR)
         except LiumError as e:
             if json_output:
                 _emit_json_error("lium_error", str(e))
             console.error(f"Error: {e}")
+            raise SystemExit(EXIT_GENERAL_ERROR)
         except Exception as e:
             if json_output:
                 _emit_json_error("unexpected_error", str(e))
             console.error(f"Unexpected error: {e}")
+            raise SystemExit(EXIT_GENERAL_ERROR)
     return wrapper
 
 

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -254,6 +254,21 @@ EXIT_POD_NOT_FOUND = 5
 EXIT_PERMISSION_DENIED = 6
 
 
+class CliFailure(Exception):
+    """A command failing for a reason it can name.
+
+    Raised instead of exiting inline so that rendering — JSON envelope for a
+    machine caller, Rich text for a human — and the exit code are decided in one
+    place, ``handle_errors``, rather than at every error site in every command.
+    """
+
+    def __init__(self, code: str, message: str, exit_code: int = EXIT_GENERAL_ERROR) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.exit_code = exit_code
+
+
 def _emit_json_error(code: str, message: str, exit_code: int = EXIT_GENERAL_ERROR) -> None:
     """Print a machine-readable error envelope to stderr and exit non-zero.
 
@@ -285,11 +300,18 @@ def handle_errors(func):
             return func(*args, **kwargs)
         except (click.ClickException, click.Abort):
             raise
+        except CliFailure as e:
+            if json_output:
+                _emit_json_error(e.code, e.message, e.exit_code)
+            console.error(e.message)
+            raise SystemExit(e.exit_code)
         except ValueError as e:
             is_missing_api_key = "No API key found" in str(e)
             if json_output:
                 _emit_json_error(
-                    "no_api_key" if is_missing_api_key else "value_error", str(e)
+                    "no_api_key" if is_missing_api_key else "value_error",
+                    str(e),
+                    EXIT_CONFIGURATION_ERROR,
                 )
             elif is_missing_api_key:
                 console.error("No API key configured")

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -901,6 +901,9 @@ class Lium:
 
         with self.ssh_connection(pod) as client:
             stdin, stdout, stderr = client.exec_command(command)
+            # Send EOF: a remote command that reads stdin waits forever otherwise,
+            # and this call has no stdin to give it.
+            stdin.close()
             exit_code = stdout.channel.recv_exit_status()
             return {
                 "stdout": stdout.read().decode("utf-8", errors="replace"),

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -11,12 +11,15 @@ cheapest node" hands back the most expensive one.
 import json
 from types import SimpleNamespace
 
+import pytest
 from click.testing import CliRunner
 
 from lium.cli.cli import cli
 from lium.cli.commands import exec as exec_module
+from lium.cli.ls import command as ls_command_module
 from lium.cli.ls import display as ls_display
 from lium.cli.rm import command as rm_module
+from lium.cli.utils import EXIT_POD_NOT_FOUND
 
 
 def _pod(huid: str = "eager-wolf-aa", name: str = "my-pod") -> SimpleNamespace:
@@ -35,13 +38,16 @@ def _executor(huid: str, price_per_hour: float, download: int) -> SimpleNamespac
         download_speed=download,
         upload_speed=download,
         specs={"network": {"download_speed": download, "upload_speed": download}},
+        docker_in_docker=False,
+        max_cuda_version=12.4,
+        tier="secure",
     )
 
 
 class _FakeLium:
     """Stands in for the SDK: one pod, and an exec result the test dictates."""
 
-    result: dict = {}
+    result: dict[str, object] = {}
 
     def __init__(self, *args, **kwargs):
         pass
@@ -49,14 +55,25 @@ class _FakeLium:
     def ps(self):
         return [_pod()]
 
-    def exec(self, pod, command=None, env=None, timeout=None):
+    def exec(self, pod, command=None, env=None):
         return dict(self.result)
 
 
-def _run_exec(monkeypatch, result: dict, extra_args: list[str] | None = None):
+def _run_exec(
+    monkeypatch,
+    result: dict[str, object],
+    extra_args: list[str] | None = None,
+    target: str = "my-pod",
+):
     _FakeLium.result = result
     monkeypatch.setattr(exec_module, "Lium", _FakeLium)
-    return CliRunner().invoke(cli, ["exec", "my-pod", "echo hi", *(extra_args or [])])
+    return CliRunner().invoke(cli, ["exec", target, "echo hi", *(extra_args or [])])
+
+
+def _run_rm(monkeypatch, target: str = "my-pod"):
+    _FakeRmLium.removed = []
+    monkeypatch.setattr(rm_module, "Lium", _FakeRmLium)
+    return CliRunner().invoke(cli, ["rm", target, "-y"])
 
 
 def test_exec_keeps_stdout_when_the_remote_command_fails(monkeypatch):
@@ -97,24 +114,26 @@ def test_exec_json_carries_stdout_stderr_and_exit_code(monkeypatch):
     )
 
     payload = json.loads(result.output)
-    assert payload["stdout"] == "out\n"
-    assert payload["stderr"] == "err\n"
-    assert payload["exit_code"] == 7
+    assert payload["ok"] is False
+    assert payload["results"] == [
+        {"pod": "eager-wolf-aa", "stdout": "out\n", "stderr": "err\n", "exit_code": 7, "error": None}
+    ]
     assert result.exit_code == 7
 
 
 def test_exec_fails_loudly_when_no_pod_matches(monkeypatch):
     """A typo must not read as a successful run on a pod that was never touched."""
-    _FakeLium.result = {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
-    monkeypatch.setattr(exec_module, "Lium", _FakeLium)
+    result = _run_exec(
+        monkeypatch,
+        {"success": True, "exit_code": 0, "stdout": "", "stderr": ""},
+        target="no-such-pod-zz",
+    )
 
-    result = CliRunner().invoke(cli, ["exec", "no-such-pod-zz", "echo hi"])
-
-    assert result.exit_code != 0
+    assert result.exit_code == EXIT_POD_NOT_FOUND
 
 
 class _FakeRmLium:
-    removed: list = []
+    removed: list[str] = []
 
     def __init__(self, *args, **kwargs):
         pass
@@ -126,57 +145,74 @@ class _FakeRmLium:
         _FakeRmLium.removed.append(pod.huid)
 
 
-def test_rm_accepts_yes_flag(monkeypatch):
-    """Agents learn `-y` on `up`; the same idiom must not fail on teardown."""
-    _FakeRmLium.removed = []
-    monkeypatch.setattr(rm_module, "Lium", _FakeRmLium)
-
-    result = CliRunner().invoke(cli, ["rm", "my-pod", "-y"])
+def test_rm_accepts_yes_and_reports_what_it_removed(monkeypatch):
+    """Agents learn `-y` on `up`, and silence on teardown reads like a no-op."""
+    result = _run_rm(monkeypatch)
 
     assert result.exit_code == 0
     assert _FakeRmLium.removed == ["eager-wolf-aa"]
-
-
-def test_rm_reports_what_it_removed(monkeypatch):
-    """Silence on the one mandatory step is indistinguishable from a no-op."""
-    _FakeRmLium.removed = []
-    monkeypatch.setattr(rm_module, "Lium", _FakeRmLium)
-
-    result = CliRunner().invoke(cli, ["rm", "my-pod", "-y"])
-
     assert "eager-wolf-aa" in result.output
 
 
 def test_rm_fails_loudly_when_no_pod_matches(monkeypatch):
     """`lium rm <typo>` must not look exactly like a successful termination."""
-    _FakeRmLium.removed = []
-    monkeypatch.setattr(rm_module, "Lium", _FakeRmLium)
+    result = _run_rm(monkeypatch, target="no-such-pod-zz")
 
-    result = CliRunner().invoke(cli, ["rm", "no-such-pod-zz", "-y"])
-
-    assert result.exit_code != 0
+    assert result.exit_code == EXIT_POD_NOT_FOUND
     assert _FakeRmLium.removed == []
 
 
-def test_explicit_sort_is_not_overridden_by_the_pareto_star():
+@pytest.mark.parametrize("sort_by", ["price_total", "price_per_hour"])
+def test_explicit_sort_is_not_overridden_by_the_pareto_star(sort_by):
     """"Cheapest first" must mean cheapest first, star or no star."""
     cheap = _executor("cheap-node", price_per_hour=0.30, download=10)
     expensive_but_starred = _executor("starred-node", price_per_hour=64.00, download=9999)
 
     ordered, _ = ls_display.sort_executors(
-        [cheap, expensive_but_starred], sort_by="price_total", pareto_first=False
+        [cheap, expensive_but_starred], sort_by=sort_by, pareto_first=False
     )
 
     assert ordered[0].huid == "cheap-node"
 
 
-def test_price_per_hour_is_accepted_as_a_sort_key():
-    """The JSON field is price_per_hour; --sort must accept the name it emits."""
+@pytest.mark.parametrize("sort_by", ["price_total", "price_per_hour"])
+def test_cheapest_sort_survives_the_whole_ls_command(monkeypatch, sort_by):
+    """End to end: the option a caller types must reach the sort it names."""
     cheap = _executor("cheap-node", price_per_hour=0.30, download=10)
-    pricey = _executor("pricey-node", price_per_hour=64.00, download=9999)
+    expensive_but_starred = _executor("starred-node", price_per_hour=64.00, download=9999)
 
-    ordered, _ = ls_display.sort_executors(
-        [cheap, pricey], sort_by="price_per_hour", pareto_first=False
-    )
+    class _FakeLsLium:
+        def __init__(self, *args, **kwargs):
+            pass
 
-    assert ordered[0].huid == "cheap-node"
+        def ls(self, **kwargs):
+            return [expensive_but_starred, cheap]
+
+    monkeypatch.setattr(ls_command_module, "Lium", _FakeLsLium)
+    monkeypatch.setattr(ls_command_module, "store_executor_selection", lambda executors: None)
+
+    result = CliRunner().invoke(cli, ["ls", "--sort", sort_by, "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert [row["huid"] for row in json.loads(result.output)][0] == "cheap-node"
+
+
+def test_default_ls_ordering_still_puts_the_starred_node_first(monkeypatch):
+    """Without --sort the ★ ordering a human reads is unchanged."""
+    cheap = _executor("cheap-node", price_per_hour=0.30, download=10)
+    expensive_but_starred = _executor("starred-node", price_per_hour=64.00, download=9999)
+
+    class _FakeLsLium:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ls(self, **kwargs):
+            return [cheap, expensive_but_starred]
+
+    monkeypatch.setattr(ls_command_module, "Lium", _FakeLsLium)
+    monkeypatch.setattr(ls_command_module, "store_executor_selection", lambda executors: None)
+
+    result = CliRunner().invoke(cli, ["ls", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)[0]["huid"] == "starred-node"

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -19,7 +19,7 @@ from lium.cli.commands import exec as exec_module
 from lium.cli.ls import command as ls_command_module
 from lium.cli.ls import display as ls_display
 from lium.cli.rm import command as rm_module
-from lium.cli.utils import EXIT_POD_NOT_FOUND
+from lium.cli.utils import EXIT_CONFIGURATION_ERROR, EXIT_POD_NOT_FOUND
 
 
 def _pod(huid: str = "eager-wolf-aa", name: str = "my-pod") -> SimpleNamespace:
@@ -216,3 +216,103 @@ def test_default_ls_ordering_still_puts_the_starred_node_first(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)[0]["huid"] == "starred-node"
+
+
+def test_exec_script_flag_reads_the_file(monkeypatch, tmp_path):
+    """--script is the documented way to send a multi-line job; it must work."""
+    script = tmp_path / "job.sh"
+    script.write_text("echo from-script\n")
+    _FakeLium.result = {"success": True, "exit_code": 0, "stdout": "ran\n", "stderr": ""}
+    monkeypatch.setattr(exec_module, "Lium", _FakeLium)
+
+    result = CliRunner().invoke(cli, ["exec", "my-pod", "--script", str(script)])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_exec_config_errors_stay_json_under_json(monkeypatch):
+    """A machine caller must get the envelope on every failure, not just some."""
+    _FakeLium.result = {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
+    monkeypatch.setattr(exec_module, "Lium", _FakeLium)
+
+    result = CliRunner().invoke(cli, ["exec", "my-pod", "-e", "NOT_A_PAIR", "cmd", "--json"])
+
+    assert result.exit_code == EXIT_CONFIGURATION_ERROR
+    assert json.loads(result.stderr)["ok"] is False
+
+
+def test_exec_stderr_carries_no_rich_markup(monkeypatch):
+    """The command's own stderr must reach the caller unstyled."""
+    result = _run_exec(
+        monkeypatch,
+        {"success": False, "exit_code": 3, "stdout": "", "stderr": "boom\n"},
+    )
+
+    assert "boom" in result.output
+    assert "[/]" not in result.output
+
+
+def test_rm_named_pod_on_an_empty_account_fails(monkeypatch):
+    """A typo must fail even when the account happens to hold no pods."""
+
+    class _EmptyLium:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ps(self):
+            return []
+
+    monkeypatch.setattr(rm_module, "Lium", _EmptyLium)
+
+    result = CliRunner().invoke(cli, ["rm", "no-such-pod-zz", "-y"])
+
+    assert result.exit_code == EXIT_POD_NOT_FOUND
+
+
+def test_rm_all_on_an_empty_account_is_a_no_op(monkeypatch):
+    """Removing everything when there is nothing is success, not failure."""
+
+    class _EmptyLium:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ps(self):
+            return []
+
+    monkeypatch.setattr(rm_module, "Lium", _EmptyLium)
+
+    result = CliRunner().invoke(cli, ["rm", "--all", "-y"])
+
+    assert result.exit_code == 0
+
+
+def test_exec_missing_script_still_speaks_json(monkeypatch):
+    """A bad --script path must not fall out as click usage text under --json."""
+    _FakeLium.result = {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
+    monkeypatch.setattr(exec_module, "Lium", _FakeLium)
+
+    result = CliRunner().invoke(
+        cli, ["exec", "my-pod", "--script", "/no/such/file.sh", "--json"]
+    )
+
+    assert result.exit_code == EXIT_CONFIGURATION_ERROR
+    assert json.loads(result.stderr)["error"]["code"] == "unreadable_script"
+
+
+def test_exec_json_keeps_stdout_clean_when_the_api_fails(monkeypatch):
+    """stdout belongs to the JSON consumer; the progress spinner must stay off it."""
+
+    class _BrokenLium:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ps(self):
+            raise RuntimeError("api down")
+
+    monkeypatch.setattr(exec_module, "Lium", _BrokenLium)
+
+    result = CliRunner().invoke(cli, ["exec", "my-pod", "echo hi", "--json"])
+
+    assert result.exit_code != 0
+    assert result.stdout == ""
+    assert json.loads(result.stderr)["ok"] is False

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -348,3 +348,11 @@ def test_ssh_session_connected_reports_only_connection_failure(monkeypatch, retu
     )
 
     assert ssh_module.ssh_session_connected("ssh root@x") is connected
+
+
+def test_rm_all_treats_a_lost_terminal_as_no(monkeypatch):
+    """No answer is not a yes — an EOF at the prompt must not wipe the account."""
+    monkeypatch.setattr(rm_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(rm_module.ui, "confirm", lambda message: (_ for _ in ()).throw(EOFError()))
+
+    assert rm_module.human_approved_removing_every_pod([_pod()]) is False

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -316,3 +316,28 @@ def test_exec_json_keeps_stdout_clean_when_the_api_fails(monkeypatch):
     assert result.exit_code != 0
     assert result.stdout == ""
     assert json.loads(result.stderr)["ok"] is False
+
+
+def test_up_fails_when_ssh_is_unavailable(monkeypatch):
+    """A pod that is rented but unreachable must not report success — DAH-2556."""
+    from lium.cli.up import actions as up_actions
+
+    monkeypatch.setattr(
+        "lium.cli.ssh.command.get_ssh_method_and_pod", lambda pod_name: (None, None)
+    )
+
+    result = up_actions.PrepareSSHAction().execute({"pod_name": "brave-orbit-b9"})
+
+    assert result.ok is False
+    assert "brave-orbit-b9" in result.error
+
+
+def test_ssh_to_pod_returns_the_connection_status(monkeypatch):
+    """up needs the status: a connection that never opened is not a closed session."""
+    from lium.cli.ssh import command as ssh_module
+
+    monkeypatch.setattr(
+        ssh_module.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=255)
+    )
+
+    assert ssh_module.ssh_to_pod("ssh root@x", _pod()) == ssh_module.SSH_CONNECTION_FAILED

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -168,9 +168,7 @@ def test_explicit_sort_is_not_overridden_by_the_pareto_star(sort_by):
     cheap = _executor("cheap-node", price_per_hour=0.30, download=10)
     expensive_but_starred = _executor("starred-node", price_per_hour=64.00, download=9999)
 
-    ordered, _ = ls_display.sort_executors(
-        [cheap, expensive_but_starred], sort_by=sort_by, pareto_first=False
-    )
+    ordered, _ = ls_display.sort_executors([cheap, expensive_but_starred], sort_by=sort_by)
 
     assert ordered[0].huid == "cheap-node"
 
@@ -321,10 +319,16 @@ def test_exec_json_keeps_stdout_clean_when_the_api_fails(monkeypatch):
 def test_up_fails_when_ssh_is_unavailable(monkeypatch):
     """A pod that is rented but unreachable must not report success — DAH-2556."""
     from lium.cli.up import actions as up_actions
+    from lium.cli.utils import CliFailure, EXIT_SSH_ERROR
 
-    monkeypatch.setattr(
-        "lium.cli.ssh.command.get_ssh_method_and_pod", lambda pod_name: (None, None)
-    )
+    def _no_ssh(pod_name):
+        raise CliFailure(
+            "ssh_unavailable",
+            f"No SSH connection available for pod '{pod_name}'",
+            EXIT_SSH_ERROR,
+        )
+
+    monkeypatch.setattr("lium.cli.ssh.command.get_ssh_method_and_pod", _no_ssh)
 
     result = up_actions.PrepareSSHAction().execute({"pod_name": "brave-orbit-b9"})
 
@@ -332,12 +336,15 @@ def test_up_fails_when_ssh_is_unavailable(monkeypatch):
     assert "brave-orbit-b9" in result.error
 
 
-def test_ssh_to_pod_returns_the_connection_status(monkeypatch):
-    """up needs the status: a connection that never opened is not a closed session."""
+@pytest.mark.parametrize(
+    "returncode, connected", [(0, True), (3, True), (255, False)]
+)
+def test_ssh_session_connected_reports_only_connection_failure(monkeypatch, returncode, connected):
+    """A remote shell exiting non-zero is the user's business; 255 is ours."""
     from lium.cli.ssh import command as ssh_module
 
     monkeypatch.setattr(
-        ssh_module.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=255)
+        ssh_module.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=returncode)
     )
 
-    assert ssh_module.ssh_to_pod("ssh root@x", _pod()) == ssh_module.SSH_CONNECTION_FAILED
+    assert ssh_module.ssh_session_connected("ssh root@x") is connected

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -1,0 +1,182 @@
+"""DAH-2556: the CLI's contract with a non-interactive caller.
+
+An autonomous agent drives the CLI through a pipe: it cannot read Rich-formatted
+hints, it cannot answer a prompt, and the only two things it can act on are the
+process exit code and what lands on stdout. Today a failed remote command loses
+its stdout and still exits 0, `rm` rejects the `-y` an agent learned on `up`,
+and an explicit `--sort` is overridden by the Pareto star, so "give me the
+cheapest node" hands back the most expensive one.
+"""
+
+import json
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from lium.cli.cli import cli
+from lium.cli.commands import exec as exec_module
+from lium.cli.ls import display as ls_display
+from lium.cli.rm import command as rm_module
+
+
+def _pod(huid: str = "eager-wolf-aa", name: str = "my-pod") -> SimpleNamespace:
+    return SimpleNamespace(id="pod-uuid-1", huid=huid, name=name)
+
+
+def _executor(huid: str, price_per_hour: float, download: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=f"id-{huid}",
+        huid=huid,
+        gpu_type="RTX4090",
+        gpu_count=1,
+        price_per_hour=price_per_hour,
+        price_per_gpu=price_per_hour,
+        location={"country": "Ukraine", "country_code": "UA"},
+        download_speed=download,
+        upload_speed=download,
+        specs={"network": {"download_speed": download, "upload_speed": download}},
+    )
+
+
+class _FakeLium:
+    """Stands in for the SDK: one pod, and an exec result the test dictates."""
+
+    result: dict = {}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def ps(self):
+        return [_pod()]
+
+    def exec(self, pod, command=None, env=None, timeout=None):
+        return dict(self.result)
+
+
+def _run_exec(monkeypatch, result: dict, extra_args: list[str] | None = None):
+    _FakeLium.result = result
+    monkeypatch.setattr(exec_module, "Lium", _FakeLium)
+    return CliRunner().invoke(cli, ["exec", "my-pod", "echo hi", *(extra_args or [])])
+
+
+def test_exec_keeps_stdout_when_the_remote_command_fails(monkeypatch):
+    """The log an agent needs to diagnose a crash must survive the crash."""
+    result = _run_exec(
+        monkeypatch,
+        {"success": False, "exit_code": 3, "stdout": "VISIBLE_STDOUT\n", "stderr": ""},
+    )
+
+    assert "VISIBLE_STDOUT" in result.output
+
+
+def test_exec_exits_with_the_remote_exit_code(monkeypatch):
+    """`lium exec ... && next` must not run `next` after a failed command."""
+    result = _run_exec(
+        monkeypatch,
+        {"success": False, "exit_code": 3, "stdout": "", "stderr": "boom\n"},
+    )
+
+    assert result.exit_code == 3
+
+
+def test_exec_exits_zero_when_the_remote_command_succeeds(monkeypatch):
+    result = _run_exec(
+        monkeypatch,
+        {"success": True, "exit_code": 0, "stdout": "ok\n", "stderr": ""},
+    )
+
+    assert result.exit_code == 0
+    assert "ok" in result.output
+
+
+def test_exec_json_carries_stdout_stderr_and_exit_code(monkeypatch):
+    result = _run_exec(
+        monkeypatch,
+        {"success": False, "exit_code": 7, "stdout": "out\n", "stderr": "err\n"},
+        ["--json"],
+    )
+
+    payload = json.loads(result.output)
+    assert payload["stdout"] == "out\n"
+    assert payload["stderr"] == "err\n"
+    assert payload["exit_code"] == 7
+    assert result.exit_code == 7
+
+
+def test_exec_fails_loudly_when_no_pod_matches(monkeypatch):
+    """A typo must not read as a successful run on a pod that was never touched."""
+    _FakeLium.result = {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
+    monkeypatch.setattr(exec_module, "Lium", _FakeLium)
+
+    result = CliRunner().invoke(cli, ["exec", "no-such-pod-zz", "echo hi"])
+
+    assert result.exit_code != 0
+
+
+class _FakeRmLium:
+    removed: list = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def ps(self):
+        return [_pod()]
+
+    def rm(self, pod):
+        _FakeRmLium.removed.append(pod.huid)
+
+
+def test_rm_accepts_yes_flag(monkeypatch):
+    """Agents learn `-y` on `up`; the same idiom must not fail on teardown."""
+    _FakeRmLium.removed = []
+    monkeypatch.setattr(rm_module, "Lium", _FakeRmLium)
+
+    result = CliRunner().invoke(cli, ["rm", "my-pod", "-y"])
+
+    assert result.exit_code == 0
+    assert _FakeRmLium.removed == ["eager-wolf-aa"]
+
+
+def test_rm_reports_what_it_removed(monkeypatch):
+    """Silence on the one mandatory step is indistinguishable from a no-op."""
+    _FakeRmLium.removed = []
+    monkeypatch.setattr(rm_module, "Lium", _FakeRmLium)
+
+    result = CliRunner().invoke(cli, ["rm", "my-pod", "-y"])
+
+    assert "eager-wolf-aa" in result.output
+
+
+def test_rm_fails_loudly_when_no_pod_matches(monkeypatch):
+    """`lium rm <typo>` must not look exactly like a successful termination."""
+    _FakeRmLium.removed = []
+    monkeypatch.setattr(rm_module, "Lium", _FakeRmLium)
+
+    result = CliRunner().invoke(cli, ["rm", "no-such-pod-zz", "-y"])
+
+    assert result.exit_code != 0
+    assert _FakeRmLium.removed == []
+
+
+def test_explicit_sort_is_not_overridden_by_the_pareto_star():
+    """"Cheapest first" must mean cheapest first, star or no star."""
+    cheap = _executor("cheap-node", price_per_hour=0.30, download=10)
+    expensive_but_starred = _executor("starred-node", price_per_hour=64.00, download=9999)
+
+    ordered, _ = ls_display.sort_executors(
+        [cheap, expensive_but_starred], sort_by="price_total", pareto_first=False
+    )
+
+    assert ordered[0].huid == "cheap-node"
+
+
+def test_price_per_hour_is_accepted_as_a_sort_key():
+    """The JSON field is price_per_hour; --sort must accept the name it emits."""
+    cheap = _executor("cheap-node", price_per_hour=0.30, download=10)
+    pricey = _executor("pricey-node", price_per_hour=64.00, download=9999)
+
+    ordered, _ = ls_display.sort_executors(
+        [cheap, pricey], sort_by="price_per_hour", pareto_first=False
+    )
+
+    assert ordered[0].huid == "cheap-node"

--- a/test/test_up_dockerfile.py
+++ b/test/test_up_dockerfile.py
@@ -305,7 +305,8 @@ def test_up_command_rejects_dockerfile_with_image(monkeypatch, tmp_path):
         ["brave-fox-3a", "--dockerfile", str(dockerfile), "--image", "pytorch/pytorch:2.0"],
     )
 
-    assert result.exit_code == 0
+    # A rejected invocation must not report success — DAH-2556.
+    assert result.exit_code == 2
     assert "Cannot specify both --dockerfile and --image" in result.output
 
 
@@ -321,7 +322,7 @@ def test_up_command_rejects_env_with_dockerfile(monkeypatch, tmp_path):
         ["brave-fox-3a", "--dockerfile", str(dockerfile), "-e", "KEY=VAL"],
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 2
     assert "--env" in result.output
     assert "--dockerfile" in result.output
 
@@ -338,5 +339,5 @@ def test_up_command_reports_non_utf8_dockerfile(monkeypatch, tmp_path):
         ["brave-fox-3a", "--dockerfile", str(dockerfile)],
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 2
     assert "Could not read Dockerfile" in result.output

--- a/test/test_up_dockerfile.py
+++ b/test/test_up_dockerfile.py
@@ -255,7 +255,7 @@ def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path)
         available_port_count=10,
         download_speed=1000,
     )
-    pod = SimpleNamespace(id="pod-1", name="custom-pod")
+    pod = SimpleNamespace(id="pod-1", name="custom-pod", huid="brave-fox-3a")
 
     class _FakeResolveExecutor:
         def execute(self, ctx):

--- a/test/test_up_dockerfile.py
+++ b/test/test_up_dockerfile.py
@@ -280,7 +280,7 @@ def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path)
     monkeypatch.setattr(up_command, "RentPodAction", _FakeRentPod)
     monkeypatch.setattr(up_command, "WaitReadyAction", _FakeWaitReady)
     monkeypatch.setattr(up_command, "PrepareSSHAction", _FakePrepareSSH)
-    monkeypatch.setattr("lium.cli.ssh.command.ssh_to_pod", lambda *a, **k: None)
+    monkeypatch.setattr("lium.cli.ssh.command.ssh_session_connected", lambda *a, **k: True)
 
     # Act
     result = CliRunner().invoke(


### PR DESCRIPTION
An agent drives the CLI through a pipe. It cannot read a Rich-formatted hint, it cannot answer a prompt, and the only two things it can act on are the exit code and stdout. Today both lie to it.

Found by the DAH-1942 agent-first audit (13 agents, every path walked three times on prod, 2026-08-03). `exec` was the top finding in 6 of 6 runs that touched it; one run burned 6m45s of paid GPU polling blind because a trailing `ls` failed and took the whole stdout with it.

## What changes

**`exec` can report failure.** Output is printed the same way whether the command succeeded or not — the log you need to diagnose a failure is exactly the log a failing command produced. The process now exits with the remote exit code, so `lium exec <pod> "cmd" && next-step` behaves the way a caller expects. Adds `--json` (stdout / stderr / exit_code), following the envelope `balance` and `topup` already use.

**`rm` is assertable.** Adds `-y/--yes`, the flag an agent already learned on `up`. Says what it removed, because silence on the one mandatory step is indistinguishable from having done nothing. Exits non-zero when nothing matched, so a typo cannot look like a successful teardown. `--all` now confirms once when stdin is a TTY — it is unguarded today and this account is shared.

**`up` returns a handle.** Adds `--no-ssh`, and always prints the pod it created. Until now the only output on success was the Ubuntu MOTD, so a caller that omitted `--name` could not name the pod it was paying for.

**`--sort` outranks the star.** `pairs.sort(key=lambda x: (not x[1], sort_key))` let the pareto flag dominate, so `--sort price_total` still returned the 8xB300 at \$64.00/h ahead of the \$0.30/h nodes — an agent told to take the cheapest node overpaid 213x. An explicit `--sort` now wins; the default ordering is untouched. `price_per_hour` and `price_per_gpu_hour` are accepted as sort keys so you can sort by the name `--format json` emits.

## Not in this PR

- A global `--non-interactive` — cross-cutting, better on its own.
- `ls` succeeding with an invalid API key: the executors endpoint accepts the bad key, so the fix belongs in the backend, not here.

## Verification

`test/test_agent_cli_contract.py`, 10 tests, all failing before this change. Full suite: 332 passed, 11 failed — the same 11 fail on unmodified `main` (provider CLI, gpu-splitting, and install-script tests that hit the network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)