### PR TITLE
DAH-2585: fail lium fund non-zero when the coldkey will not unlock

### DIFF
--- a/lium/cli/fund/command.py
+++ b/lium/cli/fund/command.py
@@ -71,30 +71,6 @@ def _legacy_tao_fund(wallet: Optional[str], amount: Optional[str], yes: bool) ->
     wallet_address = result.data["address"]
     lium = Lium()
 
-    ctx = {
-        "lium": lium,
-        "wallet_address": wallet_address,
-        "bt_wallet": bt_wallet,
-    }
-
-    # Ask for the coldkey password here, outside every spinner — registration and the
-    # transfer both sign with it, and a prompt raised under ui.load lands glued to a
-    # frozen spinner line, which reads as a hung command.
-    result = UnlockColdkeyAction().execute({"bt_wallet": bt_wallet})
-    if not result.ok:
-        ui.error(f"Failed to unlock coldkey for wallet '{wallet_name}': {result.error}")
-        return
-
-    action = CheckWalletRegistrationAction()
-    result = ui.load("Checking wallet registration", lambda: action.execute(ctx))
-
-    if not result.ok:
-        raise CliFailure(
-            "wallet_registration_failed",
-            f"Failed to register wallet: {result.error}",
-            EXIT_GENERAL_ERROR,
-        )
-
     if not amount:
         amount_str = Prompt.ask("Enter TAO amount to fund").strip()
     else:
@@ -111,6 +87,35 @@ def _legacy_tao_fund(wallet: Optional[str], amount: Optional[str], yes: bool) ->
         f"Fund account with {tao_amount} TAO?", default=False
     ):
         return
+
+    # Ask for the coldkey password here, outside every spinner — registration and the
+    # transfer both sign with it, and a prompt raised under ui.load lands glued to a
+    # frozen spinner line, which reads as a hung command. It comes after the confirm so
+    # a user who backs out never has to type it; nothing before this point reads the
+    # coldkey.
+    result = UnlockColdkeyAction().execute({"bt_wallet": bt_wallet})
+    if not result.ok:
+        raise CliFailure(
+            "coldkey_unlock_failed",
+            f"Failed to unlock coldkey for wallet '{wallet_name}': {result.error}",
+            EXIT_CONFIGURATION_ERROR,
+        )
+
+    ctx = {
+        "lium": lium,
+        "wallet_address": wallet_address,
+        "bt_wallet": bt_wallet,
+    }
+
+    action = CheckWalletRegistrationAction()
+    result = ui.load("Checking wallet registration", lambda: action.execute(ctx))
+
+    if not result.ok:
+        raise CliFailure(
+            "wallet_registration_failed",
+            f"Failed to register wallet: {result.error}",
+            EXIT_GENERAL_ERROR,
+        )
 
     ui.info("Waiting for bittensor...")
     ctx = {

--- a/test/test_fund_cli.py
+++ b/test/test_fund_cli.py
@@ -38,14 +38,25 @@ def _fake_bt_wallet(events=None, unlock_error=None):
 
 
 def _spy_ui_load(monkeypatch, events):
-    """Record every spinner `ui.load` opens in ``events``, keeping the real behaviour."""
+    """Record where every spinner `ui.load` opens and closes, keeping the real behaviour."""
     real_load = fund_module.ui.load
 
     def spy(message, fn):
         events.append(f"ui.load:{message}")
-        return real_load(message, fn)
+        try:
+            return real_load(message, fn)
+        finally:
+            events.append(f"ui.load-end:{message}")
 
     monkeypatch.setattr(fund_module.ui, "load", spy)
+
+
+def _open_spinners_at(events, event):
+    # how many spinners were still running when `event` was recorded
+    prefix = events[: events.index(event)]
+    opened = sum(1 for name in prefix if name.startswith("ui.load:"))
+    closed = sum(1 for name in prefix if name.startswith("ui.load-end:"))
+    return opened - closed
 
 
 def test_fund_help_documents_tao_flow():
@@ -133,6 +144,9 @@ def test_fund_tao_unlocks_coldkey_before_the_signing_spinner(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert events.count("unlock_coldkey") == 1
+    # No spinner may be running while the password prompt is up — wrapping the unlock in
+    # a spinner of its own is the regression this pins, not just its position in the run.
+    assert _open_spinners_at(events, "unlock_coldkey") == 0
     # Pin the spinner the unlock has to come before, so de-spinnering the registration
     # step can't leave this test vacuously green.
     assert "ui.load:Checking wallet registration" in events

--- a/test/test_fund_cli.py
+++ b/test/test_fund_cli.py
@@ -18,6 +18,7 @@ from lium.cli.actions import ActionResult
 from lium.cli import balance as balance_module
 from lium.cli.cli import cli
 from lium.cli.fund import command as fund_module
+from lium.cli.utils import EXIT_CONFIGURATION_ERROR
 from lium.sdk import AlphaQuote, Config, Lium
 from lium.sdk.exceptions import LiumNotFoundError, LiumServerError
 
@@ -93,10 +94,11 @@ def test_fund_tao_dispatch_runs(monkeypatch):
     assert "Done." in result.output
 
 
-def test_fund_tao_unlocks_coldkey_before_any_spinner(monkeypatch):
+def test_fund_tao_unlocks_coldkey_before_the_signing_spinner(monkeypatch):
     # DAH-2585: bittensor prints "Enter your password:" straight to the terminal, and its
     # reader holds the GIL — so under ui.load the prompt lands glued to a frozen spinner
-    # line and `lium fund` reads as hung. The unlock must precede every ui.load spinner.
+    # line and `lium fund` reads as hung. The unlock must precede the registration
+    # spinner, which is the first step that signs with the coldkey.
     events = []
     monkeypatch.setitem(sys.modules, "bittensor", types.SimpleNamespace())
     bt_wallet = _fake_bt_wallet(events)
@@ -130,11 +132,13 @@ def test_fund_tao_unlocks_coldkey_before_any_spinner(monkeypatch):
     result = CliRunner().invoke(cli, ["fund", "-w", "default", "-a", "1.5", "-y"])
 
     assert result.exit_code == 0, result.output
-    assert events[0] == "unlock_coldkey"
     assert events.count("unlock_coldkey") == 1
     # Pin the spinner the unlock has to come before, so de-spinnering the registration
     # step can't leave this test vacuously green.
     assert "ui.load:Checking wallet registration" in events
+    assert events.index("unlock_coldkey") < events.index(
+        "ui.load:Checking wallet registration"
+    )
 
 
 def test_fund_tao_unlock_failure_aborts(monkeypatch):
@@ -162,7 +166,9 @@ def test_fund_tao_unlock_failure_aborts(monkeypatch):
             calls.append("transfer")
             return ActionResult(ok=True, data={})
 
-    monkeypatch.setattr(fund_module, "Lium", lambda: types.SimpleNamespace())
+    monkeypatch.setattr(
+        fund_module, "Lium", lambda: types.SimpleNamespace(balance=lambda: 10.0)
+    )
     monkeypatch.setattr(fund_module, "LoadWalletAction", FakeLoadWalletAction)
     monkeypatch.setattr(
         fund_module, "CheckWalletRegistrationAction", FakeCheckWalletRegistrationAction
@@ -171,9 +177,51 @@ def test_fund_tao_unlock_failure_aborts(monkeypatch):
 
     result = CliRunner().invoke(cli, ["fund", "-w", "default", "-a", "1.5", "-y"])
 
+    # A wrong password must exit non-zero: a caller chaining `lium fund && ...` can
+    # only see the failure through the exit code.
+    assert result.exit_code == EXIT_CONFIGURATION_ERROR, result.output
     assert "Failed to unlock coldkey for wallet 'default'" in result.output
     assert "Wrong password for decryption" in result.output
     assert calls == []
+
+
+def test_fund_tao_declined_confirm_never_asks_for_the_password(monkeypatch):
+    # The coldkey password is the most expensive thing we can ask for, so a user who
+    # backs out at the confirm must not have typed it.
+    monkeypatch.setitem(sys.modules, "bittensor", types.SimpleNamespace())
+    events = []
+    bt_wallet = _fake_bt_wallet(events)
+
+    class FakeLoadWalletAction:
+        def execute(self, ctx):
+            return ActionResult(
+                ok=True, data={"wallet": bt_wallet, "address": "coldkey"}
+            )
+
+    class FakeCheckWalletRegistrationAction:
+        def execute(self, ctx):
+            events.append("register")
+            return ActionResult(ok=True, data={"registered": True})
+
+    class FakeExecuteTransferAction:
+        def execute(self, ctx):
+            events.append("transfer")
+            return ActionResult(ok=True, data={})
+
+    monkeypatch.setattr(
+        fund_module, "Lium", lambda: types.SimpleNamespace(balance=lambda: 10.0)
+    )
+    monkeypatch.setattr(fund_module, "LoadWalletAction", FakeLoadWalletAction)
+    monkeypatch.setattr(
+        fund_module, "CheckWalletRegistrationAction", FakeCheckWalletRegistrationAction
+    )
+    monkeypatch.setattr(fund_module, "ExecuteTransferAction", FakeExecuteTransferAction)
+    monkeypatch.setattr(fund_module.ui, "confirm", lambda message, default=False: False)
+
+    result = CliRunner().invoke(cli, ["fund", "-w", "default", "-a", "1.5"])
+
+    assert result.exit_code == 0, result.output
+    assert events == []
 
 
 def test_fund_crypto_subcommand_is_retired():


### PR DESCRIPTION
Follow-up to #99, which was merged before the second review pass landed. Two review comments, both on the TAO path of `lium fund`.

- **A wrong coldkey password exited 0.** The unlock block added in #99 did `ui.error(...)` plus a bare `return`; `ui.error` only prints, so `handle_errors` never saw a failure and click exited successfully. `lium fund && lium up` therefore treated a failed top-up as a completed one. It now raises `CliFailure("coldkey_unlock_failed", ..., EXIT_CONFIGURATION_ERROR)`, matching `wallet_load_failed` and `invalid_amount` in the same function. This is the exact anti-pattern DAH-2593 (#104) removed from the Action layer — the new block reintroduced it in one spot. The alpha path was already correct (it raises `LiumError`).
- **The password was asked before the amount prompt and the confirm**, so a user who backed out had already typed it. The amount prompt, the balance spinner and the confirm now run first; the unlock and the registration spinner moved below the confirm. Nothing backend-mutating happens until the user confirms.
- **#99's fix is intact.** The unlock still runs outside every spinner and still immediately precedes `CheckWalletRegistrationAction`, the only coldkey-signing step — `Lium.add_wallet` reads `bt_wallet.coldkey`, which is what triggers bittensor's raw password prompt. The one spinner now ahead of it, `ui.load("Loading balance")`, never touches the coldkey and so cannot hide a prompt. The guard test was retightened to state that invariant precisely instead of "unlock is the first event".

Tests: `test_fund_tao_unlock_failure_aborts` now asserts the exit code, and `test_fund_tao_declined_confirm_never_asks_for_the_password` is new. Both fail against `main` and pass here. `uv run pytest test/test_fund_cli.py -q` → 53 passed. Full suite: 11 pre-existing failures, identical on an untouched tree.

No version bump — this needs to ride the next release.


- **The reorder also moved wallet registration behind the confirm**, which is not a read-only step: for a coldkey the backend has not seen, `CheckWalletRegistrationAction` -> `Lium.add_wallet` posts `/tao/create-transfer` and `/token/verify` and binds the wallet to the account. Before, `lium fund -w new_wallet` bound the wallet even when the user then declined at the confirm; now declining leaves the account untouched. Side effect of the same move: the first network call is `balance()`, so a broken API key no longer costs the user a password prompt first.

A review pass on this branch found the renamed guard test had been weakened — `events.index(...)` comparison alone still passes if the unlock is wrapped in a spinner of its own, which is the exact failure #99 fixed. `_spy_ui_load` now records spinner exits too and the test asserts no spinner is open when the prompt goes up. Verified by mutation: wrapping the unlock in `ui.load("Unlocking coldkey", ...)` fails the test, and passed it before the change.
