### PR TITLE
DAH-2593: stop the CLI Action layer from swallowing errors

### DIFF
--- a/lium/cli/bk/logs/actions.py
+++ b/lium/cli/bk/logs/actions.py
@@ -8,31 +8,28 @@ class GetBackupLogsAction:
         pod: PodInfo | None = ctx.get("pod")
         backup_id: str | None = ctx.get("backup_id")
 
-        try:
-            if backup_id:
-                # Search for specific backup ID across all pods
-                all_pods = lium.ps()
-                for pod_info in all_pods:
-                    pod_name_search = pod_info.name or pod_info.huid
-                    logs = lium.backup_logs(pod=pod_info)
-                    for log in logs:
-                        if getattr(log, 'id', '').startswith(backup_id):
-                            return ActionResult(
-                                ok=True,
-                                data={
-                                    "single_backup": True,
-                                    "pod_name": pod_name_search,
-                                    "log": log
-                                }
-                            )
-                return ActionResult(ok=False, error=f"Backup '{backup_id}' not found", data={})
+        if backup_id:
+            # Search for specific backup ID across all pods
+            all_pods = lium.ps()
+            for pod_info in all_pods:
+                pod_name_search = pod_info.name or pod_info.huid
+                logs = lium.backup_logs(pod=pod_info)
+                for log in logs:
+                    if getattr(log, 'id', '').startswith(backup_id):
+                        return ActionResult(
+                            ok=True,
+                            data={
+                                "single_backup": True,
+                                "pod_name": pod_name_search,
+                                "log": log
+                            }
+                        )
+            return ActionResult(ok=False, error=f"Backup '{backup_id}' not found", data={})
 
-            # Get logs for specific pod
-            backup_logs = lium.backup_logs(pod=pod) if pod else []
+        # Get logs for specific pod
+        backup_logs = lium.backup_logs(pod=pod) if pod else []
 
-            if not backup_logs:
-                return ActionResult(ok=True, data={"logs": []})
+        if not backup_logs:
+            return ActionResult(ok=True, data={"logs": []})
 
-            return ActionResult(ok=True, data={"logs": backup_logs[:10]})
-        except Exception as e:
-            return ActionResult(ok=False, error=str(e), data={})
+        return ActionResult(ok=True, data={"logs": backup_logs[:10]})

--- a/lium/cli/bk/logs/command.py
+++ b/lium/cli/bk/logs/command.py
@@ -4,7 +4,14 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+    ensure_config,
+)
 from . import validation, parsing, display
 from .actions import GetBackupLogsAction
 
@@ -20,8 +27,7 @@ def bk_logs_command(pod_id: Optional[str], backup_id: Optional[str]):
     # Validate
     valid, error = validation.validate(pod_id, backup_id)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     lium = Lium()
 
@@ -32,8 +38,7 @@ def bk_logs_command(pod_id: Optional[str], backup_id: Optional[str]):
         result = ui.load("Loading backup details", lambda: action.execute(ctx))
 
         if not result.ok:
-            ui.error(result.error)
-            return
+            raise CliFailure("backup_not_found", result.error, EXIT_GENERAL_ERROR)
 
         pod_name_found = result.data.get("pod_name")
         log = result.data.get("log")
@@ -62,12 +67,7 @@ def bk_logs_command(pod_id: Optional[str], backup_id: Optional[str]):
     result, error = ui.load("Loading backup logs", load_logs)
 
     if error:
-        ui.error(error)
-        return
-
-    if result and result.error:
-        ui.error(result.error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     logs = result.data.get("logs")
 

--- a/lium/cli/bk/now/actions.py
+++ b/lium/cli/bk/now/actions.py
@@ -12,20 +12,17 @@ class TriggerBackupAction:
         name: str = ctx["name"]
         description: str = ctx["description"]
 
-        try:
-            # Check if backup config exists
-            backup_config = lium.backup_config(pod)
+        # Check if backup config exists
+        backup_config = lium.backup_config(pod)
 
-            if not backup_config:
-                return ActionResult(ok=False, data={}, error="No backup configuration found")
+        if not backup_config:
+            return ActionResult(ok=False, data={}, error="No backup configuration found")
 
-            # Trigger backup
-            backup_result = lium.backup_now(
-                pod=pod,
-                name=name,
-                description=description
-            )
+        # Trigger backup
+        backup_result = lium.backup_now(
+            pod=pod,
+            name=name,
+            description=description
+        )
 
-            return ActionResult(ok=True, data={"backup": backup_result})
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(ok=True, data={"backup": backup_result})

--- a/lium/cli/bk/now/command.py
+++ b/lium/cli/bk/now/command.py
@@ -6,7 +6,14 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+    ensure_config,
+)
 from . import validation, parsing
 from .actions import TriggerBackupAction
 
@@ -23,22 +30,19 @@ def bk_now_command(pod_id: str, name: Optional[str], description: Optional[str])
     # Validate
     valid, error = validation.validate(pod_id)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(pod_id, name, description, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     pod = parsed.get("pod")
     pod_name = parsed.get("pod_name")
@@ -58,8 +62,7 @@ def bk_now_command(pod_id: str, name: Optional[str], description: Optional[str])
     result = ui.load(f"Triggering backup '{backup_name}'", lambda: action.execute(ctx))
 
     if not result.ok:
-        ui.error(result.error)
-        return
+        raise CliFailure("no_backup_config", result.error, EXIT_GENERAL_ERROR)
 
     backup = result.data.get("backup") or {}
     backup_log_id = backup.get("backup_log_id")

--- a/lium/cli/bk/restore/actions.py
+++ b/lium/cli/bk/restore/actions.py
@@ -12,9 +12,6 @@ class RestoreBackupAction:
         backup_id: str = ctx["backup_id"]
         restore_path: str = ctx["restore_path"]
 
-        try:
-            restore_result = lium.restore(pod=pod, backup_id=backup_id, restore_path=restore_path)
+        restore_result = lium.restore(pod=pod, backup_id=backup_id, restore_path=restore_path)
 
-            return ActionResult(ok=True, data={"restore": restore_result})
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(ok=True, data={"restore": restore_result})

--- a/lium/cli/bk/restore/command.py
+++ b/lium/cli/bk/restore/command.py
@@ -2,7 +2,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+    ensure_config,
+)
 from . import validation, parsing
 from .actions import RestoreBackupAction
 
@@ -20,22 +26,19 @@ def bk_restore_command(pod_id: str, backup_id: str, restore_path: str, yes: bool
     # Validate
     valid, error = validation.validate(pod_id, backup_id)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(pod_id, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     pod = parsed.get("pod")
     pod_name = parsed.get("pod_name")
@@ -55,10 +58,6 @@ def bk_restore_command(pod_id: str, backup_id: str, restore_path: str, yes: bool
     }
 
     action = RestoreBackupAction()
-    result = ui.load(f"Restoring backup to {restore_path}", lambda: action.execute(ctx))
-
-    if not result.ok:
-        ui.error(result.error)
-        return
+    ui.load(f"Restoring backup to {restore_path}", lambda: action.execute(ctx))
 
     ui.success(f"Restore started for {pod_name} at {restore_path}")

--- a/lium/cli/bk/restore_logs/actions.py
+++ b/lium/cli/bk/restore_logs/actions.py
@@ -8,29 +8,26 @@ class GetRestoreLogsAction:
         pod: PodInfo | None = ctx.get("pod")
         restore_id: str | None = ctx.get("restore_id")
 
-        try:
-            if restore_id:
-                all_pods = lium.ps()
-                for pod_info in all_pods:
-                    pod_name_search = pod_info.name or pod_info.huid
-                    logs = lium.restore_logs(pod=pod_info)
-                    for log in logs:
-                        if getattr(log, "id", "").startswith(restore_id):
-                            return ActionResult(
-                                ok=True,
-                                data={
-                                    "single_restore": True,
-                                    "pod_name": pod_name_search,
-                                    "log": log,
-                                },
-                            )
-                return ActionResult(ok=False, error=f"Restore '{restore_id}' not found", data={})
+        if restore_id:
+            all_pods = lium.ps()
+            for pod_info in all_pods:
+                pod_name_search = pod_info.name or pod_info.huid
+                logs = lium.restore_logs(pod=pod_info)
+                for log in logs:
+                    if getattr(log, "id", "").startswith(restore_id):
+                        return ActionResult(
+                            ok=True,
+                            data={
+                                "single_restore": True,
+                                "pod_name": pod_name_search,
+                                "log": log,
+                            },
+                        )
+            return ActionResult(ok=False, error=f"Restore '{restore_id}' not found", data={})
 
-            restore_logs = lium.restore_logs(pod=pod) if pod else []
+        restore_logs = lium.restore_logs(pod=pod) if pod else []
 
-            if not restore_logs:
-                return ActionResult(ok=True, data={"logs": []})
+        if not restore_logs:
+            return ActionResult(ok=True, data={"logs": []})
 
-            return ActionResult(ok=True, data={"logs": restore_logs[:10]})
-        except Exception as e:
-            return ActionResult(ok=False, error=str(e), data={})
+        return ActionResult(ok=True, data={"logs": restore_logs[:10]})

--- a/lium/cli/bk/restore_logs/command.py
+++ b/lium/cli/bk/restore_logs/command.py
@@ -3,7 +3,14 @@ from typing import Optional
 import click
 
 from lium.cli import ui
-from lium.cli.utils import ensure_config, handle_errors
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+    ensure_config,
+)
 from lium.sdk import Lium
 
 from . import display, parsing, validation
@@ -20,8 +27,7 @@ def bk_restore_logs_command(pod_id: Optional[str], restore_id: Optional[str]):
 
     valid, error = validation.validate(pod_id, restore_id)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     lium = Lium()
 
@@ -31,8 +37,7 @@ def bk_restore_logs_command(pod_id: Optional[str], restore_id: Optional[str]):
         result = ui.load("Loading restore details", lambda: action.execute(ctx))
 
         if not result.ok:
-            ui.error(result.error)
-            return
+            raise CliFailure("restore_not_found", result.error, EXIT_GENERAL_ERROR)
 
         pod_name_found = result.data.get("pod_name")
         log = result.data.get("log")
@@ -58,12 +63,7 @@ def bk_restore_logs_command(pod_id: Optional[str], restore_id: Optional[str]):
     result, error = ui.load("Loading restore logs", load_logs)
 
     if error:
-        ui.error(error)
-        return
-
-    if result and result.error:
-        ui.error(result.error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     logs = result.data.get("logs")
 

--- a/lium/cli/bk/rm/actions.py
+++ b/lium/cli/bk/rm/actions.py
@@ -10,14 +10,11 @@ class RemoveBackupAction:
         lium: Lium = ctx["lium"]
         pod: PodInfo = ctx["pod"]
 
-        try:
-            backup_config = lium.backup_config(pod)
+        backup_config = lium.backup_config(pod)
 
-            if not backup_config:
-                return ActionResult(ok=False, data={}, error="No backup configuration found")
+        if not backup_config:
+            return ActionResult(ok=False, data={}, error="No backup configuration found")
 
-            lium.backup_delete(backup_config.id)
+        lium.backup_delete(backup_config.id)
 
-            return ActionResult(ok=True, data={"backup_config_id": backup_config.id})
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(ok=True, data={"backup_config_id": backup_config.id})

--- a/lium/cli/bk/rm/command.py
+++ b/lium/cli/bk/rm/command.py
@@ -4,7 +4,14 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+    ensure_config,
+)
 from . import validation, parsing
 from .actions import RemoveBackupAction
 
@@ -32,22 +39,19 @@ def bk_rm_command(pod_id: str, yes: bool):
     # Validate
     valid, error = validation.validate(pod_id)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(pod_id, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     pod = parsed.get("pod")
     pod_name = parsed.get("pod_name")
@@ -64,7 +68,6 @@ def bk_rm_command(pod_id: str, yes: bool):
     result = ui.load("Removing backup configuration", lambda: action.execute(ctx))
 
     if not result.ok:
-        ui.error(result.error)
-        return
+        raise CliFailure("no_backup_config", result.error, EXIT_GENERAL_ERROR)
 
     ui.success(f"Backup configuration removed for {pod_name}")

--- a/lium/cli/bk/set/actions.py
+++ b/lium/cli/bk/set/actions.py
@@ -13,21 +13,18 @@ class SetBackupAction:
         frequency_hours: int = ctx["frequency_hours"]
         retention_days: int = ctx["retention_days"]
 
-        try:
-            # Check if backup already exists
-            existing_config = lium.backup_config(pod)
+        # Check if backup already exists
+        existing_config = lium.backup_config(pod)
 
-            if existing_config:
-                lium.backup_delete(existing_config.id)
+        if existing_config:
+            lium.backup_delete(existing_config.id)
 
-            # Create new backup config
-            backup_config = lium.backup_create(
-                pod=pod,
-                path=path,
-                frequency_hours=frequency_hours,
-                retention_days=retention_days
-            )
+        # Create new backup config
+        backup_config = lium.backup_create(
+            pod=pod,
+            path=path,
+            frequency_hours=frequency_hours,
+            retention_days=retention_days
+        )
 
-            return ActionResult(ok=True, data={"backup_config": backup_config})
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(ok=True, data={"backup_config": backup_config})

--- a/lium/cli/bk/set/command.py
+++ b/lium/cli/bk/set/command.py
@@ -4,7 +4,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+    ensure_config,
+)
 from . import validation, parsing
 from .actions import SetBackupAction
 
@@ -34,22 +40,19 @@ def bk_set_command(pod_id: str, path: str, every: str, keep: str, yes: bool):
     # Validate
     valid, error = validation.validate(pod_id, every, keep)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(pod_id, path, every, keep, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     pod = parsed.get("pod")
     pod_name = parsed.get("pod_name")
@@ -68,11 +71,7 @@ def bk_set_command(pod_id: str, path: str, every: str, keep: str, yes: bool):
     }
 
     action = SetBackupAction()
-    result = ui.load("Setting backup configuration", lambda: action.execute(ctx))
-
-    if not result.ok:
-        ui.error(result.error)
-        return
+    ui.load("Setting backup configuration", lambda: action.execute(ctx))
 
     ui.success(
         f"Backup configured for {pod_name}: "

--- a/lium/cli/bk/show/actions.py
+++ b/lium/cli/bk/show/actions.py
@@ -12,47 +12,44 @@ class ShowBackupAction:
         lium: Lium = ctx["lium"]
         pod: PodInfo = ctx["pod"]
 
-        try:
-            backup_config = lium.backup_config(pod)
+        backup_config = lium.backup_config(pod)
 
-            if not backup_config:
-                return ActionResult(ok=True, data={"has_config": False})
+        if not backup_config:
+            return ActionResult(ok=True, data={"has_config": False})
 
-            backup_logs = lium.backup_logs(pod)
+        backup_logs = lium.backup_logs(pod)
 
-            last_backup_info = None
-            if backup_logs and len(backup_logs) > 0:
-                last_log = backup_logs[0]
-                status = getattr(last_log, 'status', 'UNKNOWN').upper()
-                timestamp = getattr(last_log, 'created_at', 'Unknown')
-                backup_id = getattr(last_log, 'id', '')[:8] if getattr(last_log, 'id', None) else 'unknown'
-                last_backup_info = {
-                    "status": status,
-                    "timestamp": timestamp,
-                    "id": backup_id
-                }
+        last_backup_info = None
+        if backup_logs and len(backup_logs) > 0:
+            last_log = backup_logs[0]
+            status = getattr(last_log, 'status', 'UNKNOWN').upper()
+            timestamp = getattr(last_log, 'created_at', 'Unknown')
+            backup_id = getattr(last_log, 'id', '')[:8] if getattr(last_log, 'id', None) else 'unknown'
+            last_backup_info = {
+                "status": status,
+                "timestamp": timestamp,
+                "id": backup_id
+            }
 
-            next_due = None
-            if hasattr(backup_config, 'next_backup_at') and backup_config.next_backup_at:
-                next_due = backup_config.next_backup_at
-            elif backup_logs and len(backup_logs) > 0:
-                try:
-                    last_time = datetime.fromisoformat(getattr(backup_logs[0], 'created_at', '').replace('Z', '+00:00'))
-                    next_time = last_time + timedelta(hours=backup_config.backup_frequency_hours)
-                    next_due = next_time.strftime('%Y-%m-%d %H:%M')
-                except:
-                    pass
+        next_due = None
+        if hasattr(backup_config, 'next_backup_at') and backup_config.next_backup_at:
+            next_due = backup_config.next_backup_at
+        elif backup_logs and len(backup_logs) > 0:
+            try:
+                last_time = datetime.fromisoformat(getattr(backup_logs[0], 'created_at', '').replace('Z', '+00:00'))
+                next_time = last_time + timedelta(hours=backup_config.backup_frequency_hours)
+                next_due = next_time.strftime('%Y-%m-%d %H:%M')
+            except:
+                pass
 
-            return ActionResult(
-                ok=True,
-                data={
-                    "has_config": True,
-                    "backup_path": backup_config.backup_path,
-                    "frequency_hours": backup_config.backup_frequency_hours,
-                    "retention_days": backup_config.retention_days,
-                    "last_backup": last_backup_info,
-                    "next_due": next_due
-                }
-            )
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(
+            ok=True,
+            data={
+                "has_config": True,
+                "backup_path": backup_config.backup_path,
+                "frequency_hours": backup_config.backup_frequency_hours,
+                "retention_days": backup_config.retention_days,
+                "last_backup": last_backup_info,
+                "next_due": next_due
+            }
+        )

--- a/lium/cli/bk/show/command.py
+++ b/lium/cli/bk/show/command.py
@@ -4,7 +4,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+    ensure_config,
+)
 from . import validation, parsing
 from .actions import ShowBackupAction
 
@@ -30,22 +36,19 @@ def bk_show_command(pod_id: str):
     # Validate
     valid, error = validation.validate(pod_id)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(pod_id, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     pod = parsed.get("pod")
     pod = parsed.get("pod")
@@ -56,10 +59,6 @@ def bk_show_command(pod_id: str):
 
     action = ShowBackupAction()
     result = ui.load("Loading backup config", lambda: action.execute(ctx))
-
-    if not result.ok:
-        ui.error(result.error)
-        return
 
     if not result.data.get("has_config"):
         ui.warning(f"No backup configuration found for {pod_name}")

--- a/lium/cli/config/edit/command.py
+++ b/lium/cli/config/edit/command.py
@@ -2,8 +2,7 @@
 
 import click
 
-from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import CliFailure, EXIT_GENERAL_ERROR, handle_errors
 from .actions import EditConfigAction
 
 
@@ -19,4 +18,4 @@ def config_edit_command():
     result = action.execute(ctx)
 
     if not result.ok:
-        ui.error(result.error)
+        raise CliFailure("editor_failed", result.error, EXIT_GENERAL_ERROR)

--- a/lium/cli/config/get/command.py
+++ b/lium/cli/config/get/command.py
@@ -3,7 +3,7 @@
 import click
 
 from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import CliFailure, EXIT_CONFIGURATION_ERROR, EXIT_GENERAL_ERROR, handle_errors
 from . import validation
 from .actions import GetConfigAction
 
@@ -24,8 +24,7 @@ def config_get_command(key: str):
     # Validate
     valid, error = validation.validate(key)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_key", error, EXIT_CONFIGURATION_ERROR)
 
     # Execute
     ctx = {"key": key}
@@ -34,8 +33,7 @@ def config_get_command(key: str):
     result = action.execute(ctx)
 
     if not result.ok:
-        ui.error(result.error)
-        return
+        raise CliFailure("key_not_found", result.error, EXIT_GENERAL_ERROR)
 
     value = result.data.get("value")
     styled_value = mask_value(value, key)

--- a/lium/cli/config/set/command.py
+++ b/lium/cli/config/set/command.py
@@ -4,8 +4,7 @@ from typing import Optional
 
 import click
 
-from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import CliFailure, EXIT_CONFIGURATION_ERROR, EXIT_GENERAL_ERROR, handle_errors
 from . import validation
 from .actions import SetConfigAction
 
@@ -27,8 +26,7 @@ def config_set_command(key: str, value: Optional[str]):
     # Validate
     valid, error = validation.validate(key)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_key", error, EXIT_CONFIGURATION_ERROR)
 
     # Execute
     ctx = {"key": key, "value": value or ""}
@@ -37,4 +35,4 @@ def config_set_command(key: str, value: Optional[str]):
     result = action.execute(ctx)
 
     if not result.ok:
-        ui.error(result.error)
+        raise CliFailure("config_set_failed", result.error, EXIT_GENERAL_ERROR)

--- a/lium/cli/config/unset/command.py
+++ b/lium/cli/config/unset/command.py
@@ -2,7 +2,8 @@
 
 import click
 
-from lium.cli.utils import CliFailure, EXIT_GENERAL_ERROR, handle_errors
+from lium.cli import ui
+from lium.cli.utils import handle_errors
 from .actions import UnsetConfigAction
 
 
@@ -18,5 +19,7 @@ def config_unset_command(key: str):
     action = UnsetConfigAction()
     result = action.execute(ctx)
 
+    # Clearing a key that is already absent leaves the config in the asked-for
+    # state, so it stays a success — the same call as `rm --all` on no pods.
     if not result.ok:
-        raise CliFailure("key_not_found", result.error, EXIT_GENERAL_ERROR)
+        ui.warning(result.error)

--- a/lium/cli/config/unset/command.py
+++ b/lium/cli/config/unset/command.py
@@ -2,8 +2,7 @@
 
 import click
 
-from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import CliFailure, EXIT_GENERAL_ERROR, handle_errors
 from .actions import UnsetConfigAction
 
 
@@ -19,5 +18,5 @@ def config_unset_command(key: str):
     action = UnsetConfigAction()
     result = action.execute(ctx)
 
-    if result.error:
-        ui.warning(result.error)
+    if not result.ok:
+        raise CliFailure("key_not_found", result.error, EXIT_GENERAL_ERROR)

--- a/lium/cli/fund/actions.py
+++ b/lium/cli/fund/actions.py
@@ -107,28 +107,25 @@ class CheckWalletRegistrationAction:
         wallet_address = ctx["wallet_address"]
         bt_wallet = ctx["bt_wallet"]
 
-        try:
-            user_wallets = lium.wallets()
-            wallet_addresses = [w.get('wallet_hash', '') for w in user_wallets]
+        user_wallets = lium.wallets()
+        wallet_addresses = [w.get('wallet_hash', '') for w in user_wallets]
 
-            needs_registration = wallet_address not in wallet_addresses
+        needs_registration = wallet_address not in wallet_addresses
 
-            app_id = None
-            if needs_registration:
-                # add_wallet returns (app_id, customer_id) parsed from the same
-                # /tao/create-transfer round-trip; the alpha flow reuses app_id so
-                # it never issues a second create-transfer. The TAO flow ignores it.
-                registration = lium.add_wallet(bt_wallet)
-                if registration:
-                    app_id = registration[0]
-                time.sleep(2)  # Allow registration to complete
+        app_id = None
+        if needs_registration:
+            # add_wallet returns (app_id, customer_id) parsed from the same
+            # /tao/create-transfer round-trip; the alpha flow reuses app_id so
+            # it never issues a second create-transfer. The TAO flow ignores it.
+            registration = lium.add_wallet(bt_wallet)
+            if registration:
+                app_id = registration[0]
+            time.sleep(2)  # Allow registration to complete
 
-            return ActionResult(
-                ok=True,
-                data={"registered": not needs_registration, "app_id": app_id}
-            )
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(
+            ok=True,
+            data={"registered": not needs_registration, "app_id": app_id}
+        )
 
 
 class ExecuteTransferAction:

--- a/lium/cli/init/actions.py
+++ b/lium/cli/init/actions.py
@@ -33,10 +33,7 @@ class RequestAuthUrlAction:
         if current_key:
             return ActionResult(ok=True, data={"already_configured": True})
 
-        try:
-            browser_url, session_id = init_auth()
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=f"Failed to request auth URL: {e}")
+        browser_url, session_id = init_auth()
 
         ui.info("Open this URL to authenticate:")
         ui.print(f"\n  {browser_url}\n")

--- a/lium/cli/init/command.py
+++ b/lium/cli/init/command.py
@@ -2,9 +2,8 @@
 
 import click
 
-from lium.cli import ui
 from lium.cli.settings import config
-from lium.cli.utils import handle_errors
+from lium.cli.utils import CliFailure, EXIT_GENERAL_ERROR, handle_errors
 from .actions import SetupApiKeyAction, RequestAuthUrlAction, VerifySessionAction, SetupSshKeyAction
 
 
@@ -31,17 +30,14 @@ def init_command(no_browser: bool, session: str | None):
         verify_action = VerifySessionAction(session_id=session)
         verify_result = verify_action.execute({})
         if not verify_result.ok:
-            ui.error(verify_result.error)
-            return
+            raise CliFailure("auth_failed", verify_result.error, EXIT_GENERAL_ERROR)
         _setup_ssh()
         return
 
     # Step 1 (headless): just print URL and exit
     if no_browser:
         url_action = RequestAuthUrlAction()
-        url_result = url_action.execute({})
-        if not url_result.ok:
-            ui.error(url_result.error)
+        url_action.execute({})
         return
 
     # Default: browser flow
@@ -49,8 +45,7 @@ def init_command(no_browser: bool, session: str | None):
     api_result = api_action.execute({})
 
     if not api_result.ok:
-        ui.error(api_result.error)
-        return
+        raise CliFailure("auth_failed", api_result.error, EXIT_GENERAL_ERROR)
 
     _setup_ssh()
 
@@ -60,4 +55,4 @@ def _setup_ssh():
     ssh_action = SetupSshKeyAction()
     ssh_result = ssh_action.execute({})
     if not ssh_result.ok:
-        ui.error(ssh_result.error)
+        raise CliFailure("ssh_key_setup_failed", ssh_result.error, EXIT_GENERAL_ERROR)

--- a/lium/cli/logs/command.py
+++ b/lium/cli/logs/command.py
@@ -4,7 +4,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+    ensure_config,
+)
 from . import validation, parsing
 from .actions import StreamLogsAction
 
@@ -32,22 +38,19 @@ def logs_command(pod_id: str, tail: int, follow: bool):
     # Validate
     valid, error = validation.validate(pod_id, tail)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(pod_id, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     pod = parsed["pod"]
 

--- a/lium/cli/ls/actions.py
+++ b/lium/cli/ls/actions.py
@@ -18,18 +18,15 @@ class GetExecutorsAction:
         max_distance = ctx.get("max_distance")
         min_cuda_version = ctx.get("min_cuda_version")
 
-        try:
-            executors = lium.ls(
-                gpu_type=gpu_type,
-                gpu_count=gpu_count,
-                lat=lat,
-                lon=lon,
-                max_distance_miles=max_distance,
-                min_cuda_version=min_cuda_version,
-            )
-            return ActionResult(
-                ok=True,
-                data={"executors": executors}
-            )
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        executors = lium.ls(
+            gpu_type=gpu_type,
+            gpu_count=gpu_count,
+            lat=lat,
+            lon=lon,
+            max_distance_miles=max_distance,
+            min_cuda_version=min_cuda_version,
+        )
+        return ActionResult(
+            ok=True,
+            data={"executors": executors}
+        )

--- a/lium/cli/ls/command.py
+++ b/lium/cli/ls/command.py
@@ -97,10 +97,6 @@ def ls_command(
     else:
         result = ui.load("Loading nodes", lambda: action.execute(ctx))
 
-    if not result.ok:
-        ui.error(result.error)
-        return
-
     executors = result.data["executors"]
 
     # Check if empty

--- a/lium/cli/port_forward/command.py
+++ b/lium/cli/port_forward/command.py
@@ -102,13 +102,12 @@ def port_forward_command(target: str, port: int, local_port: Optional[int]):
     external_port = get_port_mapping(pod, port)
     if not external_port:
         available_ports = list(pod.ports.keys()) if pod.ports else []
+        # The hint travels inside the message: printed on its own it would land
+        # above the error it explains, because the error is rendered on the way out.
+        message = f"Port {port} is not exposed on pod '{pod.huid}'"
         if available_ports:
-            ui.dim(f"Available internal ports: {', '.join(available_ports)}")
-        raise CliFailure(
-            "port_not_exposed",
-            f"Port {port} is not exposed on pod '{pod.huid}'",
-            EXIT_GENERAL_ERROR,
-        )
+            message += f"\nAvailable internal ports: {', '.join(available_ports)}"
+        raise CliFailure("port_not_exposed", message, EXIT_GENERAL_ERROR)
 
     host = pod.executor.ip if pod.executor else pod.host
     if not host:

--- a/lium/cli/port_forward/command.py
+++ b/lium/cli/port_forward/command.py
@@ -7,7 +7,13 @@ import click
 
 from lium.sdk import Lium, PodInfo
 from lium.cli import ui
-from lium.cli.utils import handle_errors, parse_targets
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+    parse_targets,
+)
 
 
 def get_port_mapping(pod: PodInfo, internal_port: int) -> Optional[int]:
@@ -78,32 +84,39 @@ def port_forward_command(target: str, port: int, local_port: Optional[int]):
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     pods = parse_targets(target, all_pods)
     pod = pods[0] if pods else None
 
     if not pod:
-        ui.error(f"Pod '{target}' not found")
-        return
+        raise CliFailure("pod_not_found", f"Pod '{target}' not found", EXIT_POD_NOT_FOUND)
 
     if pod.status.lower() != "running":
-        ui.error(f"Pod '{pod.huid}' is not running (status: {pod.status})")
-        return
+        raise CliFailure(
+            "pod_not_running",
+            f"Pod '{pod.huid}' is not running (status: {pod.status})",
+            EXIT_GENERAL_ERROR,
+        )
 
     external_port = get_port_mapping(pod, port)
     if not external_port:
         available_ports = list(pod.ports.keys()) if pod.ports else []
-        ui.error(f"Port {port} is not exposed on pod '{pod.huid}'")
         if available_ports:
             ui.dim(f"Available internal ports: {', '.join(available_ports)}")
-        return
+        raise CliFailure(
+            "port_not_exposed",
+            f"Port {port} is not exposed on pod '{pod.huid}'",
+            EXIT_GENERAL_ERROR,
+        )
 
     host = pod.executor.ip if pod.executor else pod.host
     if not host:
-        ui.error(f"Cannot determine host IP for pod '{pod.huid}'")
-        return
+        raise CliFailure(
+            "host_unknown",
+            f"Cannot determine host IP for pod '{pod.huid}'",
+            EXIT_GENERAL_ERROR,
+        )
 
     ui.success(f"Forwarding localhost:{local_port} -> {host}:{external_port} (pod port {port})")
     ui.dim("Press Ctrl+C to stop")
@@ -127,6 +140,10 @@ def port_forward_command(target: str, port: int, local_port: Optional[int]):
     except KeyboardInterrupt:
         ui.dim("\nPort forwarding stopped")
     except OSError as e:
-        ui.error(f"Failed to bind to port {local_port}: {e}")
+        raise CliFailure(
+            "port_bind_failed",
+            f"Failed to bind to port {local_port}: {e}",
+            EXIT_GENERAL_ERROR,
+        )
     finally:
         server.close()

--- a/lium/cli/ps/actions.py
+++ b/lium/cli/ps/actions.py
@@ -14,11 +14,8 @@ class GetPodsAction:
         """
         lium = ctx["lium"]
 
-        try:
-            pods = lium.ps()
-            return ActionResult(
-                ok=True,
-                data={"pods": pods}
-            )
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        pods = lium.ps()
+        return ActionResult(
+            ok=True,
+            data={"pods": pods}
+        )

--- a/lium/cli/ps/command.py
+++ b/lium/cli/ps/command.py
@@ -6,7 +6,7 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config
+from lium.cli.utils import CliFailure, EXIT_POD_NOT_FOUND, handle_errors, ensure_config
 from . import display
 from .actions import GetPodsAction
 
@@ -35,23 +35,14 @@ def ps_command(pod_id: Optional[str], output_format: str):
     else:
         result = ui.load("Loading pods", lambda: action.execute(ctx))
 
-    if not result.ok:
-        ui.error(result.error)
-        return
-
     pods = result.data["pods"]
 
     # Filter by pod_id if provided
-    if pod_id and pods:
+    if pod_id:
         pod = next((p for p in pods if p.id == pod_id or p.huid == pod_id or p.name == pod_id), None)
-        if pod:
-            pods = [pod]
-        else:
-            if output_format == "json":
-                click.echo("[]")
-            else:
-                ui.error(f"Pod '{pod_id}' not found")
-            return
+        if not pod:
+            raise CliFailure("pod_not_found", f"Pod '{pod_id}' not found", EXIT_POD_NOT_FOUND)
+        pods = [pod]
 
     # Check if empty
     if not pods:

--- a/lium/cli/reboot/command.py
+++ b/lium/cli/reboot/command.py
@@ -5,7 +5,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+)
 from . import validation, parsing
 from .actions import RebootPodsAction
 
@@ -21,22 +27,23 @@ def reboot_command(targets: Optional[str], all: bool, volume_id: Optional[str]):
     # Validate
     valid, error = validation.validate(targets, all)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
+    # --all against an empty account is an idempotent no-op; a named target is not.
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        if all:
+            ui.warning("No active pods")
+            return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(targets, all, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     selected_pods = parsed.get("selected_pods")
 
@@ -50,4 +57,8 @@ def reboot_command(targets: Optional[str], all: bool, volume_id: Optional[str]):
     # Only error if anything failed
     if not result.ok:
         failed_huids = result.data.get("failed_huids", [])
-        ui.error(f"Failed to reboot pods: {', '.join(failed_huids)}")
+        raise CliFailure(
+            "reboot_failed",
+            f"Failed to reboot pods: {', '.join(failed_huids)}",
+            EXIT_GENERAL_ERROR,
+        )

--- a/lium/cli/rsync/command.py
+++ b/lium/cli/rsync/command.py
@@ -5,7 +5,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+)
 from . import validation, parsing
 from .actions import RsyncPodsAction
 
@@ -21,22 +27,19 @@ def rsync_command(targets: str, local_path: str, remote_path: Optional[str]):
     # Validate
     valid, error = validation.validate(local_path)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(targets, all_pods, local_path, remote_path)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     selected_pods = parsed.get("selected_pods")
     local_dir = parsed.get("local_dir")
@@ -56,4 +59,8 @@ def rsync_command(targets: str, local_path: str, remote_path: Optional[str]):
     # Only error if anything failed
     if not result.ok:
         failed_huids = result.data.get("failed_huids", [])
-        ui.error(f"Failed to rsync to pods: {', '.join(failed_huids)}")
+        raise CliFailure(
+            "rsync_failed",
+            f"Failed to rsync to pods: {', '.join(failed_huids)}",
+            EXIT_GENERAL_ERROR,
+        )

--- a/lium/cli/schedules/rm/command.py
+++ b/lium/cli/schedules/rm/command.py
@@ -4,7 +4,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+)
 from . import validation, parsing
 from .actions import CancelSchedulesAction
 
@@ -18,22 +24,19 @@ def schedules_rm_command(indices: str):
     # Validate
     valid, error = validation.validate(indices)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading scheduled terminations", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(indices, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     pods_to_cancel = parsed.get("pods_to_cancel")
 
@@ -46,4 +49,8 @@ def schedules_rm_command(indices: str):
     # Only error if anything failed
     if not result.ok:
         failed_huids = result.data.get("failed_huids", [])
-        ui.error(f"Failed to cancel schedules: {', '.join(failed_huids)}")
+        raise CliFailure(
+            "schedule_cancel_failed",
+            f"Failed to cancel schedules: {', '.join(failed_huids)}",
+            EXIT_GENERAL_ERROR,
+        )

--- a/lium/cli/scp/command.py
+++ b/lium/cli/scp/command.py
@@ -6,7 +6,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+)
 from . import validation, parsing
 from .actions import ScpAction
 
@@ -52,22 +58,19 @@ def scp_command(
     # Validate
     valid, error = validation.validate(targets, source_path, download)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(targets, source_path, destination_path, download, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     pods = parsed.get("pods")
     download_mode = parsed.get("download")
@@ -86,4 +89,8 @@ def scp_command(
     if not result.ok:
         failed_huids = result.data.get("failed_huids", [])
         action_name = "download from" if download_mode else "upload to"
-        ui.error(f"Failed to {action_name}: {', '.join(failed_huids)}")
+        raise CliFailure(
+            "scp_failed",
+            f"Failed to {action_name}: {', '.join(failed_huids)}",
+            EXIT_GENERAL_ERROR,
+        )

--- a/lium/cli/ssh/actions.py
+++ b/lium/cli/ssh/actions.py
@@ -22,16 +22,10 @@ class SshAction:
 
         try:
             result = subprocess.run(ssh_cmd, shell=True, check=False)
-
-            if result.returncode != 0 and result.returncode != 255:
-                return ActionResult(
-                    ok=False,
-                    data={"exit_code": result.returncode}
-                )
-
+        except KeyboardInterrupt:
+            # Ctrl+C out of a session is the user's own doing, not a lium failure.
+            ui.warning("\nSSH session interrupted")
             return ActionResult(ok=True, data={})
 
-        except KeyboardInterrupt:
-            return ActionResult(ok=False, data={}, error="SSH session interrupted")
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        # A non-zero remote shell is the remote's business; 255 is ssh itself.
+        return ActionResult(ok=True, data={"exit_code": result.returncode})

--- a/lium/cli/ssh/command.py
+++ b/lium/cli/ssh/command.py
@@ -8,7 +8,7 @@ import click
 from lium.sdk import Lium, PodInfo
 from lium.cli import ui
 from lium.cli.utils import handle_errors, parse_targets
-from lium.cli.utils import CliFailure, EXIT_POD_NOT_FOUND, EXIT_SSH_ERROR
+from lium.cli.utils import CliFailure, EXIT_CONFIGURATION_ERROR, EXIT_POD_NOT_FOUND, EXIT_SSH_ERROR
 from . import validation, parsing
 from .actions import SshAction
 
@@ -91,22 +91,24 @@ def ssh_command(target: str):
     # Validate
     valid, error = validation.validate(target)
     if not valid:
-        ui.error(error)
-        return
+        if "'ssh' command not found" in error:
+            raise CliFailure("ssh_client_missing", error, EXIT_SSH_ERROR)
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(target, all_pods)
     if error:
-        ui.error(error)
-        return
+        # "not found" is a miss; a pod that exists but cannot take a session is ssh's own failure.
+        if "not found" in error and "SSH connection" not in error:
+            raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
+        raise CliFailure("ssh_unavailable", error, EXIT_SSH_ERROR)
 
     pod = parsed.get("pod")
 
@@ -116,8 +118,12 @@ def ssh_command(target: str):
     action = SshAction()
     result = action.execute(ctx)
 
-    if not result.ok:
-        if result.error:
-            ui.error(result.error)
-        elif result.data.get("exit_code"):
-            ui.dim(f"SSH session ended with exit code {result.data['exit_code']}")
+    exit_code = result.data.get("exit_code")
+    if exit_code == _SSH_CONNECTION_FAILED:
+        raise CliFailure(
+            "ssh_failed",
+            f"SSH connection to '{pod.huid}' failed",
+            EXIT_SSH_ERROR,
+        )
+    if exit_code:
+        ui.dim(f"SSH session ended with exit code {exit_code}")

--- a/lium/cli/ssh/command.py
+++ b/lium/cli/ssh/command.py
@@ -103,12 +103,9 @@ def ssh_command(target: str):
         raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
-    parsed, error = parsing.parse(target, all_pods)
-    if error:
-        # "not found" is a miss; a pod that exists but cannot take a session is ssh's own failure.
-        if "not found" in error and "SSH connection" not in error:
-            raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
-        raise CliFailure("ssh_unavailable", error, EXIT_SSH_ERROR)
+    parsed, failure = parsing.parse(target, all_pods)
+    if failure:
+        raise failure
 
     pod = parsed.get("pod")
 

--- a/lium/cli/ssh/parsing.py
+++ b/lium/cli/ssh/parsing.py
@@ -3,24 +3,41 @@
 from typing import List
 
 from lium.sdk import PodInfo
-from lium.cli.utils import parse_targets
+from lium.cli.utils import CliFailure, EXIT_POD_NOT_FOUND, EXIT_SSH_ERROR, parse_targets
 
 
-def parse(target: str, all_pods: List[PodInfo]) -> tuple[dict | None, str]:
-    """Parse ssh command arguments."""
+def parse(target: str, all_pods: List[PodInfo]) -> tuple[dict | None, CliFailure | None]:
+    """Parse ssh command arguments.
+
+    The failure carries its own exit code, so the command layer does not have to
+    read it back out of the message text: a name that matches nothing is a miss,
+    a pod that exists but cannot take a session is ssh's own failure.
+    """
 
     pods = parse_targets(target, all_pods)
     pod = pods[0] if pods else None
 
     if not pod:
-        return None, f"Pod '{target}' not found"
+        return None, CliFailure(
+            "pod_not_found", f"Pod '{target}' not found", EXIT_POD_NOT_FOUND
+        )
 
     if pod.status not in ["RUNNING", "STARTING"]:
         if pod.status in ["STOPPED", "FAILED"]:
-            return None, f"Cannot SSH to a stopped or failed pod '{pod.huid}'"
-        return None, f"Pod '{pod.huid}' is {pod.status}"
+            return None, CliFailure(
+                "ssh_unavailable",
+                f"Cannot SSH to a stopped or failed pod '{pod.huid}'",
+                EXIT_SSH_ERROR,
+            )
+        return None, CliFailure(
+            "ssh_unavailable", f"Pod '{pod.huid}' is {pod.status}", EXIT_SSH_ERROR
+        )
 
     if not pod.ssh_cmd:
-        return None, f"No SSH connection available for pod '{pod.huid}'"
+        return None, CliFailure(
+            "ssh_unavailable",
+            f"No SSH connection available for pod '{pod.huid}'",
+            EXIT_SSH_ERROR,
+        )
 
-    return {"pod": pod}, ""
+    return {"pod": pod}, None

--- a/lium/cli/ssh_keys/list/actions.py
+++ b/lium/cli/ssh_keys/list/actions.py
@@ -6,8 +6,5 @@ from lium.cli.actions import ActionResult
 class GetSSHKeysAction:
     def execute(self, ctx: dict) -> ActionResult:
         lium = ctx["lium"]
-        try:
-            keys = lium.list_ssh_keys()
-            return ActionResult(ok=True, data={"keys": keys})
-        except Exception as exc:
-            return ActionResult(ok=False, data={}, error=str(exc))
+        keys = lium.list_ssh_keys()
+        return ActionResult(ok=True, data={"keys": keys})

--- a/lium/cli/ssh_keys/list/command.py
+++ b/lium/cli/ssh_keys/list/command.py
@@ -22,10 +22,6 @@ def ssh_keys_list_command():
     action = GetSSHKeysAction()
     result = ui.load("Loading SSH keys", lambda: action.execute(ctx))
 
-    if not result.ok:
-        ui.error(result.error)
-        return
-
     keys = result.data["keys"]
 
     if not keys:

--- a/lium/cli/ssh_keys/sync/actions.py
+++ b/lium/cli/ssh_keys/sync/actions.py
@@ -4,54 +4,43 @@ from typing import List
 
 from lium.cli.actions import ActionResult
 from lium.sdk import Lium, SSHKey
-from lium.sdk.exceptions import LiumError
 from lium.sdk.ssh_key_cache import fingerprint, load_cache, save_cache
 
 
 class SyncSSHKeysAction:
     def execute(self, ctx: dict) -> ActionResult:
         lium: Lium = ctx["lium"]
-        try:
-            local_pubkeys = [pk.strip() for pk in lium.config.ssh_public_keys if pk.strip()]
-            server_keys = lium.list_ssh_keys()
-            server_index = {k.public_key.strip(): k for k in server_keys if k.public_key}
-            default_name = lium.default_ssh_key_name()
+        local_pubkeys = [pk.strip() for pk in lium.config.ssh_public_keys if pk.strip()]
+        server_keys = lium.list_ssh_keys()
+        server_index = {k.public_key.strip(): k for k in server_keys if k.public_key}
+        default_name = lium.default_ssh_key_name()
 
-            already_registered = 0
-            registered: List[SSHKey] = []
-            for pk in local_pubkeys:
-                if pk in server_index:
-                    already_registered += 1
-                    continue
-                try:
-                    new_key = lium.register_ssh_key(name=default_name, public_key=pk)
-                    registered.append(new_key)
-                    server_index[pk] = new_key
-                except LiumError as exc:
-                    return ActionResult(
-                        ok=False,
-                        data={},
-                        error=f"Failed to register a key: {exc}",
-                    )
+        already_registered = 0
+        registered: List[SSHKey] = []
+        for pk in local_pubkeys:
+            if pk in server_index:
+                already_registered += 1
+                continue
+            new_key = lium.register_ssh_key(name=default_name, public_key=pk)
+            registered.append(new_key)
+            server_index[pk] = new_key
 
-            cached = load_cache(lium.config)
-            new_fps = set(cached) | {fingerprint(pk) for pk in local_pubkeys}
-            if new_fps != cached:
-                try:
-                    save_cache(lium.config, new_fps)
-                except OSError:
-                    pass
+        cached = load_cache(lium.config)
+        new_fps = set(cached) | {fingerprint(pk) for pk in local_pubkeys}
+        if new_fps != cached:
+            try:
+                save_cache(lium.config, new_fps)
+            except OSError:
+                pass
 
-            legacy = [k for k in server_index.values() if (k.name or "").startswith("sdk-")]
+        legacy = [k for k in server_index.values() if (k.name or "").startswith("sdk-")]
 
-            return ActionResult(
-                ok=True,
-                data={
-                    "registered": registered,
-                    "legacy": legacy,
-                    "already_registered": already_registered,
-                    "default_name": default_name,
-                },
-            )
-        except Exception as exc:
-            return ActionResult(ok=False, data={}, error=str(exc))
+        return ActionResult(
+            ok=True,
+            data={
+                "registered": registered,
+                "legacy": legacy,
+                "already_registered": already_registered,
+                "default_name": default_name,
+            },
+        )

--- a/lium/cli/ssh_keys/sync/command.py
+++ b/lium/cli/ssh_keys/sync/command.py
@@ -28,10 +28,6 @@ def ssh_keys_sync_command():
     action = SyncSSHKeysAction()
     result = ui.load("Syncing SSH keys", lambda: action.execute(ctx))
 
-    if not result.ok:
-        ui.error(result.error)
-        return
-
     registered = result.data["registered"]
     legacy = result.data["legacy"]
     already = result.data["already_registered"]

--- a/lium/cli/templates/actions.py
+++ b/lium/cli/templates/actions.py
@@ -9,11 +9,8 @@ class GetTemplatesAction:
         lium = ctx["lium"]
         search = ctx.get("search")
 
-        try:
-            templates = lium.templates(search)
-            return ActionResult(
-                ok=True,
-                data={"templates": templates}
-            )
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        templates = lium.templates(search)
+        return ActionResult(
+            ok=True,
+            data={"templates": templates}
+        )

--- a/lium/cli/templates/command.py
+++ b/lium/cli/templates/command.py
@@ -22,10 +22,6 @@ def templates_command(search: Optional[str]):
     action = GetTemplatesAction()
     result = ui.load("Loading templates", lambda: action.execute(ctx))
 
-    if not result.ok:
-        ui.error(result.error)
-        return
-
     templates = result.data["templates"]
 
     # Check if empty

--- a/lium/cli/theme/actions.py
+++ b/lium/cli/theme/actions.py
@@ -6,19 +6,16 @@ class GetThemeAction:
     def execute(self, ctx: dict) -> ActionResult:
         console = ctx["console"]
 
-        try:
-            current = console.get_current_theme_name()
-            resolved = console.get_resolved_theme_name()
+        current = console.get_current_theme_name()
+        resolved = console.get_resolved_theme_name()
 
-            return ActionResult(
-                ok=True,
-                data={
-                    "current": current,
-                    "resolved": resolved
-                }
-            )
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(
+            ok=True,
+            data={
+                "current": current,
+                "resolved": resolved
+            }
+        )
 
 
 class SwitchThemeAction:
@@ -27,21 +24,18 @@ class SwitchThemeAction:
         console = ctx["console"]
         theme_name = ctx["theme_name"]
 
-        try:
-            old_theme = console.get_current_theme_name()
-            console.switch_theme(theme_name)
+        old_theme = console.get_current_theme_name()
+        console.switch_theme(theme_name)
 
-            resolved = None
-            if theme_name == "auto":
-                resolved = console.get_resolved_theme_name()
+        resolved = None
+        if theme_name == "auto":
+            resolved = console.get_resolved_theme_name()
 
-            return ActionResult(
-                ok=True,
-                data={
-                    "old_theme": old_theme,
-                    "new_theme": theme_name,
-                    "resolved": resolved
-                }
-            )
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(
+            ok=True,
+            data={
+                "old_theme": old_theme,
+                "new_theme": theme_name,
+                "resolved": resolved
+            }
+        )

--- a/lium/cli/theme/command.py
+++ b/lium/cli/theme/command.py
@@ -3,7 +3,6 @@
 import click
 
 from lium.cli.themed_console import ThemedConsole
-from lium.cli import ui
 from lium.cli.utils import handle_errors
 from .actions import SwitchThemeAction
 
@@ -17,7 +16,4 @@ def theme_command(theme_name: str):
 
     ctx = {"console": console, "theme_name": theme_name}
     action = SwitchThemeAction()
-    result = action.execute(ctx)
-
-    if not result.ok:
-        ui.error(result.error)
+    action.execute(ctx)

--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -21,65 +21,61 @@ class ResolveExecutorAction:
         country: Optional[str] = ctx.get("country")
         ports: Optional[int] = ctx.get("ports")
 
-        try:
-            if executor_id:
-                if executor_id.isdigit():
-                    resolved_ids, error = resolve_executor_indices([executor_id])
-                    if error or not resolved_ids:
-                        return ActionResult(ok=False, data={}, error=error or "Failed to resolve node index")
-                    executor_id = resolved_ids[0]
+        if executor_id:
+            if executor_id.isdigit():
+                resolved_ids, error = resolve_executor_indices([executor_id])
+                if error or not resolved_ids:
+                    return ActionResult(ok=False, data={}, error=error or "Failed to resolve node index")
+                executor_id = resolved_ids[0]
 
-                executor = lium.get_executor(executor_id)
-                if not executor:
-                    return ActionResult(ok=False, data={}, error=f"Node '{executor_id}' not found")
+            executor = lium.get_executor(executor_id)
+            if not executor:
+                return ActionResult(ok=False, data={}, error=f"Node '{executor_id}' not found")
 
-                if ports and (not executor.available_port_count or executor.available_port_count < ports):
-                    available = executor.available_port_count or 0
-                    return ActionResult(
-                        ok=False,
-                        data={},
-                        error=f"Node {executor.huid} has insufficient ports (available: {available}, required: {ports})"
-                    )
-            else:
-                executors = lium.ls(gpu_type=gpu)
+            if ports and (not executor.available_port_count or executor.available_port_count < ports):
+                available = executor.available_port_count or 0
+                return ActionResult(
+                    ok=False,
+                    data={},
+                    error=f"Node {executor.huid} has insufficient ports (available: {available}, required: {ports})"
+                )
+        else:
+            executors = lium.ls(gpu_type=gpu)
 
+            if count:
+                executors = [e for e in executors if e.gpu_count == count]
+            if country:
+                executors = [
+                    e for e in executors
+                    if e.location and e.location.get('country_code', '').upper() == country.upper()
+                ]
+            if ports:
+                executors = [
+                    e for e in executors
+                    if e.available_port_count and e.available_port_count >= ports
+                ]
+
+            if not executors:
+                filters = []
+                if gpu:
+                    filters.append(f"GPU type={gpu}")
                 if count:
-                    executors = [e for e in executors if e.gpu_count == count]
+                    filters.append(f"GPU count={count}")
                 if country:
-                    executors = [
-                        e for e in executors
-                        if e.location and e.location.get('country_code', '').upper() == country.upper()
-                    ]
+                    filters.append(f"country={country}")
                 if ports:
-                    executors = [
-                        e for e in executors
-                        if e.available_port_count and e.available_port_count >= ports
-                    ]
+                    filters.append(f"min ports={ports}")
+                filter_desc = ', '.join(filters) if filters else "specified filters"
+                return ActionResult(ok=False, data={}, error=f"No nodes available with {filter_desc}")
 
-                if not executors:
-                    filters = []
-                    if gpu:
-                        filters.append(f"GPU type={gpu}")
-                    if count:
-                        filters.append(f"GPU count={count}")
-                    if country:
-                        filters.append(f"country={country}")
-                    if ports:
-                        filters.append(f"min ports={ports}")
-                    filter_desc = ', '.join(filters) if filters else "specified filters"
-                    return ActionResult(ok=False, data={}, error=f"No nodes available with {filter_desc}")
+            from lium.cli.ls.command import ls_store_executor
+            ls_store_executor(gpu_type=gpu)
 
-                from lium.cli.ls.command import ls_store_executor
-                ls_store_executor(gpu_type=gpu)
+            pareto_flags = calculate_pareto_frontier(executors)
+            pareto_executors = [e for e, is_pareto in zip(executors, pareto_flags) if is_pareto]
+            executor = pareto_executors[0] if pareto_executors else executors[0]
 
-                pareto_flags = calculate_pareto_frontier(executors)
-                pareto_executors = [e for e, is_pareto in zip(executors, pareto_flags) if is_pareto]
-                executor = pareto_executors[0] if pareto_executors else executors[0]
-
-            return ActionResult(ok=True, data={"executor": executor})
-
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(ok=True, data={"executor": executor})
 
 
 class ResolveTemplateAction:
@@ -89,20 +85,16 @@ class ResolveTemplateAction:
         template_id: Optional[str] = ctx.get("template_id")
         executor: Optional[ExecutorInfo] = ctx.get("executor")
 
-        try:
-            if template_id:
-                template = lium.get_template(template_id)
-                if not template:
-                    return ActionResult(ok=False, data={}, error=f"Template '{template_id}' not found")
-            else:
-                template = lium.default_docker_template(executor.id) if executor else None
-                if not template:
-                    template = lium.get_template(get_pytorch_template_id())
+        if template_id:
+            template = lium.get_template(template_id)
+            if not template:
+                return ActionResult(ok=False, data={}, error=f"Template '{template_id}' not found")
+        else:
+            template = lium.default_docker_template(executor.id) if executor else None
+            if not template:
+                template = lium.get_template(get_pytorch_template_id())
 
-            return ActionResult(ok=True, data={"template": template})
-
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(ok=True, data={"template": template})
 
 
 class CreateEphemeralTemplateAction:
@@ -116,36 +108,32 @@ class CreateEphemeralTemplateAction:
         cmd: Optional[str] = ctx.get("cmd", "")
         ports: List[int] = ctx.get("ports", [22])
 
-        try:
-            # Parse image:tag
-            if ":" in image:
-                docker_image, docker_tag = image.rsplit(":", 1)
-            else:
-                docker_image = image
-                docker_tag = "latest"
+        # Parse image:tag
+        if ":" in image:
+            docker_image, docker_tag = image.rsplit(":", 1)
+        else:
+            docker_image = image
+            docker_tag = "latest"
 
-            # Generate a unique name for the ephemeral template
-            import hashlib
-            hash_input = f"{image}{env}{entrypoint}{cmd}"
-            short_hash = hashlib.md5(hash_input.encode()).hexdigest()[:8]
-            template_name = f"ephemeral-{short_hash}"
+        # Generate a unique name for the ephemeral template
+        import hashlib
+        hash_input = f"{image}{env}{entrypoint}{cmd}"
+        short_hash = hashlib.md5(hash_input.encode()).hexdigest()[:8]
+        template_name = f"ephemeral-{short_hash}"
 
-            template = lium.create_template(
-                name=template_name,
-                docker_image=docker_image,
-                docker_image_tag=docker_tag,
-                ports=ports,
-                start_command=cmd,
-                entrypoint=entrypoint,
-                environment=env or {},
-                is_private=True,
-                one_time_template=True,
-            )
+        template = lium.create_template(
+            name=template_name,
+            docker_image=docker_image,
+            docker_image_tag=docker_tag,
+            ports=ports,
+            start_command=cmd,
+            entrypoint=entrypoint,
+            environment=env or {},
+            is_private=True,
+            one_time_template=True,
+        )
 
-            return ActionResult(ok=True, data={"template": template})
-
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(ok=True, data={"template": template})
 
 
 class CreateVolumeAction:
@@ -154,15 +142,11 @@ class CreateVolumeAction:
         lium: Lium = ctx["lium"]
         volume_create_params: Dict[str, str] = ctx["volume_create_params"]
 
-        try:
-            volume = lium.volume_create(
-                name=volume_create_params['name'],
-                description=volume_create_params.get('description', '')
-            )
-            return ActionResult(ok=True, data={"volume": volume, "volume_id": volume.id})
-
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        volume = lium.volume_create(
+            name=volume_create_params['name'],
+            description=volume_create_params.get('description', '')
+        )
+        return ActionResult(ok=True, data={"volume": volume, "volume_id": volume.id})
 
 
 class RentPodAction:
@@ -178,26 +162,22 @@ class RentPodAction:
         ssh_name: Optional[str] = ctx.get("ssh_name")
         enable_volume_encryption: bool | None = ctx.get("enable_volume_encryption")
 
-        try:
-            if not name:
-                name = executor.huid
+        if not name:
+            name = executor.huid
 
-            pod_info = lium.up(
-                executor_id=executor.id,
-                name=name,
-                template_id=template.id if template else None,
-                dockerfile_content=dockerfile_content,
-                volume_id=volume_id,
-                ports=ports,
-                ssh_name=ssh_name,
-                enable_volume_encryption=enable_volume_encryption,
-            )
+        pod_info = lium.up(
+            executor_id=executor.id,
+            name=name,
+            template_id=template.id if template else None,
+            dockerfile_content=dockerfile_content,
+            volume_id=volume_id,
+            ports=ports,
+            ssh_name=ssh_name,
+            enable_volume_encryption=enable_volume_encryption,
+        )
 
-            pod_id = pod_info.get('id') or pod_info.get('name', '')
-            return ActionResult(ok=True, data={"pod_info": pod_info, "pod_id": pod_id, "pod_name": name})
-
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        pod_id = pod_info.get('id') or pod_info.get('name', '')
+        return ActionResult(ok=True, data={"pod_info": pod_info, "pod_id": pod_id, "pod_name": name})
 
 
 class WaitReadyAction:
@@ -206,12 +186,8 @@ class WaitReadyAction:
         lium: Lium = ctx["lium"]
         pod_id: str = ctx["pod_id"]
 
-        try:
-            pod = wait_ready_no_timeout(lium, pod_id)
-            return ActionResult(ok=True, data={"pod": pod})
-
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        pod = wait_ready_no_timeout(lium, pod_id)
+        return ActionResult(ok=True, data={"pod": pod})
 
 
 class ScheduleTerminationAction:
@@ -221,24 +197,20 @@ class ScheduleTerminationAction:
         pod: PodInfo = ctx["pod"]
         termination_time = ctx["termination_time"]
 
-        try:
-            termination_time_str = termination_time.isoformat()
-            lium.schedule_termination(pod, termination_time=termination_time_str)
+        termination_time_str = termination_time.isoformat()
+        lium.schedule_termination(pod, termination_time=termination_time_str)
 
-            from datetime import datetime, timezone
-            time_delta = termination_time - datetime.now(timezone.utc)
-            hours_until = time_delta.total_seconds() / 3600
+        from datetime import datetime, timezone
+        time_delta = termination_time - datetime.now(timezone.utc)
+        hours_until = time_delta.total_seconds() / 3600
 
-            return ActionResult(
-                ok=True,
-                data={
-                    "termination_time": termination_time,
-                    "hours_until": hours_until
-                }
-            )
-
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(
+            ok=True,
+            data={
+                "termination_time": termination_time,
+                "hours_until": hours_until
+            }
+        )
 
 
 class InstallJupyterAction:
@@ -248,57 +220,53 @@ class InstallJupyterAction:
         pod: PodInfo = ctx["pod"]
         ui = ctx.get("ui")
 
-        try:
-            if not pod.ports:
-                return ActionResult(ok=False, data={}, error="No ports allocated to pod for Jupyter installation")
+        if not pod.ports:
+            return ActionResult(ok=False, data={}, error="No ports allocated to pod for Jupyter installation")
 
-            available_ports = [int(port) for port in pod.ports.keys() if int(port) != 22]
+        available_ports = [int(port) for port in pod.ports.keys() if int(port) != 22]
 
-            if not available_ports:
-                return ActionResult(
-                    ok=False,
-                    data={},
-                    error="No suitable ports available for Jupyter (only SSH port 22 found)"
-                )
-
-            jupyter_port = available_ports[0]
-
-            lium.install_jupyter(pod, jupyter_internal_port=jupyter_port)
-
-            max_wait = 120
-            wait_interval = 3
-            elapsed = 0
-            pod_id = pod.id
-
-            while elapsed < max_wait:
-                time.sleep(wait_interval)
-                elapsed += wait_interval
-
-                all_pods = lium.ps()
-                updated_pod = next((p for p in all_pods if p.id == pod_id or p.huid == pod_id or p.name == pod_id), None)
-
-                if updated_pod and hasattr(updated_pod, 'jupyter_installation_status'):
-                    if updated_pod.jupyter_installation_status == "SUCCESS":
-                        jupyter_url = getattr(updated_pod, 'jupyter_url', None)
-                        return ActionResult(
-                            ok=True,
-                            data={"jupyter_url": jupyter_url, "jupyter_port": jupyter_port}
-                        )
-                    elif updated_pod.jupyter_installation_status == "FAILED":
-                        error_details = getattr(updated_pod, 'jupyter_error', '')
-                        error_msg = f"Jupyter installation failed"
-                        if error_details:
-                            error_msg += f": {error_details}"
-                        return ActionResult(ok=False, data={}, error=error_msg)
-
+        if not available_ports:
             return ActionResult(
                 ok=False,
                 data={},
-                error="Jupyter installation timed out. Run 'lium ps' to check status"
+                error="No suitable ports available for Jupyter (only SSH port 22 found)"
             )
 
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        jupyter_port = available_ports[0]
+
+        lium.install_jupyter(pod, jupyter_internal_port=jupyter_port)
+
+        max_wait = 120
+        wait_interval = 3
+        elapsed = 0
+        pod_id = pod.id
+
+        while elapsed < max_wait:
+            time.sleep(wait_interval)
+            elapsed += wait_interval
+
+            all_pods = lium.ps()
+            updated_pod = next((p for p in all_pods if p.id == pod_id or p.huid == pod_id or p.name == pod_id), None)
+
+            if updated_pod and hasattr(updated_pod, 'jupyter_installation_status'):
+                if updated_pod.jupyter_installation_status == "SUCCESS":
+                    jupyter_url = getattr(updated_pod, 'jupyter_url', None)
+                    return ActionResult(
+                        ok=True,
+                        data={"jupyter_url": jupyter_url, "jupyter_port": jupyter_port}
+                    )
+                elif updated_pod.jupyter_installation_status == "FAILED":
+                    error_details = getattr(updated_pod, 'jupyter_error', '')
+                    error_msg = f"Jupyter installation failed"
+                    if error_details:
+                        error_msg += f": {error_details}"
+                    return ActionResult(ok=False, data={}, error=error_msg)
+
+        return ActionResult(
+            ok=False,
+            data={},
+            error="Jupyter installation timed out. Run 'lium ps' to check status"
+        )
 
 
 class PrepareSSHAction:
@@ -306,10 +274,6 @@ class PrepareSSHAction:
     def execute(self, ctx: dict) -> ActionResult:
         pod_name: str = ctx["pod_name"]
 
-        try:
-            from lium.cli.ssh.command import get_ssh_method_and_pod
-            ssh_cmd, pod = get_ssh_method_and_pod(pod_name)
-            return ActionResult(ok=True, data={"ssh_cmd": ssh_cmd, "pod": pod})
-
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        from lium.cli.ssh.command import get_ssh_method_and_pod
+        ssh_cmd, pod = get_ssh_method_and_pod(pod_name)
+        return ActionResult(ok=True, data={"ssh_cmd": ssh_cmd, "pod": pod})

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -247,8 +247,6 @@ def up_command(
                 "ports": ports_list,
             })
         )
-        if not result.ok:
-            raise CliFailure("template_failed", result.error, EXIT_GENERAL_ERROR)
         template = result.data["template"]
     else:
         action = ResolveTemplateAction()
@@ -295,9 +293,6 @@ def up_command(
             })
         )
 
-        if not result.ok:
-            raise CliFailure("volume_failed", result.error, EXIT_GENERAL_ERROR)
-
         volume_id = result.data["volume_id"]
 
     action = RentPodAction()
@@ -316,59 +311,56 @@ def up_command(
         })
     )
 
-    if not result.ok:
-        raise CliFailure("rent_failed", result.error, EXIT_GENERAL_ERROR)
-
     pod_id = result.data["pod_id"]
     pod_name = result.data["pod_name"]
 
+    # The pod is rented and already billing from here on. Every failure below
+    # names it before propagating, or the caller cannot clean up what it pays for.
     action = WaitReadyAction()
-    result = ui.load(
-        "Loading image",
-        lambda: action.execute({
-            "lium": lium,
-            "pod_id": pod_id
-        })
-    )
-
-    if not result.ok:
-        # The pod is rented and already billing. Name it before failing, or the
-        # caller cannot clean up what it is now paying for.
+    try:
+        result = ui.load(
+            "Loading image",
+            lambda: action.execute({
+                "lium": lium,
+                "pod_id": pod_id
+            })
+        )
+    except Exception:
         ui.error(f"Pod {pod_name} (id: {pod_id}) was created but did not become ready")
-        raise CliFailure("pod_not_ready", result.error, EXIT_GENERAL_ERROR)
+        raise
 
     pod = result.data["pod"]
     pod_label = f"Pod {ui.styled(pod.huid, 'pod_id')} (name: {pod_name}, id: {pod_id})"
 
     if termination_time:
         action = ScheduleTerminationAction()
-        result = ui.load(
-            "Scheduling termination",
-            lambda: action.execute({
-                "lium": lium,
-                "pod": pod,
-                "termination_time": termination_time
-            })
-        )
-
-        if not result.ok:
-            ui.info(pod_label)
-            raise CliFailure(
-                "termination_not_scheduled",
-                f"Pod is running but auto-termination was NOT scheduled: {result.error}",
-                EXIT_GENERAL_ERROR,
+        try:
+            ui.load(
+                "Scheduling termination",
+                lambda: action.execute({
+                    "lium": lium,
+                    "pod": pod,
+                    "termination_time": termination_time
+                })
             )
+        except Exception:
+            ui.info(f"{pod_label} is running but auto-termination was NOT scheduled")
+            raise
 
     if jupyter:
         action = InstallJupyterAction()
-        result = ui.load(
-            "Installing Jupyter",
-            lambda: action.execute({
-                "lium": lium,
-                "pod": pod,
-                "ui": ui
-            })
-        )
+        try:
+            result = ui.load(
+                "Installing Jupyter",
+                lambda: action.execute({
+                    "lium": lium,
+                    "pod": pod,
+                    "ui": ui
+                })
+            )
+        except Exception:
+            ui.info(f"{pod_label} is running but Jupyter was NOT installed")
+            raise
 
         if not result.ok:
             ui.info(pod_label)

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -410,9 +410,6 @@ def up_command(
         })
     )
 
-    if not result.ok:
-        raise CliFailure("ssh_unavailable", result.error, EXIT_SSH_ERROR)
-
     ssh_cmd = result.data["ssh_cmd"]
     pod = result.data["pod"]
 

--- a/lium/cli/update/actions.py
+++ b/lium/cli/update/actions.py
@@ -14,31 +14,27 @@ class InstallJupyterAction:
         pod: PodInfo = ctx["pod"]
         port: int = ctx["port"]
 
-        try:
-            lium.install_jupyter(pod, jupyter_internal_port=port)
+        lium.install_jupyter(pod, jupyter_internal_port=port)
 
-            max_wait = 120
-            wait_interval = 3
-            elapsed = 0
+        max_wait = 120
+        wait_interval = 3
+        elapsed = 0
 
-            while elapsed < max_wait:
-                time.sleep(wait_interval)
-                elapsed += wait_interval
+        while elapsed < max_wait:
+            time.sleep(wait_interval)
+            elapsed += wait_interval
 
-                all_pods = lium.ps()
-                updated_pod = next((p for p in all_pods if p.id == pod.id), None)
+            all_pods = lium.ps()
+            updated_pod = next((p for p in all_pods if p.id == pod.id), None)
 
-                if updated_pod and hasattr(updated_pod, 'jupyter_installation_status'):
-                    if updated_pod.jupyter_installation_status == "SUCCESS":
-                        jupyter_url = getattr(updated_pod, 'jupyter_url', None)
-                        return ActionResult(
-                            ok=True,
-                            data={"jupyter_url": jupyter_url}
-                        )
-                    elif updated_pod.jupyter_installation_status == "FAILED":
-                        return ActionResult(ok=False, data={}, error="Jupyter installation failed")
+            if updated_pod and hasattr(updated_pod, 'jupyter_installation_status'):
+                if updated_pod.jupyter_installation_status == "SUCCESS":
+                    jupyter_url = getattr(updated_pod, 'jupyter_url', None)
+                    return ActionResult(
+                        ok=True,
+                        data={"jupyter_url": jupyter_url}
+                    )
+                elif updated_pod.jupyter_installation_status == "FAILED":
+                    return ActionResult(ok=False, data={}, error="Jupyter installation failed")
 
-            return ActionResult(ok=False, data={}, error="Jupyter installation timed out")
-
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        return ActionResult(ok=False, data={}, error="Jupyter installation timed out")

--- a/lium/cli/update/command.py
+++ b/lium/cli/update/command.py
@@ -6,7 +6,13 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_POD_NOT_FOUND,
+    handle_errors,
+)
 from . import validation, parsing
 from .actions import InstallJupyterAction
 
@@ -32,22 +38,19 @@ def update_command(target: str, jupyter: Optional[int]):
     # Validate
     valid, error = validation.validate(target, jupyter)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
     lium = Lium()
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:
-        ui.warning("No active pods")
-        return
+        raise CliFailure("pod_not_found", "No active pods", EXIT_POD_NOT_FOUND)
 
     # Parse
     parsed, error = parsing.parse(target, all_pods)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("pod_not_found", error, EXIT_POD_NOT_FOUND)
 
     pod = parsed.get("pod")
 
@@ -58,8 +61,11 @@ def update_command(target: str, jupyter: Optional[int]):
     result = ui.load("Installing Jupyter Notebook", lambda: action.execute(ctx))
 
     if not result.ok:
-        ui.error(result.error or "Failed to install Jupyter Notebook")
-        return
+        raise CliFailure(
+            "jupyter_install_failed",
+            result.error or "Failed to install Jupyter Notebook",
+            EXIT_GENERAL_ERROR,
+        )
 
     jupyter_url = result.data.get("jupyter_url")
     if jupyter_url:

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -260,15 +260,19 @@ def timed_step_status(step: int = 0, total_steps: int = 0, message: str = ""):
         raise
 
 
-# Exit codes published in docs/developers/cli/reference/index.md. Commands import
-# these rather than spelling the numbers, so the published table stays the one
-# source of truth.
-EXIT_GENERAL_ERROR = 1
-EXIT_CONFIGURATION_ERROR = 2
-EXIT_API_ERROR = 3
-EXIT_SSH_ERROR = 4
-EXIT_POD_NOT_FOUND = 5
-EXIT_PERMISSION_DENIED = 6
+# The exit-code taxonomy every command shares. Commands import these rather than
+# spelling the numbers, so this table is the one source of truth and
+# docs/developers/cli/reference/index.md mirrors it.
+#
+# ``lium provider …`` is the one exception: it keeps its own map in
+# lium/cli/provider/_render.py, where the same numbers carry different meanings
+# (2 auth, 3 portal, 5 ssh, 6 config missing, 7 token-cache contention).
+EXIT_GENERAL_ERROR = 1        # a failure with no better classification
+EXIT_CONFIGURATION_ERROR = 2  # bad arguments, missing or unreadable configuration
+EXIT_API_ERROR = 3            # the API refused or failed the call
+EXIT_SSH_ERROR = 4            # ssh could not connect, or no client is installed
+EXIT_POD_NOT_FOUND = 5        # the named pod does not exist
+EXIT_PERMISSION_DENIED = 6    # the account is not allowed to do this
 
 
 class CliFailure(Exception):

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -354,7 +354,7 @@ def handle_errors(func):
         except LiumPermissionError as e:
             if json_output:
                 _emit_json_error("permission_denied", str(e), EXIT_PERMISSION_DENIED)
-            console.error(f"Error: {e}")
+            console.error(f"Error: {escape(str(e))}")
             raise SystemExit(EXIT_PERMISSION_DENIED)
         except LiumError as e:
             if json_output:

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -152,16 +152,18 @@ class BackupParams:
 
 @contextmanager
 def loading_status(message: str, success_message: str = ""):
-    """Universal context manager to show loading status."""
+    """Universal context manager to show loading status.
+
+    A failure is not reported here. ``handle_errors`` is the one place that
+    renders an error, and a spinner that prints its own line first makes a
+    single failure read as two separate problems.
+    """
     status = Status(f"{console.get_styled(message + '...', 'info')}", console=console)
     status.start()
     try:
         yield
         if success_message:
             console.success(f"✓ {success_message}")
-    except Exception as e:
-        console.error(f"✗ Failed: {e}")
-        raise
     finally:
         status.stop()
 

--- a/lium/cli/utils.py
+++ b/lium/cli/utils.py
@@ -8,7 +8,7 @@ import click
 from lium.cli.settings import config
 from datetime import datetime
 from rich.status import Status
-from lium.sdk import LiumError, ExecutorInfo, PodInfo,Lium
+from lium.sdk import LiumError, LiumPermissionError, ExecutorInfo, PodInfo,Lium
 from .themed_console import ThemedConsole
 from dataclasses import dataclass
 from rich.markup import escape
@@ -345,11 +345,16 @@ def handle_errors(func):
             else:
                 console.error(f"Error: {escape(str(e))}")
             raise SystemExit(EXIT_CONFIGURATION_ERROR)
+        except LiumPermissionError as e:
+            if json_output:
+                _emit_json_error("permission_denied", str(e), EXIT_PERMISSION_DENIED)
+            console.error(f"Error: {e}")
+            raise SystemExit(EXIT_PERMISSION_DENIED)
         except LiumError as e:
             if json_output:
-                _emit_json_error("lium_error", str(e))
+                _emit_json_error("lium_error", str(e), EXIT_API_ERROR)
             console.error(f"Error: {escape(str(e))}")
-            raise SystemExit(EXIT_GENERAL_ERROR)
+            raise SystemExit(EXIT_API_ERROR)
         except Exception as e:
             if json_output:
                 _emit_json_error("unexpected_error", str(e))
@@ -786,12 +791,16 @@ def ensure_config():
     if not config.get('api.api_key'):
         # Setup API key
         action = SetupApiKeyAction()
-        action.execute({})
+        result = action.execute({})
+        if not result.ok:
+            raise CliFailure("api_key_setup_failed", result.error, EXIT_CONFIGURATION_ERROR)
 
     if not config.get('ssh.key_path'):
         # Setup SSH key
         action = SetupSshKeyAction()
-        action.execute({})
+        result = action.execute({})
+        if not result.ok:
+            raise CliFailure("ssh_key_setup_failed", result.error, EXIT_CONFIGURATION_ERROR)
 
 
 def ensure_backup_params(

--- a/lium/cli/volumes/list/actions.py
+++ b/lium/cli/volumes/list/actions.py
@@ -6,11 +6,8 @@ class GetVolumesAction:
     def execute(self, ctx: dict) -> ActionResult:
         lium = ctx["lium"]
 
-        try:
-            volumes = lium.volumes()
-            return ActionResult(
-                ok=True,
-                data={"volumes": volumes}
-            )
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        volumes = lium.volumes()
+        return ActionResult(
+            ok=True,
+            data={"volumes": volumes}
+        )

--- a/lium/cli/volumes/list/command.py
+++ b/lium/cli/volumes/list/command.py
@@ -21,10 +21,6 @@ def volumes_list_command():
     action = GetVolumesAction()
     result = ui.load("Loading volumes", lambda: action.execute(ctx))
 
-    if not result.ok:
-        ui.error(result.error)
-        return
-
     volumes = result.data["volumes"]
 
     if not volumes:

--- a/lium/cli/volumes/new/actions.py
+++ b/lium/cli/volumes/new/actions.py
@@ -8,11 +8,8 @@ class CreateVolumeAction:
         name = ctx["name"]
         description = ctx.get("description", "")
 
-        try:
-            new_volume = lium.volume_create(name=name, description=description)
-            return ActionResult(
-                ok=True,
-                data={"volume": new_volume}
-            )
-        except Exception as e:
-            return ActionResult(ok=False, data={}, error=str(e))
+        new_volume = lium.volume_create(name=name, description=description)
+        return ActionResult(
+            ok=True,
+            data={"volume": new_volume}
+        )

--- a/lium/cli/volumes/new/command.py
+++ b/lium/cli/volumes/new/command.py
@@ -21,7 +21,4 @@ def volumes_new_command(name: str, desc: Optional[str]):
     ctx = {"lium": lium, "name": name, "description": desc or ""}
 
     action = CreateVolumeAction()
-    result = ui.load(f"Creating volume '{name}'", lambda: action.execute(ctx))
-
-    if not result.ok:
-        ui.error(result.error)
+    ui.load(f"Creating volume '{name}'", lambda: action.execute(ctx))

--- a/lium/cli/volumes/rm/command.py
+++ b/lium/cli/volumes/rm/command.py
@@ -4,7 +4,14 @@ import click
 
 from lium.sdk import Lium
 from lium.cli import ui
-from lium.cli.utils import handle_errors, ensure_config, get_last_volume_selection
+from lium.cli.utils import (
+    CliFailure,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_GENERAL_ERROR,
+    handle_errors,
+    ensure_config,
+    get_last_volume_selection,
+)
 from . import validation, parsing
 from .actions import RemoveVolumesAction
 
@@ -20,22 +27,23 @@ def volumes_rm_command(indices: str, yes: bool):
     # Validate
     valid, error = validation.validate(indices)
     if not valid:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Get cached volumes
     last_selection = get_last_volume_selection()
     if not last_selection or not last_selection.get('volumes', []):
-        ui.error("No volumes cached. Run 'lium volumes' first.")
-        return
+        raise CliFailure(
+            "no_volumes_cached",
+            "No volumes cached. Run 'lium volumes' first.",
+            EXIT_GENERAL_ERROR,
+        )
 
     volumes_data = last_selection.get('volumes', [])
 
     # Parse
     parsed, error = parsing.parse(indices, volumes_data)
     if error:
-        ui.error(error)
-        return
+        raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     volumes_to_remove = parsed["volumes_to_remove"]
 
@@ -55,4 +63,8 @@ def volumes_rm_command(indices: str, yes: bool):
 
     if not result.ok:
         failed_huids = result.data.get("failed_huids", [])
-        ui.error(f"Failed to remove volumes: {', '.join(failed_huids)}")
+        raise CliFailure(
+            "volume_removal_failed",
+            f"Failed to remove volumes: {', '.join(failed_huids)}",
+            EXIT_GENERAL_ERROR,
+        )

--- a/lium/sdk/__init__.py
+++ b/lium/sdk/__init__.py
@@ -7,6 +7,7 @@ from .exceptions import (
     LiumAuthError,
     LiumError,
     LiumNotFoundError,
+    LiumPermissionError,
     LiumRateLimitError,
     LiumServerError,
 )
@@ -38,5 +39,6 @@ __all__ = [
     "LiumRateLimitError",
     "LiumServerError",
     "LiumNotFoundError",
+    "LiumPermissionError",
     "machine",
 ]

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -27,6 +27,7 @@ from .exceptions import (
     LiumAuthError,
     LiumError,
     LiumNotFoundError,
+    LiumPermissionError,
     LiumRateLimitError,
     LiumServerError,
 )
@@ -104,6 +105,8 @@ class Lium:
         # Map errors
         if resp.status_code == 401:
             raise LiumAuthError("Invalid API key")
+        if resp.status_code == 403:
+            raise LiumPermissionError(f"Permission denied: {resp.text}")
         if resp.status_code == 404:
             raise LiumNotFoundError(f"Resource not found: {resp.text}")
         if resp.status_code == 429:
@@ -435,6 +438,8 @@ class Lium:
             if not response.ok:
                 if response.status_code == 401:
                     raise LiumAuthError("Invalid API key")
+                if response.status_code == 403:
+                    raise LiumPermissionError(f"Permission denied: {response.text}")
                 if response.status_code == 404:
                     raise LiumNotFoundError(f"Pod not found: {pod_id}")
                 if response.status_code == 429:

--- a/lium/sdk/exceptions.py
+++ b/lium/sdk/exceptions.py
@@ -20,10 +20,15 @@ class LiumNotFoundError(LiumError):
     """Resource not found (404)."""
 
 
+class LiumPermissionError(LiumError):
+    """The account is not allowed to do this (403)."""
+
+
 __all__ = [
     "LiumError",
     "LiumAuthError",
     "LiumRateLimitError",
     "LiumServerError",
     "LiumNotFoundError",
+    "LiumPermissionError",
 ]

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -14,12 +14,23 @@ from types import SimpleNamespace
 import pytest
 from click.testing import CliRunner
 
+from lium.cli.actions import ActionResult
 from lium.cli.cli import cli
 from lium.cli.commands import exec as exec_module
 from lium.cli.ls import command as ls_command_module
 from lium.cli.ls import display as ls_display
+from lium.cli.ps import command as ps_module
+from lium.cli.reboot import command as reboot_module
+from lium.cli.rsync import command as rsync_module
 from lium.cli.rm import command as rm_module
-from lium.cli.utils import EXIT_CONFIGURATION_ERROR, EXIT_POD_NOT_FOUND
+from lium.cli.utils import (
+    EXIT_API_ERROR,
+    EXIT_GENERAL_ERROR,
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_PERMISSION_DENIED,
+    EXIT_POD_NOT_FOUND,
+)
+from lium.sdk import LiumPermissionError, LiumServerError
 
 
 def _pod(huid: str = "eager-wolf-aa", name: str = "my-pod") -> SimpleNamespace:
@@ -330,10 +341,11 @@ def test_up_fails_when_ssh_is_unavailable(monkeypatch):
 
     monkeypatch.setattr("lium.cli.ssh.command.get_ssh_method_and_pod", _no_ssh)
 
-    result = up_actions.PrepareSSHAction().execute({"pod_name": "brave-orbit-b9"})
+    with pytest.raises(CliFailure) as raised:
+        up_actions.PrepareSSHAction().execute({"pod_name": "brave-orbit-b9"})
 
-    assert result.ok is False
-    assert "brave-orbit-b9" in result.error
+    assert raised.value.exit_code == EXIT_SSH_ERROR
+    assert "brave-orbit-b9" in raised.value.message
 
 
 @pytest.mark.parametrize(
@@ -356,3 +368,222 @@ def test_rm_all_treats_a_lost_terminal_as_no(monkeypatch):
     monkeypatch.setattr(rm_module.ui, "confirm", lambda message: (_ for _ in ()).throw(EOFError()))
 
     assert rm_module.human_approved_removing_every_pod([_pod()]) is False
+
+
+def _run_ps_raising(monkeypatch, error: Exception):
+    class _RaisingLium:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ps(self):
+            raise error
+
+    monkeypatch.setattr(ps_module, "Lium", _RaisingLium)
+    return CliRunner().invoke(cli, ["ps"])
+
+
+def test_permission_denied_exits_with_its_own_code(monkeypatch):
+    """An unverified account is a fixable state, not a generic failure."""
+    result = _run_ps_raising(monkeypatch, LiumPermissionError("User is not verified"))
+
+    assert result.exit_code == EXIT_PERMISSION_DENIED
+
+
+def test_other_api_failures_exit_with_the_api_code(monkeypatch):
+    """Everything the API rejects for another reason is an API error, not code 1."""
+    result = _run_ps_raising(monkeypatch, LiumServerError("Server error: 502"))
+
+    assert result.exit_code == EXIT_API_ERROR
+
+
+@pytest.mark.parametrize("extra_args", [[], ["--format", "json"]])
+def test_ps_named_target_that_matches_nothing_fails(monkeypatch, extra_args):
+    """Asking for one pod by name and getting none is a miss in every format."""
+    monkeypatch.setattr(ps_module, "Lium", _FakeLium)
+
+    result = CliRunner().invoke(cli, ["ps", "no-such-pod-zz", *extra_args])
+
+    assert result.exit_code == EXIT_POD_NOT_FOUND
+
+
+def test_port_forward_to_a_missing_pod_fails(monkeypatch):
+    """A tunnel that was never opened must not report success to its caller."""
+    from lium.cli.port_forward import command as port_forward_module
+
+    monkeypatch.setattr(port_forward_module, "Lium", _FakeLium)
+
+    result = CliRunner().invoke(cli, ["port-forward", "no-such-pod-zz", "8000"])
+
+    assert result.exit_code == EXIT_POD_NOT_FOUND
+
+
+def test_legacy_fund_reports_a_wallet_it_could_not_load(monkeypatch):
+    """`lium fund` without --alpha is the default path, not dead code."""
+    from lium.cli.fund import command as fund_module
+
+    class _FailingLoadWallet:
+        def execute(self, ctx):
+            return ActionResult(ok=False, data={}, error="Keyfile not found")
+
+    monkeypatch.setattr(fund_module, "LoadWalletAction", _FailingLoadWallet)
+
+    result = CliRunner().invoke(cli, ["fund", "-w", "default", "-a", "1.5", "-y"])
+
+    assert result.exit_code == EXIT_API_ERROR
+
+
+def test_up_reports_an_api_failure_while_resolving_a_node(monkeypatch):
+    """`up` used to flatten every SDK error into a generic exit 1."""
+    from lium.cli.up import command as up_module
+
+    class _BrokenUpLium:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_executor(self, executor_id):
+            raise LiumServerError("Server error: 502")
+
+    monkeypatch.setattr(up_module, "Lium", _BrokenUpLium)
+    monkeypatch.setattr(up_module, "ensure_config", lambda: None)
+
+    result = CliRunner().invoke(cli, ["up", "some-node-id", "-y"])
+
+    assert result.exit_code == EXIT_API_ERROR
+
+
+def test_ls_reports_a_failed_market_listing(monkeypatch):
+    """"No nodes" and "the market is unreachable" must not look identical."""
+    class _BrokenLsLium:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ls(self, **kwargs):
+            raise LiumServerError("Server error: 502")
+
+    monkeypatch.setattr(ls_command_module, "Lium", _BrokenLsLium)
+
+    result = CliRunner().invoke(cli, ["ls"])
+
+    assert result.exit_code == EXIT_API_ERROR
+
+
+def test_ssh_to_a_missing_pod_fails(monkeypatch):
+    """The ticket's own example: `lium ssh <typo>` printed a warning and exited 0."""
+    from lium.cli.ssh import command as ssh_module
+
+    monkeypatch.setattr(ssh_module, "Lium", _FakeLium)
+
+    result = CliRunner().invoke(cli, ["ssh", "no-such-pod-zz"])
+
+    assert result.exit_code == EXIT_POD_NOT_FOUND
+
+
+def test_rsync_reports_a_pod_it_could_not_reach(tmp_path, monkeypatch):
+    """A batch copy that skipped a pod must not read as "everything is in place"."""
+    class _RsyncLium:
+        def __init__(self, *a, **kw):
+            pass
+
+        def ps(self):
+            return [_pod()]
+
+        def rsync(self, *a, **kw):
+            raise LiumServerError("Server error: 502")
+
+    monkeypatch.setattr(rsync_module, "Lium", _RsyncLium)
+    local = tmp_path / "payload"
+    local.mkdir()
+
+    result = CliRunner().invoke(cli, ["rsync", "all", str(local)])
+
+    assert result.exit_code == EXIT_GENERAL_ERROR
+
+
+def _run_reboot(monkeypatch, args, pods):
+    class _RebootLium:
+        def __init__(self, *a, **kw):
+            pass
+
+        def ps(self):
+            return pods
+
+        def reboot(self, pod, volume_id=None):
+            raise LiumServerError("Server error: 502")
+
+    monkeypatch.setattr(reboot_module, "Lium", _RebootLium)
+    return CliRunner().invoke(cli, ["reboot", *args])
+
+
+def test_reboot_of_a_missing_pod_fails(monkeypatch):
+    """A named target that matches nothing is the `rm` asymmetry's failing half."""
+    result = _run_reboot(monkeypatch, ["no-such-pod-zz"], [])
+
+    assert result.exit_code == EXIT_POD_NOT_FOUND
+
+
+def test_reboot_all_on_an_empty_account_is_a_no_op(monkeypatch):
+    """`--all` says "whatever is there" — nothing there is the requested state."""
+    result = _run_reboot(monkeypatch, ["--all"], [])
+
+    assert result.exit_code == 0
+
+
+def test_reboot_reports_a_failed_item_after_finishing_the_batch(monkeypatch):
+    """Batch commands run to the end, then fail once — silence would hide it."""
+    result = _run_reboot(monkeypatch, ["--all"], [_pod()])
+
+    assert result.exit_code == EXIT_GENERAL_ERROR
+
+
+def test_bk_show_of_a_missing_pod_fails(monkeypatch):
+    """The whole bk family names one pod — a miss is a miss, not a silent skip."""
+    from lium.cli.bk.show import command as bk_show_module
+
+    monkeypatch.setattr(bk_show_module, "Lium", _FakeLium)
+    monkeypatch.setattr(bk_show_module, "ensure_config", lambda: None)
+
+    result = CliRunner().invoke(cli, ["bk", "show", "no-such-pod-zz"])
+
+    assert result.exit_code == EXIT_POD_NOT_FOUND
+
+
+def test_config_get_of_a_missing_key_fails(monkeypatch):
+    """`config get` is how a script reads state — a miss must not look like a hit."""
+    from lium.cli.config.get import actions as config_get_actions
+
+    monkeypatch.setattr(config_get_actions.config, "get", lambda key, default=None: None)
+
+    result = CliRunner().invoke(cli, ["config", "get", "api.api_key"])
+
+    assert result.exit_code == EXIT_GENERAL_ERROR
+
+
+def test_config_setup_failure_stops_the_command(monkeypatch):
+    """ensure_config() gates ~15 commands — a failed setup must not read as ready."""
+    from lium.cli import settings
+    from lium.cli.init import actions as init_actions
+
+    monkeypatch.setattr(settings.config, "get", lambda key, default=None: None)
+
+    class _FailingSetup:
+        def execute(self, ctx):
+            return ActionResult(ok=False, data={}, error="Invalid API key")
+
+    monkeypatch.setattr(init_actions, "SetupApiKeyAction", _FailingSetup)
+
+    result = CliRunner().invoke(cli, ["ps"])
+
+    assert result.exit_code == EXIT_CONFIGURATION_ERROR
+
+
+def test_ps_empty_account_is_not_a_failure(monkeypatch):
+    """Nothing rented is a legitimate state, not an error."""
+    class _EmptyLium(_FakeLium):
+        def ps(self):
+            return []
+
+    monkeypatch.setattr(ps_module, "Lium", _EmptyLium)
+
+    result = CliRunner().invoke(cli, ["ps"])
+
+    assert result.exit_code == 0

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -430,7 +430,8 @@ def test_legacy_fund_reports_a_wallet_it_could_not_load(monkeypatch):
 
     result = CliRunner().invoke(cli, ["fund", "-w", "default", "-a", "1.5", "-y"])
 
-    assert result.exit_code == EXIT_API_ERROR
+    # An unreadable keyfile is a local setup problem, not the API refusing.
+    assert result.exit_code == EXIT_CONFIGURATION_ERROR
 
 
 def _run_up_past_the_rent(monkeypatch, extra_args, break_on):

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -28,6 +28,7 @@ from lium.cli.utils import (
     EXIT_GENERAL_ERROR,
     EXIT_CONFIGURATION_ERROR,
     EXIT_PERMISSION_DENIED,
+    EXIT_SSH_ERROR,
     EXIT_POD_NOT_FOUND,
 )
 from lium.sdk import LiumPermissionError, LiumServerError
@@ -432,6 +433,61 @@ def test_legacy_fund_reports_a_wallet_it_could_not_load(monkeypatch):
     assert result.exit_code == EXIT_API_ERROR
 
 
+def _run_up_past_the_rent(monkeypatch, extra_args, break_on):
+    """Rent succeeds, then the named SDK call fails — the pod is already billing."""
+    from lium.cli.up import command as up_module
+
+    class _RentingLium:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_executor(self, executor_id):
+            return _executor("brave-orbit-b9", price_per_hour=1.0, download=100)
+
+        def default_docker_template(self, executor_id):
+            return SimpleNamespace(id="tpl-1", name="pytorch")
+
+        def get_deployment_estimate(self, executor_id, template_id):
+            return {}
+
+        def up(self, **kwargs):
+            return {"id": "pod-uuid-1234", "name": "brave-orbit-b9"}
+
+        def ps(self):
+            if break_on == "ps":
+                raise LiumServerError("Server error: 502")
+            return [SimpleNamespace(
+                id="pod-uuid-1234", huid="brave-orbit-b9", name="brave-orbit-b9",
+                status="RUNNING", ssh_cmd="ssh root@1.2.3.4",
+                # a second port, or InstallJupyterAction fails before it reaches the SDK
+                ports={"22": 10022, "8888": 18888},
+            )]
+
+        def schedule_termination(self, pod, termination_time=None):
+            raise LiumServerError("Server error: 502")
+
+        def install_jupyter(self, pod, jupyter_internal_port=None):
+            raise LiumServerError("Server error: 502")
+
+    monkeypatch.setattr(up_module, "Lium", _RentingLium)
+    monkeypatch.setattr(up_module, "ensure_config", lambda: None)
+    return CliRunner().invoke(cli, ["up", "some-node-id", "-y", "--no-ssh", *extra_args])
+
+
+@pytest.mark.parametrize(
+    "extra_args, break_on",
+    [([], "ps"), (["--ttl", "1h"], "schedule"), (["--jupyter"], "jupyter")],
+)
+def test_up_names_the_pod_it_already_rented_when_a_later_step_fails(
+    monkeypatch, extra_args, break_on
+):
+    """Past the rent the pod is billing: a failure that hides its id is unusable."""
+    result = _run_up_past_the_rent(monkeypatch, extra_args, break_on)
+
+    assert result.exit_code != 0
+    assert "pod-uuid-1234" in result.output or "brave-orbit-b9" in result.output
+
+
 def test_up_reports_an_api_failure_while_resolving_a_node(monkeypatch):
     """`up` used to flatten every SDK error into a generic exit 1."""
     from lium.cli.up import command as up_module
@@ -476,6 +532,48 @@ def test_ssh_to_a_missing_pod_fails(monkeypatch):
     result = CliRunner().invoke(cli, ["ssh", "no-such-pod-zz"])
 
     assert result.exit_code == EXIT_POD_NOT_FOUND
+
+
+def test_ssh_separates_its_own_failure_from_the_remote_shell(monkeypatch):
+    """255 is ssh failing to connect; anything else is the remote's own status."""
+    from lium.cli.ssh import actions as ssh_actions
+    from lium.cli.ssh import command as ssh_module
+
+    class _SshLium:
+        def __init__(self, *a, **kw):
+            pass
+
+        def ps(self):
+            return [SimpleNamespace(
+                id="pod-uuid-1", huid="eager-wolf-aa", name="my-pod",
+                status="RUNNING", ssh_cmd="ssh root@1.2.3.4",
+            )]
+
+        def ssh(self, pod):
+            return "ssh root@1.2.3.4"
+
+    monkeypatch.setattr(ssh_module, "Lium", _SshLium)
+
+    def _returncode(code):
+        monkeypatch.setattr(
+            ssh_actions.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=code)
+        )
+        return CliRunner().invoke(cli, ["ssh", "my-pod"])
+
+    assert _returncode(255).exit_code == EXIT_SSH_ERROR
+    assert _returncode(3).exit_code == 0
+
+
+def test_volumes_rm_without_a_cached_listing_fails(monkeypatch):
+    """"Run `lium volumes` first" is an instruction, not a completed removal."""
+    from lium.cli.volumes.rm import command as volumes_rm_module
+
+    monkeypatch.setattr(volumes_rm_module, "ensure_config", lambda: None)
+    monkeypatch.setattr(volumes_rm_module, "get_last_volume_selection", lambda: None)
+
+    result = CliRunner().invoke(cli, ["volumes", "rm", "1", "-y"])
+
+    assert result.exit_code == EXIT_GENERAL_ERROR
 
 
 def test_rsync_reports_a_pod_it_could_not_reach(tmp_path, monkeypatch):

--- a/test/test_agent_cli_contract.py
+++ b/test/test_agent_cli_contract.py
@@ -685,3 +685,40 @@ def test_ps_empty_account_is_not_a_failure(monkeypatch):
     result = CliRunner().invoke(cli, ["ps"])
 
     assert result.exit_code == 0
+
+
+def test_a_failure_under_the_spinner_is_reported_once(monkeypatch):
+    """The spinner printed its own line, so one failure read as two problems."""
+    class _BrokenLsLium:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ls(self, **kwargs):
+            raise LiumServerError("Server error: 502")
+
+    monkeypatch.setattr(ls_command_module, "Lium", _BrokenLsLium)
+
+    result = CliRunner().invoke(cli, ["ls"])
+
+    assert result.exit_code == EXIT_API_ERROR
+    assert result.output.count("502") == 1
+
+
+def test_port_forward_lists_the_ports_it_has_below_the_error(monkeypatch):
+    """The hint explains the error, so it must not be printed above it."""
+    from lium.cli.port_forward import command as port_forward_module
+
+    class _PodWithPorts(_FakeLium):
+        def ps(self):
+            pod = _pod()
+            pod.status = "running"
+            pod.ports = {"22": 30022}
+            pod.executor = SimpleNamespace(ip="1.2.3.4")
+            return [pod]
+
+    monkeypatch.setattr(port_forward_module, "Lium", _PodWithPorts)
+
+    result = CliRunner().invoke(cli, ["port-forward", "my-pod", "8000"])
+
+    assert result.exit_code == EXIT_GENERAL_ERROR
+    assert result.output.index("not exposed") < result.output.index("Available internal ports")

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -1,4 +1,20 @@
-from lium.sdk import Config, Lium
+import pytest
+
+from lium.sdk import Config, Lium, LiumPermissionError
+
+
+class _Forbidden:
+    """A 403 response, usable both directly and as a streaming context manager."""
+
+    ok = False
+    status_code = 403
+    text = "User is not verified"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
 
 
 def test_client_sets_version_header(monkeypatch):
@@ -9,3 +25,19 @@ def test_client_sets_version_header(monkeypatch):
     assert client.headers["X-API-KEY"] == "test"
     assert client.headers["X-Source"] == "cli"
     assert client.headers["X-Lium-Client-Version"] == "1.2.3"
+
+
+def test_request_403_raises_permission_error(monkeypatch):
+    monkeypatch.setattr("lium.sdk.client.requests.request", lambda *a, **kw: _Forbidden())
+    client = Lium(Config(api_key="test"))
+
+    with pytest.raises(LiumPermissionError):
+        client._request("GET", "/pods")
+
+
+def test_logs_403_raises_permission_error(monkeypatch):
+    monkeypatch.setattr("lium.sdk.client.requests.get", lambda *a, **kw: _Forbidden())
+    client = Lium(Config(api_key="test"))
+
+    with pytest.raises(LiumPermissionError):
+        list(client.logs("pod-1"))


### PR DESCRIPTION
Continuation of DAH-2556. Every `Action.execute()` wrapped its work in a blanket
`except Exception` and returned `ActionResult(ok=False, error=str(e))`; the
command then did `if not result.ok: ui.error(result.error); return`, and a bare
`return` from a Click callback exits **0**. `handle_errors` — the one place that
maps a failure to an exit code — never ran, because nothing was ever raised.

## What changed

**Actions stop swallowing.** The exception reaches `handle_errors`, which
already renders it once and maps it to a code. Commands raise `CliFailure` only
for decisions they make themselves — the `rm/command.py:30-65` pattern.

Three classes of `except` block are treated differently:

- **removed** — a blanket `except Exception` around an SDK call with no decision
  inside it.
- **kept, per-item** — the seven batch Actions that aggregate `failed_huids`
  (`rm` ×2, `reboot`, `rsync`, `scp`, `volumes rm`, `schedules rm`). Removing
  their `except` would stop the loop at the first bad item. Their command raises
  once at the end, mirroring `rm/command.py:122-134`.
- **kept, narrow** — targeted catches that are not the anti-pattern:
  `EditConfigAction`'s `CalledProcessError`, `SetupSshKeyAction`'s local
  ssh-keygen, `fund`'s bittensor/subtensor wrappers, a best-effort
  `except OSError: pass` around the ssh-key cache write.

**Exit codes 3 and 6 became reachable.** `lium/sdk` grows a typed
`LiumPermissionError` raised on 403 at both `client.py` status sites (`_request`
and the streaming/logs path). `handle_errors` gains an `except
LiumPermissionError` clause **before** the general `except LiumError` — order
matters, or the general clause absorbs it — mapping 403 to
`EXIT_PERMISSION_DENIED` (6). The general `LiumError` branch moves from
`EXIT_GENERAL_ERROR` (1) to `EXIT_API_ERROR` (3), so `LiumAuthError`,
`LiumNotFoundError`, `LiumRateLimitError` and `LiumServerError` stop collapsing
to exit 1. The JSON envelope's code token stays `"lium_error"` — that token is a
separate contract from the exit number and `test/test_topup_cli.py:96` pins it.

**The `rm` asymmetry is preserved where it applies.** `--all` against an empty
account stays an idempotent no-op (exit 0); a named target that matches nothing
is a failure (exit 5). `reboot` gains that asymmetry; `rm` already had it.

## Sites the ticket did not name

- **`ls` was never fixed by DAH-2556.** `ls/command.py:100-102` still swallowed,
  so an API error while listing the market exited 0. DAH-2556 only fixed ls's
  `--sort`/Pareto-star bug.
- **`ensure_config()`** (`lium/cli/utils.py:783`) discarded both Action results
  without even checking `.ok`, and gates ~15 commands.
- **`fund` without `--alpha` is the default path**, not dead code despite the
  `_legacy_tao_fund` name. It held five silent exit-0 sites.
- **Nine commands no plan enumerated**: `update`, `theme`, `templates`,
  `ssh-keys list`, `ssh-keys sync`, `volumes new`, `volumes list`, `ps`, `logs`.
  `ps` is the command an agent reaches for right after `ls`.
- **`port-forward`**, found by the closing grep sweep: four named-target misses
  that printed an error and exited 0.

## Behaviour changes worth reviewing

- `lium ps <named-target>` that matches nothing now exits 5 in **both** output
  formats. `--format json` used to print `[]` and exit 0 even when the caller
  named one specific pod — the `rm` asymmetry read backwards. An unfiltered
  empty list still exits 0.
- `lium ssh` on a dropped connection (ssh's own 255) now exits 4, matching what
  `up`'s SSH path already did. A non-zero **remote shell** exit code still exits
  0 — that is the remote's business.
- `rsync`, `scp`, `volumes rm` and `schedules rm` lose the ability to no-op
  against an empty account: they have no boolean `--all` to key the asymmetry
  off, only a `targets` string that may literally read `"all"`. Only `rm` and
  `reboot` keep the no-op.
- Every existing `raise LiumError(...)` site (`_alpha_fund`, `topup`) moves from
  exit 1 to exit 3. No test outside the out-of-scope trees asserted the old
  number.
- `lium config reset` on an already-empty config stays a warning at exit 0 — the
  requested end state is already true, same reasoning as `rm --all`.

## Known limits, deliberately not fixed here

- `lium ls --format json` still renders failures as Rich text on stderr rather
  than the JSON error envelope: `handle_errors` keys the envelope off a kwarg
  named `json_output`, and `ls` names its flag `output_format`. The **exit
  code** — the thing an agent acts on — is fixed either way.
- Three SDK spots (`get_template`, the GPU-shortname resolver, `exec_all`'s
  per-pod wrapper) still turn any exception into `None`/an untyped dict, and
  `_ensure_ssh_keys_registered` still downgrades `LiumError` to a warning by
  design (ssh-key registration must not block a rental). A 403 arriving through
  those paths will not become exit 6.
- **`lium provider …` has its own exit-code taxonomy that collides with the main
  table.** `ProviderError` + `_EXIT_CODES` in `provider/_render.py:59-84` uses
  **6 = config missing**, 2 = auth, 5 = ssh, 7 = token-cache contention, while
  the main table reads 2 = configuration, 5 = pod-not-found, 6 =
  permission-denied. The two agree only on 3. Nothing in that tree swallows
  errors, so it needed no fix here — but the collision is real and worth its own
  ticket.

## Tests

19 new behavioural tests, one per command family, in
`test/test_agent_cli_contract.py` plus two SDK-level 403 tests in
`test/test_sdk_client.py`. Each was verified RED against the unfixed code and
GREEN after.

`test_up_fails_when_ssh_is_unavailable` was rewritten: it asserted
`result.ok is False` from `PrepareSSHAction`, i.e. it encoded the very swallow
this PR removes. It now asserts `pytest.raises(CliFailure)` with
`exit_code == EXIT_SSH_ERROR`.

Full suite: **388 passed, 11 failed** — the same 11 pre-existing failures as on
`main` (`test/provider/` ×5, `test_gpu_splitting_cli.py` ×3,
`test_release_binary_targets.py` ×3), zero new. Note that no CI workflow runs
the general suite: `ci.yml` and `release.yml` only run
`test/test_release_binary_targets.py`.
