### PR TITLE
DAH-2585: unlock coldkey before the fund spinner hides its password prompt

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.31"
+__version__ = "0.0.32"

--- a/lium/cli/fund/actions.py
+++ b/lium/cli/fund/actions.py
@@ -93,14 +93,16 @@ class LoadWalletAction:
 
 
 class UnlockColdkeyAction:
-    """Decrypt the coldkey up front, so its password prompt is never hidden.
+    """Decrypt the coldkey up front, so its password prompt lands on a clean line.
 
     ``bittensor_wallet`` prints ``Enter your password:`` straight to the terminal the
     first time the coldkey is read (registration signs with it, so do the funding
-    transfers). Under a Rich ``Status`` that line is repainted away ~12x/s and the
-    run looks hung while it blindly waits for input. Unlocking before any spinner
-    starts keeps the prompt on screen; the decrypted key is cached on the wallet, so
-    the later signing never asks a second time.
+    transfers), and its Rust reader holds the GIL — which stalls Rich's refresh
+    thread. Raised under a Rich ``Status``, the prompt therefore lands glued to the
+    tail of a frozen spinner line, with the cursor still hidden and nothing echoing:
+    a command waiting for input that reads as a hung one. Unlocking before any
+    spinner starts gives the prompt its own line; the decrypted key is cached on the
+    wallet, so the later signing never asks a second time.
     """
 
     def execute(self, ctx: dict) -> ActionResult:

--- a/lium/cli/fund/actions.py
+++ b/lium/cli/fund/actions.py
@@ -92,6 +92,30 @@ class LoadWalletAction:
             return ActionResult(ok=False, data={}, error=str(e))
 
 
+class UnlockColdkeyAction:
+    """Decrypt the coldkey up front, so its password prompt is never hidden.
+
+    ``bittensor_wallet`` prints ``Enter your password:`` straight to the terminal the
+    first time the coldkey is read (registration signs with it, so do the funding
+    transfers). Under a Rich ``Status`` that line is repainted away ~12x/s and the
+    run looks hung while it blindly waits for input. Unlocking before any spinner
+    starts keeps the prompt on screen; the decrypted key is cached on the wallet, so
+    the later signing never asks a second time.
+    """
+
+    def execute(self, ctx: dict) -> ActionResult:
+        """Unlock the coldkey.
+
+        Context:
+            bt_wallet: bittensor wallet
+        """
+        try:
+            ctx["bt_wallet"].unlock_coldkey()
+            return ActionResult(ok=True, data={})
+        except Exception as e:
+            return ActionResult(ok=False, data={}, error=str(e))
+
+
 class CheckWalletRegistrationAction:
     """Check if wallet is registered with Lium."""
 

--- a/lium/cli/fund/command.py
+++ b/lium/cli/fund/command.py
@@ -78,7 +78,8 @@ def _legacy_tao_fund(wallet: Optional[str], amount: Optional[str], yes: bool) ->
     }
 
     # Ask for the coldkey password here, outside every spinner — registration and the
-    # transfer both sign with it, and a prompt raised under ui.load is repainted away.
+    # transfer both sign with it, and a prompt raised under ui.load lands glued to a
+    # frozen spinner line, which reads as a hung command.
     result = UnlockColdkeyAction().execute({"bt_wallet": bt_wallet})
     if not result.ok:
         ui.error(f"Failed to unlock coldkey for wallet '{wallet_name}': {result.error}")
@@ -201,7 +202,8 @@ def _alpha_fund(
     lium = Lium()
 
     # Ask for the coldkey password here, outside every spinner — registration and the
-    # transfer both sign with it, and a prompt raised under ui.load is repainted away.
+    # transfer both sign with it, and a prompt raised under ui.load lands glued to a
+    # frozen spinner line, which reads as a hung command.
     result = UnlockColdkeyAction().execute({"bt_wallet": bt_wallet})
     if not result.ok:
         raise LiumError(

--- a/lium/cli/fund/command.py
+++ b/lium/cli/fund/command.py
@@ -21,6 +21,7 @@ from lium.provider.chain_stack import missing_chain_stack_message
 from . import validation
 from .actions import (
     LoadWalletAction,
+    UnlockColdkeyAction,
     CheckWalletRegistrationAction,
     ExecuteTransferAction,
     CheckFreeAlphaAction,
@@ -75,6 +76,13 @@ def _legacy_tao_fund(wallet: Optional[str], amount: Optional[str], yes: bool) ->
         "wallet_address": wallet_address,
         "bt_wallet": bt_wallet,
     }
+
+    # Ask for the coldkey password here, outside every spinner — registration and the
+    # transfer both sign with it, and a prompt raised under ui.load is repainted away.
+    result = UnlockColdkeyAction().execute({"bt_wallet": bt_wallet})
+    if not result.ok:
+        ui.error(f"Failed to unlock coldkey for wallet '{wallet_name}': {result.error}")
+        return
 
     action = CheckWalletRegistrationAction()
     result = ui.load("Checking wallet registration", lambda: action.execute(ctx))
@@ -188,8 +196,19 @@ def _alpha_fund(
     if error:
         raise LiumError(error)
 
-    # Register the wallet so the backend can attribute the deposit (mirrors TAO flow).
+    # Construct the client BEFORE the unlock so a missing API key aborts without ever
+    # asking for the coldkey password.
     lium = Lium()
+
+    # Ask for the coldkey password here, outside every spinner — registration and the
+    # transfer both sign with it, and a prompt raised under ui.load is repainted away.
+    result = UnlockColdkeyAction().execute({"bt_wallet": bt_wallet})
+    if not result.ok:
+        raise LiumError(
+            f"Failed to unlock coldkey for wallet '{wallet}': {result.error}"
+        )
+
+    # Register the wallet so the backend can attribute the deposit (mirrors TAO flow).
     reg_ctx = {
         "lium": lium,
         "wallet_address": coldkey_ss58,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.31"
+version = "0.0.32"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/test/test_fund_cli.py
+++ b/test/test_fund_cli.py
@@ -22,6 +22,31 @@ from lium.sdk import AlphaQuote, Config, Lium
 from lium.sdk.exceptions import LiumNotFoundError, LiumServerError
 
 
+def _fake_bt_wallet(events=None, unlock_error=None):
+    """Wallet double whose coldkey unlock is observable, and optionally fails."""
+    def unlock_coldkey():
+        if unlock_error is not None:
+            raise unlock_error
+        if events is not None:
+            events.append("unlock_coldkey")
+
+    return types.SimpleNamespace(
+        coldkeypub=types.SimpleNamespace(ss58_address="coldkey"),
+        unlock_coldkey=unlock_coldkey,
+    )
+
+
+def _spy_ui_load(monkeypatch, events):
+    """Record every spinner `ui.load` opens in ``events``, keeping the real behaviour."""
+    real_load = fund_module.ui.load
+
+    def spy(message, fn):
+        events.append(f"ui.load:{message}")
+        return real_load(message, fn)
+
+    monkeypatch.setattr(fund_module.ui, "load", spy)
+
+
 def test_fund_help_documents_tao_flow():
     result = CliRunner().invoke(cli, ["fund", "--help"])
 
@@ -43,7 +68,7 @@ def test_fund_tao_dispatch_runs(monkeypatch):
         def execute(self, ctx):
             return ActionResult(
                 ok=True,
-                data={"wallet": object(), "address": "coldkey"},
+                data={"wallet": _fake_bt_wallet(), "address": "coldkey"},
             )
 
     class FakeCheckWalletRegistrationAction:
@@ -66,6 +91,89 @@ def test_fund_tao_dispatch_runs(monkeypatch):
 
     assert result.exit_code == 0
     assert "Done." in result.output
+
+
+def test_fund_tao_unlocks_coldkey_before_any_spinner(monkeypatch):
+    # DAH-2585: bittensor prints "Enter your password:" straight to the terminal, and a
+    # Rich spinner repaints that line away ~12x/s — so `lium fund` looked hung while it
+    # blindly waited for input. The unlock must happen before any ui.load spinner.
+    events = []
+    monkeypatch.setitem(sys.modules, "bittensor", types.SimpleNamespace())
+    bt_wallet = _fake_bt_wallet(events)
+
+    class FakeLium:
+        def balance(self):
+            return 10.0
+
+    class FakeLoadWalletAction:
+        def execute(self, ctx):
+            return ActionResult(
+                ok=True, data={"wallet": bt_wallet, "address": "coldkey"}
+            )
+
+    class FakeCheckWalletRegistrationAction:
+        def execute(self, ctx):
+            return ActionResult(ok=True, data={"registered": True})
+
+    class FakeExecuteTransferAction:
+        def execute(self, ctx):
+            return ActionResult(ok=True, data={})
+
+    monkeypatch.setattr(fund_module, "Lium", FakeLium)
+    monkeypatch.setattr(fund_module, "LoadWalletAction", FakeLoadWalletAction)
+    monkeypatch.setattr(
+        fund_module, "CheckWalletRegistrationAction", FakeCheckWalletRegistrationAction
+    )
+    monkeypatch.setattr(fund_module, "ExecuteTransferAction", FakeExecuteTransferAction)
+    _spy_ui_load(monkeypatch, events)
+
+    result = CliRunner().invoke(cli, ["fund", "-w", "default", "-a", "1.5", "-y"])
+
+    assert result.exit_code == 0, result.output
+    assert events[0] == "unlock_coldkey"
+    assert events.count("unlock_coldkey") == 1
+    # Pin the spinner the unlock has to come before, so de-spinnering the registration
+    # step can't leave this test vacuously green.
+    assert "ui.load:Checking wallet registration" in events
+
+
+def test_fund_tao_unlock_failure_aborts(monkeypatch):
+    # A coldkey that won't decrypt must stop the run right there — nothing downstream
+    # may go on to sign (or try to) with a still-locked key.
+    monkeypatch.setitem(sys.modules, "bittensor", types.SimpleNamespace())
+    calls = []
+    bt_wallet = _fake_bt_wallet(
+        unlock_error=ValueError("Wrong password for decryption")
+    )
+
+    class FakeLoadWalletAction:
+        def execute(self, ctx):
+            return ActionResult(
+                ok=True, data={"wallet": bt_wallet, "address": "coldkey"}
+            )
+
+    class FakeCheckWalletRegistrationAction:
+        def execute(self, ctx):
+            calls.append("register")
+            return ActionResult(ok=True, data={"registered": True})
+
+    class FakeExecuteTransferAction:
+        def execute(self, ctx):
+            calls.append("transfer")
+            return ActionResult(ok=True, data={})
+
+    monkeypatch.setattr(fund_module, "Lium", lambda: types.SimpleNamespace())
+    monkeypatch.setattr(fund_module, "LoadWalletAction", FakeLoadWalletAction)
+    monkeypatch.setattr(
+        fund_module, "CheckWalletRegistrationAction", FakeCheckWalletRegistrationAction
+    )
+    monkeypatch.setattr(fund_module, "ExecuteTransferAction", FakeExecuteTransferAction)
+
+    result = CliRunner().invoke(cli, ["fund", "-w", "default", "-a", "1.5", "-y"])
+
+    assert "Failed to unlock coldkey for wallet 'default'" in result.output
+    assert "Wrong password for decryption" in result.output
+    assert calls == []
 
 
 def test_fund_crypto_subcommand_is_retired():
@@ -222,7 +330,7 @@ class _RaisingKey:
         raise FileNotFoundError(f"no hotkey '{self._name}'")
 
 
-def _make_bt(subtensor, valid_ss58=True, hotkey_names=None):
+def _make_bt(subtensor, valid_ss58=True, hotkey_names=None, events=None):
     bt = types.SimpleNamespace()
     bt.Balance = FakeBalance
     # Real bittensor >=8 exposes ``bt.Subtensor``; mirror that (lowercase alias kept
@@ -236,9 +344,7 @@ def _make_bt(subtensor, valid_ss58=True, hotkey_names=None):
     names = hotkey_names or {}
 
     def _wallet(name=None, hotkey=None, path=None):
-        ns = types.SimpleNamespace(
-            coldkeypub=types.SimpleNamespace(ss58_address="coldkey")
-        )
+        ns = _fake_bt_wallet(events)
         if hotkey is not None:
             ss58 = names.get(hotkey)
             if ss58 is None:
@@ -274,6 +380,7 @@ def _patch_common(
     convert_error=None,
     company_error=None,
     hotkey_names=None,
+    events=None,
 ):
     """Patch bittensor + the SDK/registration seams; keep the real alpha actions.
 
@@ -284,7 +391,7 @@ def _patch_common(
       - ``_discover_app_id`` -> a fixed app id.
     """
     monkeypatch.setitem(
-        sys.modules, "bittensor", _make_bt(subtensor, valid_ss58, hotkey_names)
+        sys.modules, "bittensor", _make_bt(subtensor, valid_ss58, hotkey_names, events)
     )
     netuids = list(convert_netuids)
 
@@ -347,6 +454,24 @@ def test_alpha_happy_path(monkeypatch):
     assert kw["hotkey_ss58"] == HK
     assert kw["origin_netuid"] == 51 and kw["destination_netuid"] == 51
     assert kw["amount"].tao == 2.0 and kw["amount"].netuid == 51
+
+
+def test_alpha_unlocks_coldkey_before_any_spinner(monkeypatch):
+    # DAH-2585, alpha path: same invariant as the TAO path — the coldkey password
+    # prompt must be raised before the first spinner can repaint it away.
+    events = []
+    sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
+    _patch_common(monkeypatch, sub, events=events)
+    _spy_ui_load(monkeypatch, events)
+
+    result = CliRunner().invoke(
+        cli, ["fund", "--alpha", "-k", HK, "-w", "default", "-a", "2", "-y"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert events[0] == "unlock_coldkey"
+    assert events.count("unlock_coldkey") == 1
+    assert "ui.load:Checking wallet registration" in events
 
 
 def test_alpha_insufficient_free_alpha_aborts(monkeypatch):

--- a/test/test_fund_cli.py
+++ b/test/test_fund_cli.py
@@ -94,9 +94,9 @@ def test_fund_tao_dispatch_runs(monkeypatch):
 
 
 def test_fund_tao_unlocks_coldkey_before_any_spinner(monkeypatch):
-    # DAH-2585: bittensor prints "Enter your password:" straight to the terminal, and a
-    # Rich spinner repaints that line away ~12x/s — so `lium fund` looked hung while it
-    # blindly waited for input. The unlock must happen before any ui.load spinner.
+    # DAH-2585: bittensor prints "Enter your password:" straight to the terminal, and its
+    # reader holds the GIL — so under ui.load the prompt lands glued to a frozen spinner
+    # line and `lium fund` reads as hung. The unlock must precede every ui.load spinner.
     events = []
     monkeypatch.setitem(sys.modules, "bittensor", types.SimpleNamespace())
     bt_wallet = _fake_bt_wallet(events)
@@ -458,7 +458,7 @@ def test_alpha_happy_path(monkeypatch):
 
 def test_alpha_unlocks_coldkey_before_any_spinner(monkeypatch):
     # DAH-2585, alpha path: same invariant as the TAO path — the coldkey password
-    # prompt must be raised before the first spinner can repaint it away.
+    # prompt must be raised before the first spinner freezes on top of it.
     events = []
     sub = FakeSubtensor([[_stake(stake=5.0)]], fee=0.01)
     _patch_common(monkeypatch, sub, events=events)

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.31"
+version = "0.0.32"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

`lium fund` reads as hung on `Checking wallet registration...`. On 2026-08-04 a customer gave up after minutes and sent 5 TAO to the company coldkey manually — money that stays unaccounted until registration completes.

It was never hung; it was waiting for a password that does not look like a question.

Both funding paths wrap `CheckWalletRegistrationAction` in `ui.load("Checking wallet registration", ...)`. For a wallet that is not registered yet, that action calls `Lium.add_wallet()`, which signs with `bt_wallet.coldkey` — and reading `.coldkey` makes `bittensor_wallet` print `Enter your password: ` straight to the terminal, on the same line, with no newline.

Measured under a pty against a real encrypted wallet (bittensor_wallet 4.0.1), sitting on the prompt for 4 s without answering:

- spinner frames emitted after the prompt appeared: **0**
- line-erase (`\r\x1b[2K`) sequences after the prompt appeared: **0**
- a plain Python background thread ticked **1** time in 3 s instead of ~30 — the Rust password reader holds the GIL, so Rich's refresh thread stalls
- `ESC[?25l` (hide cursor) had been sent, `ESC[?25h` had not — the cursor is hidden at the prompt

So the prompt is not repainted away. The spinner **freezes** mid-frame and the prompt lands glued to the tail of that dead line, cursor hidden, nothing echoing:

```
⠹ Checking wallet registration...Enter your password:
```

A stopped spinner with text stuck to it reads as a crashed command, not as a question — which is exactly how it was reported.

## Fix

Unlock the coldkey in `lium fund` before the first spinner opens, in both the TAO and the `--alpha` path (new `UnlockColdkeyAction`). The prompt then gets its own clean line with a visible cursor, before any `Status` is running. `unlock_coldkey()` caches the decrypted keypair on the wallet, so the later signing does not ask again — measured password prompts stay at 1.

In the alpha path `Lium()` now constructs before the unlock, so a missing API key aborts without asking for a password first. The TAO path already had that order.

## Trade-off

The password is now requested on every `lium fund` run, before the amount prompt and the confirm — including for already-registered wallets that previously only got asked after confirming. Accepted: the run ends in a coldkey signature anyway, and a wrong password now fails before any network call instead of after.

Two known limits, unchanged by this PR: the Rust prompt reads the controlling tty (a piped password is not consumed), and a wrong password has no retry — the command has to be re-run.

## Tests

Three regression tests in `test/test_fund_cli.py`: the unlock precedes every `ui.load` spinner on both paths, and a coldkey that fails to decrypt aborts before registration or transfer. All three fail if the unlock is removed (verified by mutating `UnlockColdkeyAction` into a no-op).

```
pytest test/test_fund_cli.py -q   # 52 passed
pytest test/ -q                   # 328 passed, 11 failed — same 11 fail on origin/main
```

## Pre-deploy verification

Staging, encrypted coldkey, unregistered wallet: the password prompt appears on its own line before the spinner, and registration completes.

## Post-deploy verification

+1 d: a fresh coldkey funds end-to-end — the pay-tao listener logs `Transfer matched company wallet`, with no `CRITICAL: No Stripe customer ID`.
