### PR TITLE
DAH-2589: lium describe — one pod manifest an agent can act on

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The `lium` CLI exposes the full pod lifecycle. Run `lium --help` to see everythi
 - `lium ls [GPU_TYPE]` - List available nodes
 - `lium up [NODE_ID]` - Create a pod (use node ID or filters like `--gpu`, `--count`, `--country`)
 - `lium ps` - List active pods
+- `lium describe <POD>` - Full manifest of one pod: ports, GPU, template, billing (add `--json` for machine-readable output)
 - `lium ssh <POD>` - SSH into a pod
 - `lium exec <POD> <COMMAND>` - Execute command on pod
 - `lium scp <POD> <LOCAL_FILE> [REMOTE_PATH]` - Copy files to pods (add `-d` to download from pods)

--- a/lium/cli/cli.py
+++ b/lium/cli/cli.py
@@ -10,6 +10,7 @@ from .ls import ls_command
 from .templates import templates_command
 from .up import up_command
 from .ps import ps_command
+from .describe import describe_command
 from .commands.exec import exec_command
 from .ssh.command import ssh_command
 from .rm import rm_command
@@ -70,6 +71,7 @@ cli.add_command(ls_command)
 cli.add_command(templates_command)
 cli.add_command(up_command)
 cli.add_command(ps_command)
+cli.add_command(describe_command)
 cli.add_command(exec_command)
 cli.add_command(ssh_command)
 cli.add_command(rm_command)

--- a/lium/cli/describe/__init__.py
+++ b/lium/cli/describe/__init__.py
@@ -1,0 +1,5 @@
+"""Describe command."""
+
+from .command import describe_command
+
+__all__ = ["describe_command"]

--- a/lium/cli/describe/actions.py
+++ b/lium/cli/describe/actions.py
@@ -1,0 +1,26 @@
+from lium.cli.actions import ActionResult
+
+
+class GetPodAction:
+    """Resolve one pod by id, huid or name."""
+
+    def execute(self, ctx: dict) -> ActionResult:
+        """Find the pod a caller named.
+
+        Context:
+            lium: Lium SDK instance
+            target: pod id, huid or name
+        """
+        lium = ctx["lium"]
+        target = ctx["target"]
+
+        try:
+            pods = lium.ps()
+        except Exception as e:
+            return ActionResult(ok=False, data={}, error=str(e))
+
+        pod = next((p for p in pods if target in (p.id, p.huid, p.name)), None)
+        if pod is None:
+            return ActionResult(ok=False, data={}, error=f"Pod '{target}' not found")
+
+        return ActionResult(ok=True, data={"pod": pod})

--- a/lium/cli/describe/actions.py
+++ b/lium/cli/describe/actions.py
@@ -1,26 +1,20 @@
-from lium.cli.actions import ActionResult
+import contextlib
+
+from lium.sdk import Lium, PodInfo
+from lium.cli.utils import CliFailure, EXIT_POD_NOT_FOUND, loading_status
 
 
-class GetPodAction:
-    """Resolve one pod by id, huid or name."""
+def resolve_pod_or_fail(lium: Lium, target: str, show_progress: bool) -> PodInfo:
+    """The pod matching TARGET by id, huid or name; no match is a hard failure.
 
-    def execute(self, ctx: dict) -> ActionResult:
-        """Find the pod a caller named.
+    Errors raised by the SDK travel up untouched — classifying them here by
+    message would misreport an API outage as a mistyped pod id.
+    """
+    with loading_status("Loading pod", "") if show_progress else contextlib.nullcontext():
+        pods = lium.ps()
 
-        Context:
-            lium: Lium SDK instance
-            target: pod id, huid or name
-        """
-        lium = ctx["lium"]
-        target = ctx["target"]
+    pod = next((p for p in pods if target in (p.id, p.huid, p.name)), None)
+    if pod is None:
+        raise CliFailure("pod_not_found", f"Pod '{target}' not found", EXIT_POD_NOT_FOUND)
 
-        try:
-            pods = lium.ps()
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
-
-        pod = next((p for p in pods if target in (p.id, p.huid, p.name)), None)
-        if pod is None:
-            return ActionResult(ok=False, data={}, error=f"Pod '{target}' not found")
-
-        return ActionResult(ok=True, data={"pod": pod})
+    return pod

--- a/lium/cli/describe/command.py
+++ b/lium/cli/describe/command.py
@@ -5,15 +5,9 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import (
-    CliFailure,
-    EXIT_API_ERROR,
-    EXIT_POD_NOT_FOUND,
-    ensure_config,
-    handle_errors,
-)
+from lium.cli.utils import ensure_config, handle_errors
 from . import display
-from .actions import GetPodAction
+from .actions import resolve_pod_or_fail
 
 
 @click.command("describe")
@@ -29,20 +23,8 @@ def describe_command(pod_id: str, json_output: bool):
     if not json_output:
         ensure_config()
 
-    action = GetPodAction()
-    ctx = {"lium": Lium(), "target": pod_id}
-
-    if json_output:
-        result = action.execute(ctx)
-    else:
-        result = ui.load("Loading pod", lambda: action.execute(ctx))
-
-    if not result.ok:
-        if "not found" in result.error:
-            raise CliFailure("pod_not_found", result.error, EXIT_POD_NOT_FOUND)
-        raise CliFailure("api_error", result.error, EXIT_API_ERROR)
-
-    manifest = display.build_manifest(result.data["pod"])
+    pod = resolve_pod_or_fail(Lium(), pod_id, show_progress=not json_output)
+    manifest = display.build_manifest(pod)
 
     if json_output:
         click.echo(json.dumps(manifest, indent=2, ensure_ascii=False))

--- a/lium/cli/describe/command.py
+++ b/lium/cli/describe/command.py
@@ -1,0 +1,51 @@
+"""Describe command implementation."""
+
+import json
+import click
+
+from lium.sdk import Lium
+from lium.cli import ui
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_API_ERROR,
+    EXIT_POD_NOT_FOUND,
+    ensure_config,
+    handle_errors,
+)
+from . import display
+from .actions import GetPodAction
+
+
+@click.command("describe")
+@click.argument("pod_id")
+@click.option("--json", "json_output", is_flag=True, help="Print the manifest as machine-readable JSON")
+@handle_errors
+def describe_command(pod_id: str, json_output: bool):
+    """Show everything known about one pod: ports, GPU, template, billing."""
+
+    # Only the human path may block on the interactive setup. A `--json` caller
+    # is a script or an agent behind a pipe: it cannot answer a prompt, so a
+    # missing key has to surface as the JSON error envelope Lium() raises.
+    if not json_output:
+        ensure_config()
+
+    action = GetPodAction()
+    ctx = {"lium": Lium(), "target": pod_id}
+
+    if json_output:
+        result = action.execute(ctx)
+    else:
+        result = ui.load("Loading pod", lambda: action.execute(ctx))
+
+    if not result.ok:
+        if "not found" in result.error:
+            raise CliFailure("pod_not_found", result.error, EXIT_POD_NOT_FOUND)
+        raise CliFailure("api_error", result.error, EXIT_API_ERROR)
+
+    manifest = display.build_manifest(result.data["pod"])
+
+    if json_output:
+        click.echo(json.dumps(manifest, indent=2, ensure_ascii=False))
+        return
+
+    ui.print(display.build_manifest_table(manifest))

--- a/lium/cli/describe/display.py
+++ b/lium/cli/describe/display.py
@@ -1,0 +1,152 @@
+"""Manifest assembly and rendering for the describe command."""
+
+from datetime import datetime, timezone
+from typing import Optional
+from rich.table import Table
+
+from lium.sdk import PodInfo
+from lium.cli.utils import console
+# Reused rather than reimplemented: the same timestamp handling and cost rounding
+# `lium ps` already applies, so describe and ps never disagree on spend.
+from lium.cli.ps.display import _parse_timestamp, _spent_usd
+
+SSH_INTERNAL_PORT = "22"
+
+
+def _uptime_hours(created_at: str) -> Optional[float]:
+    """Hours since pod creation; None when the timestamp is unusable."""
+    dt_created = _parse_timestamp(created_at) if created_at else None
+    if not dt_created:
+        return None
+    return round((datetime.now(timezone.utc) - dt_created).total_seconds() / 3600, 2)
+
+
+def _ports_section(ports: dict) -> dict:
+    """Port mapping split into the SSH port and the ports left for services.
+
+    Keys of the mapping are ports *inside* the container, values are the ports
+    reachable from outside. Getting that direction wrong is the single most
+    common way an agent loses time on a pod, so the manifest states it.
+    """
+    mapping = ports or {}
+    service_ports = [
+        {"internal": int(internal), "external": external}
+        for internal, external in mapping.items()
+        if str(internal) != SSH_INTERNAL_PORT
+    ]
+    return {
+        "mapping": mapping,
+        "direction": "internal -> external",
+        "ssh_external": mapping.get(SSH_INTERNAL_PORT),
+        "service_ports": service_ports,
+    }
+
+
+def build_manifest(pod: PodInfo) -> dict:
+    """Everything an agent needs to work on this pod, as one JSON document."""
+    executor = pod.executor
+    template = pod.template or {}
+    price_per_hour = executor.price_per_hour if executor else None
+
+    return {
+        "pod": {
+            "id": pod.id,
+            "huid": pod.huid,
+            "name": pod.name,
+            "status": pod.status.upper() if pod.status else None,
+            "created_at": pod.created_at,
+            "uptime_hours": _uptime_hours(pod.created_at),
+        },
+        "gpu": {
+            "type": executor.gpu_type,
+            "count": executor.gpu_count,
+            "model": executor.gpu_model or None,
+            "driver_version": executor.driver_version or None,
+            "max_cuda_version": executor.max_cuda_version,
+        } if executor else None,
+        "machine": {
+            "executor_id": executor.id,
+            "ip": executor.ip,
+            "location": executor.location,
+            "tier": executor.tier,
+            "docker_in_docker": executor.docker_in_docker,
+        } if executor else None,
+        "ports": _ports_section(pod.ports),
+        "access": {
+            "ssh_command": pod.ssh_cmd,
+            "jupyter_url": pod.jupyter_url,
+        },
+        "template": {
+            "name": template.get("name") or template.get("template_name"),
+            "docker_image": template.get("docker_image"),
+            "docker_image_tag": template.get("docker_image_tag"),
+        } if template else None,
+        "storage": {
+            "volume_encryption_enabled": pod.enable_volume_encryption,
+            "volume_encryption_status": pod.volume_encryption_status,
+        },
+        "billing": {
+            "price_per_hour": price_per_hour,
+            "spent_usd": _spent_usd(pod.created_at, price_per_hour),
+            "removal_scheduled_at": pod.removal_scheduled_at,
+        },
+    }
+
+
+def _format_ports(ports_section: dict) -> str:
+    """One line per mapped port, SSH first."""
+    mapping = ports_section["mapping"]
+    if not mapping:
+        return "—"
+
+    ssh_external = ports_section["ssh_external"]
+    lines = []
+    if ssh_external:
+        lines.append(f"{ssh_external} → 22 (ssh)")
+    lines.extend(
+        f"{service['external']} → {service['internal']}"
+        for service in ports_section["service_ports"]
+    )
+    return "\n".join(lines)
+
+
+def build_manifest_table(manifest: dict) -> Table:
+    """Human-readable rendering of the same manifest the --json flag emits."""
+    table = Table(show_header=False, box=None, pad_edge=False, padding=(0, 1))
+    table.add_column(justify="left", style="dim", no_wrap=True)
+    table.add_column(justify="left", overflow="fold")
+
+    pod = manifest["pod"]
+    gpu = manifest["gpu"]
+    machine = manifest["machine"]
+    template = manifest["template"]
+    billing = manifest["billing"]
+
+    table.add_row("Pod", console.get_styled(pod["huid"] or "—", "pod_id"))
+    table.add_row("Name", pod["name"] or "—")
+    table.add_row("Status", f"[{console.pod_status_color(pod['status'] or '')}]{pod['status'] or '—'}[/]")
+    table.add_row("Uptime", f"{pod['uptime_hours']}h" if pod["uptime_hours"] is not None else "—")
+
+    if gpu:
+        config = f"{gpu['count']}×{gpu['type']}" if (gpu["count"] or 0) > 1 else (gpu["type"] or "—")
+        table.add_row("GPU", config)
+        table.add_row("Driver", gpu["driver_version"] or "—")
+        table.add_row("Max CUDA", str(gpu["max_cuda_version"]) if gpu["max_cuda_version"] else "—")
+    if machine:
+        table.add_row("IP", machine["ip"] or "—")
+        table.add_row("Tier", machine["tier"] or "—")
+    if template:
+        table.add_row("Template", template["name"] or "—")
+        table.add_row("Image", template["docker_image"] or "—")
+
+    table.add_row("Ports", _format_ports(manifest["ports"]))
+    table.add_row("SSH", manifest["access"]["ssh_command"] or "—")
+
+    price = billing["price_per_hour"]
+    spent = billing["spent_usd"]
+    table.add_row("$/h", f"${price:.2f}" if price is not None else "—")
+    table.add_row("Spent", f"${spent:.2f}" if spent is not None else "—")
+    if billing["removal_scheduled_at"]:
+        table.add_row("Removal at", billing["removal_scheduled_at"])
+
+    return table

--- a/lium/cli/describe/display.py
+++ b/lium/cli/describe/display.py
@@ -21,7 +21,7 @@ def _uptime_hours(created_at: str) -> Optional[float]:
     return round((datetime.now(timezone.utc) - dt_created).total_seconds() / 3600, 2)
 
 
-def _port_number(port) -> object:
+def _port_number(port: str | int) -> int | str:
     """Port as a number when it is one; left untouched otherwise (e.g. "22/tcp")."""
     try:
         return int(port)

--- a/lium/cli/describe/display.py
+++ b/lium/cli/describe/display.py
@@ -21,23 +21,38 @@ def _uptime_hours(created_at: str) -> Optional[float]:
     return round((datetime.now(timezone.utc) - dt_created).total_seconds() / 3600, 2)
 
 
+def _port_number(port) -> object:
+    """Port as a number when it is one; left untouched otherwise (e.g. "22/tcp")."""
+    try:
+        return int(port)
+    except (TypeError, ValueError):
+        return port
+
+
 def _ports_section(ports: dict) -> dict:
     """Port mapping split into the SSH port and the ports left for services.
 
     Keys of the mapping are ports *inside* the container, values are the ports
     reachable from outside. Getting that direction wrong is the single most
     common way an agent loses time on a pod, so the manifest states it.
+
+    Keys are compared as strings: the backend sends them as JSON keys today, but
+    a mapping built in Python carries real ints, and neither may drop the SSH port.
     """
     mapping = ports or {}
     service_ports = [
-        {"internal": int(internal), "external": external}
+        {"internal": _port_number(internal), "external": external}
         for internal, external in mapping.items()
         if str(internal) != SSH_INTERNAL_PORT
     ]
+    ssh_external = next(
+        (external for internal, external in mapping.items() if str(internal) == SSH_INTERNAL_PORT),
+        None,
+    )
     return {
         "mapping": mapping,
         "direction": "internal -> external",
-        "ssh_external": mapping.get(SSH_INTERNAL_PORT),
+        "ssh_external": ssh_external,
         "service_ports": service_ports,
     }
 
@@ -139,7 +154,7 @@ def build_manifest_table(manifest: dict) -> Table:
         table.add_row("Template", template["name"] or "—")
         table.add_row("Image", template["docker_image"] or "—")
 
-    table.add_row("Ports", _format_ports(manifest["ports"]))
+    table.add_row("Ports ext→int", _format_ports(manifest["ports"]))
     table.add_row("SSH", manifest["access"]["ssh_command"] or "—")
 
     price = billing["price_per_hour"]

--- a/test/test_describe_cli.py
+++ b/test/test_describe_cli.py
@@ -6,14 +6,25 @@ runs. Today that is spread across `ps`, the dashboard and guesswork.
 """
 
 import json
+from datetime import datetime, timedelta, timezone
 
 from click.testing import CliRunner
 
 from lium.sdk import ExecutorInfo, PodInfo
+from lium.sdk.exceptions import LiumNotFoundError
 from lium.cli.cli import cli
 from lium.cli.describe import command as describe_module
 from lium.cli.describe import display
-from lium.cli.utils import EXIT_POD_NOT_FOUND
+from lium.cli.utils import EXIT_GENERAL_ERROR, EXIT_POD_NOT_FOUND
+
+_DEFAULT = object()
+PRICE_PER_HOUR = 16.0
+UPTIME_HOURS = 2
+
+
+def _hours_ago(hours: int) -> str:
+    """Creation timestamp relative to now, so the test does not depend on the wall clock."""
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat().replace("+00:00", "Z")
 
 
 def _executor() -> ExecutorInfo:
@@ -23,7 +34,7 @@ def _executor() -> ExecutorInfo:
         machine_name="NVIDIA H100 SXM 8x",
         gpu_type="H100",
         gpu_count=8,
-        price_per_hour=16.0,
+        price_per_hour=PRICE_PER_HOUR,
         price_per_gpu=2.0,
         location={"country": "US"},
         specs={"gpu": {"driver": "535.104.05", "details": [{"name": "H100 80GB HBM3"}]}},
@@ -35,18 +46,21 @@ def _executor() -> ExecutorInfo:
     )
 
 
-def _pod(ports: dict | None = None, executor: ExecutorInfo | None = None) -> PodInfo:
+def _pod(ports=_DEFAULT, executor=_DEFAULT, template=_DEFAULT) -> PodInfo:
     return PodInfo(
         id="pod-uuid-1",
         name="my-pod",
         status="running",
         huid="eager-wolf-aa",
         ssh_cmd="ssh root@1.2.3.4 -p 34567",
-        ports={"22": 34567, "8000": 34568} if ports is None else ports,
-        created_at="2026-08-05T00:00:00Z",
-        updated_at="2026-08-05T00:00:00Z",
-        executor=_executor() if executor is None else executor,
-        template={"name": "PyTorch 2.4", "docker_image": "pytorch/pytorch", "docker_image_tag": "2.4"},
+        ports={"22": 34567, "8000": 34568} if ports is _DEFAULT else ports,
+        created_at=_hours_ago(UPTIME_HOURS),
+        updated_at=_hours_ago(0),
+        executor=_executor() if executor is _DEFAULT else executor,
+        template=(
+            {"name": "PyTorch 2.4", "docker_image": "pytorch/pytorch", "docker_image_tag": "2.4"}
+            if template is _DEFAULT else template
+        ),
         removal_scheduled_at=None,
         jupyter_installation_status=None,
         jupyter_url=None,
@@ -54,19 +68,23 @@ def _pod(ports: dict | None = None, executor: ExecutorInfo | None = None) -> Pod
 
 
 class _FakeLium:
-    """Stands in for the SDK: whatever list of pods the test dictates."""
+    """Stands in for the SDK: the pods a test dictates, or the error it dictates."""
 
     pods: list = []
+    error: Exception | None = None
 
     def __init__(self, *args, **kwargs):
         pass
 
     def ps(self):
+        if self.error:
+            raise self.error
         return list(self.pods)
 
 
-def _run_describe(monkeypatch, pods: list, target: str = "my-pod") -> tuple:
+def _run_describe(monkeypatch, pods: list, target: str = "my-pod", error: Exception | None = None):
     _FakeLium.pods = pods
+    _FakeLium.error = error
     monkeypatch.setattr(describe_module, "Lium", _FakeLium)
     return CliRunner().invoke(cli, ["describe", target, "--json"])
 
@@ -86,6 +104,21 @@ def test_manifest_singles_out_the_ssh_port():
     assert manifest["ports"]["ssh_external"] == 34567
 
 
+def test_manifest_finds_the_ssh_port_under_an_integer_key():
+    """A mapping built in Python carries int keys; the SSH port must not vanish."""
+    manifest = display.build_manifest(_pod(ports={22: 34567, 8000: 34568}))
+
+    assert manifest["ports"]["ssh_external"] == 34567
+    assert manifest["ports"]["service_ports"] == [{"internal": 8000, "external": 34568}]
+
+
+def test_manifest_keeps_a_non_numeric_port_key_instead_of_crashing():
+    """A key like "8000/tcp" is reported as-is rather than taking the command down."""
+    manifest = display.build_manifest(_pod(ports={"22": 34567, "8000/tcp": 34568}))
+
+    assert manifest["ports"]["service_ports"] == [{"internal": "8000/tcp", "external": 34568}]
+
+
 def test_manifest_service_ports_exclude_ssh():
     """Everything except 22 is a port a service can be published on."""
     manifest = display.build_manifest(_pod(ports={"22": 34567, "8000": 34568, "8888": 34569}))
@@ -94,6 +127,15 @@ def test_manifest_service_ports_exclude_ssh():
         {"internal": 8000, "external": 34568},
         {"internal": 8888, "external": 34569},
     ]
+
+
+def test_manifest_survives_a_pod_without_ports():
+    """The backend sends ports_mapping: null before ports are allocated."""
+    manifest = display.build_manifest(_pod(ports=None))
+
+    assert manifest["ports"]["mapping"] == {}
+    assert manifest["ports"]["ssh_external"] is None
+    assert manifest["ports"]["service_ports"] == []
 
 
 def test_manifest_reports_gpu_from_executor_specs():
@@ -107,10 +149,7 @@ def test_manifest_reports_gpu_from_executor_specs():
 
 def test_manifest_without_executor_still_describes_the_pod():
     """A pod whose executor the API omitted must not take the whole manifest down."""
-    pod = _pod()
-    pod.executor = None
-
-    manifest = display.build_manifest(pod)
+    manifest = display.build_manifest(_pod(executor=None))
 
     assert manifest["gpu"] is None
     assert manifest["machine"] is None
@@ -118,13 +157,24 @@ def test_manifest_without_executor_still_describes_the_pod():
     assert manifest["billing"]["price_per_hour"] is None
 
 
-def test_manifest_bills_by_uptime():
+def test_manifest_bills_uptime_times_price():
     """Spend is uptime × price, so an agent can see what the pod has cost so far."""
     manifest = display.build_manifest(_pod())
 
-    assert manifest["billing"]["price_per_hour"] == 16.0
-    assert manifest["billing"]["spent_usd"] > 0
-    assert manifest["pod"]["uptime_hours"] > 0
+    assert abs(manifest["pod"]["uptime_hours"] - UPTIME_HOURS) < 0.01
+    assert abs(manifest["billing"]["spent_usd"] - UPTIME_HOURS * PRICE_PER_HOUR) < 0.1
+
+
+def test_table_renders_a_pod_the_api_barely_described():
+    """The human path must not crash where the JSON path degrades quietly."""
+    bare_pod = _pod(ports=None, executor=None, template=None)
+    bare_pod.status = None
+    bare_pod.ssh_cmd = None
+    bare_pod.created_at = ""
+
+    table = display.build_manifest_table(display.build_manifest(bare_pod))
+
+    assert table.row_count > 0
 
 
 def test_describe_json_prints_the_manifest_on_stdout(monkeypatch):
@@ -150,3 +200,15 @@ def test_describe_unknown_pod_exits_with_pod_not_found(monkeypatch):
     result = _run_describe(monkeypatch, [_pod()], target="no-such-pod-zz")
 
     assert result.exit_code == EXIT_POD_NOT_FOUND
+    assert result.stdout == ""
+    assert json.loads(result.stderr)["error"]["code"] == "pod_not_found"
+
+
+def test_describe_does_not_blame_the_pod_id_for_an_api_failure(monkeypatch):
+    """The SDK's own 404 text contains "not found" — that must not read as a bad pod id."""
+    result = _run_describe(
+        monkeypatch, [], error=LiumNotFoundError("Resource not found: /pods")
+    )
+
+    assert result.exit_code == EXIT_GENERAL_ERROR
+    assert json.loads(result.stderr)["error"]["code"] != "pod_not_found"

--- a/test/test_describe_cli.py
+++ b/test/test_describe_cli.py
@@ -15,7 +15,7 @@ from lium.sdk.exceptions import LiumNotFoundError
 from lium.cli.cli import cli
 from lium.cli.describe import command as describe_module
 from lium.cli.describe import display
-from lium.cli.utils import EXIT_GENERAL_ERROR, EXIT_POD_NOT_FOUND
+from lium.cli.utils import EXIT_POD_NOT_FOUND
 
 _DEFAULT = object()
 PRICE_PER_HOUR = 16.0
@@ -210,5 +210,5 @@ def test_describe_does_not_blame_the_pod_id_for_an_api_failure(monkeypatch):
         monkeypatch, [], error=LiumNotFoundError("Resource not found: /pods")
     )
 
-    assert result.exit_code == EXIT_GENERAL_ERROR
+    assert result.exit_code not in (0, EXIT_POD_NOT_FOUND)
     assert json.loads(result.stderr)["error"]["code"] != "pod_not_found"

--- a/test/test_describe_cli.py
+++ b/test/test_describe_cli.py
@@ -1,0 +1,152 @@
+"""DAH-2589: `lium describe` — one manifest an agent can act on.
+
+An agent working on a pod needs to know which external port reaches which port
+inside the container, what GPU and image it got, and what the pod costs while it
+runs. Today that is spread across `ps`, the dashboard and guesswork.
+"""
+
+import json
+
+from click.testing import CliRunner
+
+from lium.sdk import ExecutorInfo, PodInfo
+from lium.cli.cli import cli
+from lium.cli.describe import command as describe_module
+from lium.cli.describe import display
+from lium.cli.utils import EXIT_POD_NOT_FOUND
+
+
+def _executor() -> ExecutorInfo:
+    return ExecutorInfo(
+        id="executor-uuid-1",
+        huid="brave-otter-11",
+        machine_name="NVIDIA H100 SXM 8x",
+        gpu_type="H100",
+        gpu_count=8,
+        price_per_hour=16.0,
+        price_per_gpu=2.0,
+        location={"country": "US"},
+        specs={"gpu": {"driver": "535.104.05", "details": [{"name": "H100 80GB HBM3"}]}},
+        status="active",
+        docker_in_docker=False,
+        ip="1.2.3.4",
+        max_cuda_version=12.4,
+        tier="secure",
+    )
+
+
+def _pod(ports: dict | None = None, executor: ExecutorInfo | None = None) -> PodInfo:
+    return PodInfo(
+        id="pod-uuid-1",
+        name="my-pod",
+        status="running",
+        huid="eager-wolf-aa",
+        ssh_cmd="ssh root@1.2.3.4 -p 34567",
+        ports={"22": 34567, "8000": 34568} if ports is None else ports,
+        created_at="2026-08-05T00:00:00Z",
+        updated_at="2026-08-05T00:00:00Z",
+        executor=_executor() if executor is None else executor,
+        template={"name": "PyTorch 2.4", "docker_image": "pytorch/pytorch", "docker_image_tag": "2.4"},
+        removal_scheduled_at=None,
+        jupyter_installation_status=None,
+        jupyter_url=None,
+    )
+
+
+class _FakeLium:
+    """Stands in for the SDK: whatever list of pods the test dictates."""
+
+    pods: list = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def ps(self):
+        return list(self.pods)
+
+
+def _run_describe(monkeypatch, pods: list, target: str = "my-pod") -> tuple:
+    _FakeLium.pods = pods
+    monkeypatch.setattr(describe_module, "Lium", _FakeLium)
+    return CliRunner().invoke(cli, ["describe", target, "--json"])
+
+
+def test_manifest_names_the_port_direction():
+    """Mapping keys are container ports — the manifest says so instead of leaving it to guesswork."""
+    manifest = display.build_manifest(_pod())
+
+    assert manifest["ports"]["direction"] == "internal -> external"
+    assert manifest["ports"]["mapping"] == {"22": 34567, "8000": 34568}
+
+
+def test_manifest_singles_out_the_ssh_port():
+    """The external port reaching container port 22 is the one an agent needs first."""
+    manifest = display.build_manifest(_pod())
+
+    assert manifest["ports"]["ssh_external"] == 34567
+
+
+def test_manifest_service_ports_exclude_ssh():
+    """Everything except 22 is a port a service can be published on."""
+    manifest = display.build_manifest(_pod(ports={"22": 34567, "8000": 34568, "8888": 34569}))
+
+    assert manifest["ports"]["service_ports"] == [
+        {"internal": 8000, "external": 34568},
+        {"internal": 8888, "external": 34569},
+    ]
+
+
+def test_manifest_reports_gpu_from_executor_specs():
+    """GPU model and driver come from the executor specs, not from the machine name."""
+    manifest = display.build_manifest(_pod())
+
+    assert manifest["gpu"]["model"] == "H100 80GB HBM3"
+    assert manifest["gpu"]["driver_version"] == "535.104.05"
+    assert manifest["gpu"]["count"] == 8
+
+
+def test_manifest_without_executor_still_describes_the_pod():
+    """A pod whose executor the API omitted must not take the whole manifest down."""
+    pod = _pod()
+    pod.executor = None
+
+    manifest = display.build_manifest(pod)
+
+    assert manifest["gpu"] is None
+    assert manifest["machine"] is None
+    assert manifest["ports"]["ssh_external"] == 34567
+    assert manifest["billing"]["price_per_hour"] is None
+
+
+def test_manifest_bills_by_uptime():
+    """Spend is uptime × price, so an agent can see what the pod has cost so far."""
+    manifest = display.build_manifest(_pod())
+
+    assert manifest["billing"]["price_per_hour"] == 16.0
+    assert manifest["billing"]["spent_usd"] > 0
+    assert manifest["pod"]["uptime_hours"] > 0
+
+
+def test_describe_json_prints_the_manifest_on_stdout(monkeypatch):
+    """`--json` output has to parse as-is — no spinner, no Rich decoration."""
+    result = _run_describe(monkeypatch, [_pod()])
+
+    assert result.exit_code == 0
+    manifest = json.loads(result.stdout)
+    assert manifest["pod"]["huid"] == "eager-wolf-aa"
+    assert manifest["ports"]["ssh_external"] == 34567
+
+
+def test_describe_resolves_a_pod_by_huid(monkeypatch):
+    """The huid printed by `ps` is a valid handle for describe."""
+    result = _run_describe(monkeypatch, [_pod()], target="eager-wolf-aa")
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["pod"]["id"] == "pod-uuid-1"
+
+
+def test_describe_unknown_pod_exits_with_pod_not_found(monkeypatch):
+    """A typo must fail with the pod-not-found code, not an empty success."""
+    result = _run_describe(monkeypatch, [_pod()], target="no-such-pod-zz")
+
+    assert result.exit_code == EXIT_POD_NOT_FOUND


### PR DESCRIPTION
Step A of DAH-2589 (machine layer, sub-task of DAH-1942). An agent that rents a pod has to piece together what it got from `ps`, the dashboard and guesswork. `lium describe <pod>` answers it in one document.

```bash
lium describe eager-wolf-aa          # human-readable table
lium describe eager-wolf-aa --json   # one manifest, ready for jq
```

## What the manifest carries

`pod` (id/huid/name/status/uptime), `gpu` (type, count, model and driver from the executor specs, max CUDA), `machine` (executor id, ip, location, tier, DinD), `ports`, `access` (ssh command, jupyter), `template` (name + docker image), `storage` (volume encryption), `billing` (price/h, spent so far, scheduled removal).

The `ports` section is the reason this command exists. The API returns `ports_mapping` keyed by the port **inside** the container, and getting that direction wrong is the most common way an agent burns time on a pod. So the manifest states the direction explicitly, singles out the external port that reaches SSH, and lists the remaining ports a service can be published on:

```json
"ports": {
  "mapping": {"22": 34567, "8000": 34568},
  "direction": "internal -> external",
  "ssh_external": 34567,
  "service_ports": [{"internal": 8000, "external": 34568}]
}
```

## Decisions worth reviewing

**API only, no SSH.** The manifest is assembled from data the backend already returns, so it also answers for a pod that has stopped responding. Live in-pod state (free disk, is `nvcc` present, who is listening) is deliberately out of scope — that is step C of the task, a `lium-capabilities` command running inside the pod against this same schema.

**`--json`, not `--format json`.** It follows the DAH-2556 contract: `handle_errors` keys the JSON error envelope off a `json_output` kwarg, so `--json` gets a machine-readable failure and a meaningful exit code for free. An unknown pod exits `EXIT_POD_NOT_FOUND` (5) with `{"ok": false, "error": {...}}` on stderr and clean stdout. `ls` and `ps` still use `--format table|json` and do not get that envelope — unifying the two spellings is its own change.

**`ensure_config()` runs only on the human path.** A `--json` caller is behind a pipe and cannot answer the interactive setup prompt, so a missing API key surfaces as the JSON envelope with the configuration exit code instead of hanging on a question nobody will read.

**Timestamp parsing and spend rounding are imported from `ps.display`** rather than reimplemented, so `describe` and `ps` can never disagree about what a pod has cost.

## Tests

`test/test_describe_cli.py` — 9 tests: port direction and the SSH port, service ports excluding 22, GPU read from specs, a pod whose executor the API omitted, spend by uptime, `--json` parsing as-is, resolution by huid, and the not-found exit code. Full suite: 358 passed, 11 pre-existing failures unrelated to this change (provider, gpu splitting, release binary — same 11 fail on a clean `main`).

## Follow-ups, not in this PR

- `lium/SKILL.md` in the lium-skill repo needs a "working inside a pod" section pointing at `describe` — separate repo, separate PR.
- The exit-code table in lium-docs should gain the command.