### PR TITLE
Release 0.0.28

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.27"
+__version__ = "0.0.28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.27"
+version = "0.0.28"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"


### PR DESCRIPTION
Version bump for the 0.0.28 release. Mechanical: `pyproject.toml` and `lium/__about__.py` only — the release workflow refuses to run unless both already carry the requested version.

Ships DAH-2556 (#98): a failed command no longer exits 0, `exec` keeps the output of a failed command and gains `--json`, `rm` gains `-y` and reports what it removed, `up` gains `--no-ssh` and prints the pod id, and an explicit `--sort` really sorts.

Note for anyone with automation: this changes exit codes for every command, not only the ones touched. A script that used to sail past a `lium` failure will now stop there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)