### PR TITLE
Release 0.0.30

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.29"
+__version__ = "0.0.30"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.29"
+version = "0.0.30"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.29"
+version = "0.0.30"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump only: `pyproject.toml`, `lium/__about__.py` and the lockfile. The release workflow refuses to run unless all three already carry the requested version.

Ships DAH-2553 (#103): `pip install lium.io` now works on Python 3.13 and 3.14, and a renter install is 43 packages and 54 MB instead of 84 and 161. The chain stack moved to a `provider` extra; existing installs keep it, since pip does not prune dependencies that stopped being required.

Also drops the bare single-file release asset, which had zero downloads across 0.0.26, 0.0.27 and 0.0.28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)