### PR TITLE
Release 0.0.31

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.30"
+__version__ = "0.0.31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.30"
+version = "0.0.31"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.30"
+version = "0.0.31"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump 0.0.30 → 0.0.31 in `pyproject.toml`, `lium/__about__.py` and `uv.lock`.

Ships:
- #104 — DAH-2593: the CLI Action layer stops swallowing errors (exit codes 3 and 6 become reachable)
- #101 — DAH-2589: `lium describe` (built into the 0.0.30 binaries but never published to PyPI)