### PR TITLE
DAH-2640, add safe restores and backup lifecycle controls to CLI/SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ The `lium` CLI exposes the full pod lifecycle. Run `lium --help` to see everythi
 - `lium bk set <POD> <PATH>` - Configure automatic backups
 - `lium bk logs <POD>` - View backup logs
 - `lium bk now <POD>` - Trigger immediate backup
-- `lium bk restore <POD> <BACKUP_ID>` - Restore from backup
+- `lium bk cancel --id <BACKUP_ID>` - Cancel an active backup and retain its history
+- `lium bk delete --id <BACKUP_ID>` - Delete stored data for a completed backup
+- `lium bk restore <POD> --id <BACKUP_ID>` - Restore from backup
+- `lium bk restore-cancel --id <RESTORE_ID>` - Cancel an active restore
 - `lium bk rm <POD>` - Remove backup configuration
 
 ### Schedule Commands
@@ -286,7 +289,10 @@ lium bk show my-pod
 lium bk set my-pod /root/data --frequency 24 --retention 7
 lium bk logs my-pod
 lium bk now my-pod --name manual-backup
-lium bk restore my-pod <BACKUP_ID> /root/restore
+lium bk cancel --id <BACKUP_ID>
+lium bk delete --id <BACKUP_ID>
+lium bk restore my-pod --id <BACKUP_ID> --to /root/restore
+lium bk restore-cancel --id <RESTORE_ID>
 lium bk rm my-pod
 
 # Manage schedules

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The `lium` CLI exposes the full pod lifecycle. Run `lium --help` to see everythi
 ### Backup Commands
 
 - `lium bk show <POD>` - Show backup configuration for a pod
-- `lium bk set <POD> <PATH>` - Configure automatic backups
+- `lium bk set <POD> --path <PATH>` - Configure automatic backups
 - `lium bk logs <POD>` - View backup logs
 - `lium bk now <POD>` - Trigger immediate backup
 - `lium bk cancel --id <BACKUP_ID>` - Cancel an active backup and retain its history
@@ -286,7 +286,7 @@ lium volumes rm <VOLUME_HUID>
 
 # Manage backups
 lium bk show my-pod
-lium bk set my-pod /root/data --frequency 24 --retention 7
+lium bk set my-pod --path /root/data --every 24h --keep 7d
 lium bk logs my-pod
 lium bk now my-pod --name manual-backup
 lium bk cancel --id <BACKUP_ID>

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.32"
+__version__ = "0.0.33"

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.33"
+__version__ = "0.0.34"

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.34"
+__version__ = "0.0.33"

--- a/lium/cli/bk/__init__.py
+++ b/lium/cli/bk/__init__.py
@@ -9,6 +9,7 @@ from .now.command import bk_now_command
 from .logs.command import bk_logs_command
 from .restore_logs.command import bk_restore_logs_command
 from .restore.command import bk_restore_command
+from .lifecycle import bk_cancel_command, bk_delete_command, bk_restore_cancel_command
 
 
 @click.group()
@@ -24,5 +25,8 @@ bk_command.add_command(bk_now_command)
 bk_command.add_command(bk_logs_command)
 bk_command.add_command(bk_restore_logs_command)
 bk_command.add_command(bk_restore_command)
+bk_command.add_command(bk_cancel_command)
+bk_command.add_command(bk_delete_command)
+bk_command.add_command(bk_restore_cancel_command)
 
 __all__ = ["bk_command"]

--- a/lium/cli/bk/lifecycle.py
+++ b/lium/cli/bk/lifecycle.py
@@ -18,7 +18,13 @@ def bk_cancel_command(backup_id: str, yes: bool) -> None:
         return
 
     client = Lium()
-    ui.load("Requesting backup cancellation", lambda: client.backup_cancel(backup_id))
+    resolved_backup_id = ui.load(
+        "Resolving backup ID", lambda: client.resolve_backup_id(backup_id)
+    )
+    ui.load(
+        "Requesting backup cancellation",
+        lambda: client.backup_cancel(resolved_backup_id),
+    )
     ui.success(
         "Backup cancellation requested. Its history and last reported progress will remain available."
     )
@@ -37,7 +43,12 @@ def bk_delete_command(backup_id: str, yes: bool) -> None:
         return
 
     client = Lium()
-    ui.load("Starting backup deletion", lambda: client.backup_log_delete(backup_id))
+    resolved_backup_id = ui.load(
+        "Resolving backup ID", lambda: client.resolve_backup_id(backup_id)
+    )
+    ui.load(
+        "Starting backup deletion", lambda: client.backup_log_delete(resolved_backup_id)
+    )
     ui.success(
         "Backup deletion started. Storage usage will update after cleanup finishes."
     )
@@ -56,8 +67,12 @@ def bk_restore_cancel_command(restore_id: str, yes: bool) -> None:
         return
 
     client = Lium()
+    resolved_restore_id = ui.load(
+        "Resolving restore ID", lambda: client.resolve_restore_id(restore_id)
+    )
     ui.load(
-        "Requesting restore cancellation", lambda: client.restore_cancel(restore_id)
+        "Requesting restore cancellation",
+        lambda: client.restore_cancel(resolved_restore_id),
     )
     ui.success(
         "Restore cancellation requested. Partial files may remain in the restore directory."

--- a/lium/cli/bk/lifecycle.py
+++ b/lium/cli/bk/lifecycle.py
@@ -1,0 +1,64 @@
+"""Backup and restore lifecycle commands."""
+
+import click
+
+from lium.cli import ui
+from lium.cli.utils import ensure_config, handle_errors
+from lium.sdk import Lium
+
+
+@click.command("cancel")
+@click.option("--id", "backup_id", required=True, help="Active backup ID")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@handle_errors
+def bk_cancel_command(backup_id: str, yes: bool) -> None:
+    """Cancel an active backup and keep its history."""
+    ensure_config()
+    if not yes and not ui.confirm(f"Cancel backup '{backup_id}'?"):
+        return
+
+    client = Lium()
+    ui.load("Requesting backup cancellation", lambda: client.backup_cancel(backup_id))
+    ui.success(
+        "Backup cancellation requested. Its history and last reported progress will remain available."
+    )
+
+
+@click.command("delete")
+@click.option("--id", "backup_id", required=True, help="Completed backup ID")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@handle_errors
+def bk_delete_command(backup_id: str, yes: bool) -> None:
+    """Delete stored data for a completed backup."""
+    ensure_config()
+    if not yes and not ui.confirm(
+        f"Delete backup '{backup_id}'? This cannot be undone."
+    ):
+        return
+
+    client = Lium()
+    ui.load("Starting backup deletion", lambda: client.backup_log_delete(backup_id))
+    ui.success(
+        "Backup deletion started. Storage usage will update after cleanup finishes."
+    )
+
+
+@click.command("restore-cancel")
+@click.option("--id", "restore_id", required=True, help="Active restore ID")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@handle_errors
+def bk_restore_cancel_command(restore_id: str, yes: bool) -> None:
+    """Cancel an active restore."""
+    ensure_config()
+    if not yes and not ui.confirm(
+        f"Cancel restore '{restore_id}'? Files already written to the restore directory may remain."
+    ):
+        return
+
+    client = Lium()
+    ui.load(
+        "Requesting restore cancellation", lambda: client.restore_cancel(restore_id)
+    )
+    ui.success(
+        "Restore cancellation requested. Partial files may remain in the restore directory."
+    )

--- a/lium/cli/bk/logs/actions.py
+++ b/lium/cli/bk/logs/actions.py
@@ -9,22 +9,11 @@ class GetBackupLogsAction:
         backup_id: str | None = ctx.get("backup_id")
 
         if backup_id:
-            # Search for specific backup ID across all pods
-            all_pods = lium.ps()
-            for pod_info in all_pods:
-                pod_name_search = pod_info.name or pod_info.huid
-                logs = lium.backup_logs(pod=pod_info)
-                for log in logs:
-                    if getattr(log, 'id', '').startswith(backup_id):
-                        return ActionResult(
-                            ok=True,
-                            data={
-                                "single_backup": True,
-                                "pod_name": pod_name_search,
-                                "log": log
-                            }
-                        )
-            return ActionResult(ok=False, error=f"Backup '{backup_id}' not found", data={})
+            resolved_id = lium.resolve_backup_id(backup_id)
+            return ActionResult(
+                ok=True,
+                data={"single_backup": True, "log": lium.backup_log(resolved_id)},
+            )
 
         # Get logs for specific pod
         backup_logs = lium.backup_logs(pod=pod) if pod else []

--- a/lium/cli/bk/logs/command.py
+++ b/lium/cli/bk/logs/command.py
@@ -40,10 +40,9 @@ def bk_logs_command(pod_id: Optional[str], backup_id: Optional[str]):
         if not result.ok:
             raise CliFailure("backup_not_found", result.error, EXIT_GENERAL_ERROR)
 
-        pod_name_found = result.data.get("pod_name")
         log = result.data.get("log")
 
-        output = display.format_single_backup(pod_name_found, log)
+        output = display.format_single_backup(log)
         ui.print(output)
         return
 

--- a/lium/cli/bk/logs/display.py
+++ b/lium/cli/bk/logs/display.py
@@ -106,9 +106,9 @@ def format_logs_table(logs: list) -> Table:
     return table
 
 
-def format_single_backup(pod_name: str, log) -> str:
+def format_single_backup(log) -> str:
     """Format single backup details."""
-    lines = [f"Pod: {pod_name}"]
+    lines = [f"Backup ID: {getattr(log, 'id', 'Unknown')}"]
     lines.append(f"Status: {getattr(log, 'status', 'Unknown')}")
     progress = getattr(log, "progress", None)
     if progress is not None:

--- a/lium/cli/bk/logs/display.py
+++ b/lium/cli/bk/logs/display.py
@@ -2,45 +2,96 @@ from datetime import datetime
 from rich.table import Table
 
 
+def _format_status(status: str) -> str:
+    status_upper = status.upper()
+    if status_upper == "COMPLETED":
+        return f"[green]{status}[/green]"
+    if status_upper in {"FAILED", "ERROR"}:
+        return f"[red]{status}[/red]"
+    if status_upper in {"CANCELLED", "SKIPPED", "EXPIRED", "DELETED"}:
+        return f"[dim]{status}[/dim]"
+    return f"[yellow]{status}[/yellow]"
+
+
+def _format_progress(value: float | None) -> str:
+    if value is None:
+        return ""
+    return f"{value:.2f}".rstrip("0").rstrip(".") + "%"
+
+
+def _format_bytes(value: int) -> str:
+    size = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if size < 1024 or unit == "TiB":
+            return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} B"
+        size /= 1024
+    return f"{value} B"
+
+
+def _format_duration(seconds: int | None) -> str:
+    if seconds is None:
+        return ""
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, remaining_seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m {remaining_seconds}s"
+    hours, remaining_minutes = divmod(minutes, 60)
+    return f"{hours}h {remaining_minutes}m"
+
+
+def _format_work(log) -> str:
+    details = []
+    processed_bytes = getattr(log, "processed_bytes", None)
+    total_bytes = getattr(log, "total_bytes", None)
+    if processed_bytes is not None and total_bytes is not None:
+        details.append(f"{_format_bytes(processed_bytes)}/{_format_bytes(total_bytes)}")
+    processed_files = getattr(log, "processed_files", None)
+    total_files = getattr(log, "total_files", None)
+    if processed_files is not None and total_files is not None:
+        details.append(f"{processed_files:,}/{total_files:,} files")
+    throughput = getattr(log, "throughput_bytes_per_second", None)
+    if throughput:
+        details.append(f"{_format_bytes(throughput)}/s")
+    remaining = getattr(log, "estimated_remaining_seconds", None)
+    if remaining:
+        details.append(f"~{_format_duration(remaining)} left")
+    return ", ".join(details)
+
+
 def format_logs_table(logs: list) -> Table:
     """Format logs as a table."""
-    table = Table(
-        show_header=True,
-        header_style="dim",
-        box=None,
-        padding=(0, 2)
-    )
+    table = Table(show_header=True, header_style="dim", box=None, padding=(0, 2))
 
     table.add_column("#", style="dim")
     table.add_column("Backup ID", style="cyan")
     table.add_column("Status")
     table.add_column("Progress", justify="right")
     table.add_column("Created")
-    table.add_column("Error")
+    table.add_column("Work")
+    table.add_column("Details")
 
     for idx, log in enumerate(logs, 1):
-        backup_id_full = getattr(log, 'id', 'unknown')
-        status = getattr(log, 'status', 'Unknown')
+        backup_id_full = getattr(log, "id", "unknown")
+        status = getattr(log, "status", "Unknown")
 
-        # Color status
-        if status.upper() == 'COMPLETED':
-            status = f"[green]{status}[/green]"
-        elif status.upper() in ['FAILED', 'ERROR']:
-            status = f"[red]{status}[/red]"
-        else:
-            status = f"[yellow]{status}[/yellow]"
+        status = _format_status(status)
 
-        created = getattr(log, 'created_at', 'Unknown')
-        if created != 'Unknown':
+        created = getattr(log, "created_at", "Unknown")
+        if created != "Unknown":
             try:
-                dt = datetime.fromisoformat(created.replace('Z', '+00:00'))
-                created = dt.strftime('%Y-%m-%d %H:%M')
+                dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+                created = dt.strftime("%Y-%m-%d %H:%M")
             except:
                 pass
 
-        progress = getattr(log, 'progress', None)
-        progress_text = f"{progress:.0f}%" if progress is not None else ""
-        error = getattr(log, 'error_message', None) or ""
+        progress = getattr(log, "progress", None)
+        progress_text = _format_progress(progress)
+        details = (
+            getattr(log, "error_message", None)
+            or getattr(log, "status_message", None)
+            or ""
+        )
 
         table.add_row(
             str(idx),
@@ -48,7 +99,8 @@ def format_logs_table(logs: list) -> Table:
             status,
             progress_text,
             created,
-            error
+            _format_work(log),
+            details,
         )
 
     return table
@@ -58,19 +110,25 @@ def format_single_backup(pod_name: str, log) -> str:
     """Format single backup details."""
     lines = [f"Pod: {pod_name}"]
     lines.append(f"Status: {getattr(log, 'status', 'Unknown')}")
-    progress = getattr(log, 'progress', None)
+    progress = getattr(log, "progress", None)
     if progress is not None:
-        lines.append(f"Progress: {progress:.0f}%")
+        lines.append(f"Progress: {_format_progress(progress)}")
     lines.append(f"Created: {getattr(log, 'created_at', 'Unknown')}")
 
-    if hasattr(log, 'completed_at') and log.completed_at:
+    if hasattr(log, "completed_at") and log.completed_at:
         lines.append(f"Completed: {log.completed_at}")
 
-    if hasattr(log, 'size_bytes') and log.size_bytes:
-        size_mb = log.size_bytes / (1024 * 1024)
-        lines.append(f"Size: {size_mb:.2f} MB")
+    work = _format_work(log)
+    if work:
+        lines.append(f"Work: {work}")
 
-    if hasattr(log, 'error_message') and log.error_message:
+    elapsed = getattr(log, "elapsed_seconds", None)
+    if elapsed is not None:
+        lines.append(f"Elapsed: {_format_duration(elapsed)}")
+
+    if hasattr(log, "error_message") and log.error_message:
         lines.append(f"Error: {log.error_message}")
+    elif getattr(log, "status_message", None):
+        lines.append(f"Details: {log.status_message}")
 
     return "\n".join(lines)

--- a/lium/cli/bk/now/actions.py
+++ b/lium/cli/bk/now/actions.py
@@ -13,16 +13,14 @@ class TriggerBackupAction:
         description: str = ctx["description"]
 
         # Check if backup config exists
-        backup_config = lium.backup_config(pod)
+        backup_config = ctx.get("backup_config") or lium.backup_config(pod)
 
         if not backup_config:
-            return ActionResult(ok=False, data={}, error="No backup configuration found")
+            return ActionResult(
+                ok=False, data={}, error="No backup configuration found"
+            )
 
         # Trigger backup
-        backup_result = lium.backup_now(
-            pod=pod,
-            name=name,
-            description=description
-        )
+        backup_result = lium.backup_now(pod=pod, name=name, description=description)
 
         return ActionResult(ok=True, data={"backup": backup_result})

--- a/lium/cli/bk/now/command.py
+++ b/lium/cli/bk/now/command.py
@@ -16,6 +16,7 @@ from lium.cli.utils import (
 )
 from . import validation, parsing
 from .actions import TriggerBackupAction
+from ..path_warning import entire_volume_backup_warning
 
 
 @click.command("now")
@@ -48,6 +49,18 @@ def bk_now_command(pod_id: str, name: Optional[str], description: Optional[str])
     pod_name = parsed.get("pod_name")
     backup_name = parsed.get("name")
     backup_description = parsed.get("description")
+    backup_config = ui.load(
+        "Loading backup configuration", lambda: lium.backup_config(pod)
+    )
+    if not backup_config:
+        raise CliFailure(
+            "no_backup_config", "No backup configuration found", EXIT_GENERAL_ERROR
+        )
+    path_warning = entire_volume_backup_warning(
+        pod, getattr(backup_config, "backup_path", "")
+    )
+    if path_warning:
+        ui.warning(path_warning)
 
     # Execute
     ctx = {
@@ -55,7 +68,8 @@ def bk_now_command(pod_id: str, name: Optional[str], description: Optional[str])
         "pod": pod,
         "pod_name": pod_name,
         "name": backup_name,
-        "description": backup_description
+        "description": backup_description,
+        "backup_config": backup_config,
     }
 
     action = TriggerBackupAction()

--- a/lium/cli/bk/path_warning.py
+++ b/lium/cli/bk/path_warning.py
@@ -1,0 +1,15 @@
+"""Backup path warnings shared by backup commands."""
+
+
+def entire_volume_backup_warning(pod, backup_path: str) -> str | None:
+    volume_path = getattr(pod, "volume_path", None)
+    if not volume_path:
+        volumes = (getattr(pod, "template", None) or {}).get("volumes", [])
+        volume_path = volumes[0] if volumes else "/root"
+
+    if not backup_path or backup_path.rstrip("/") == volume_path.rstrip("/"):
+        return (
+            "This backs up the entire volume. For more reliable backups, prefer a stable subdirectory "
+            "that is not being actively changed."
+        )
+    return None

--- a/lium/cli/bk/restore/actions.py
+++ b/lium/cli/bk/restore/actions.py
@@ -12,6 +12,9 @@ class RestoreBackupAction:
         backup_id: str = ctx["backup_id"]
         restore_path: str = ctx["restore_path"]
 
-        restore_result = lium.restore(pod=pod, backup_id=backup_id, restore_path=restore_path)
+        resolved_backup_id = lium.resolve_backup_id(backup_id)
+        restore_result = lium.restore(
+            pod=pod, backup_id=resolved_backup_id, restore_path=restore_path
+        )
 
         return ActionResult(ok=True, data={"restore": restore_result})

--- a/lium/cli/bk/restore/command.py
+++ b/lium/cli/bk/restore/command.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 from lium.sdk import Lium
@@ -16,10 +18,14 @@ from .actions import RestoreBackupAction
 @click.command("restore")
 @click.argument("pod_id")
 @click.option("--id", "backup_id", required=True, help="Backup ID to restore")
-@click.option("--to", "restore_path", default="/root", help="Restore path (default: /root)")
+@click.option(
+    "--to",
+    "restore_path",
+    help="New or empty restore subdirectory (default: <pod volume>/restored)",
+)
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @handle_errors
-def bk_restore_command(pod_id: str, backup_id: str, restore_path: str, yes: bool):
+def bk_restore_command(pod_id: str, backup_id: str, restore_path: Optional[str], yes: bool):
     """Restore a backup to a pod."""
     ensure_config()
 
@@ -42,6 +48,7 @@ def bk_restore_command(pod_id: str, backup_id: str, restore_path: str, yes: bool
 
     pod = parsed.get("pod")
     pod_name = parsed.get("pod_name")
+    restore_path = restore_path or pod.default_restore_path
 
     # Confirm
     if not yes:
@@ -61,3 +68,7 @@ def bk_restore_command(pod_id: str, backup_id: str, restore_path: str, yes: bool
     ui.load(f"Restoring backup to {restore_path}", lambda: action.execute(ctx))
 
     ui.success(f"Restore started for {pod_name} at {restore_path}")
+    ui.warning(
+        f"Do not add, modify, or remove files in {restore_path} until the restore completes. "
+        f"Check progress with: lium bk restore-logs {pod_name}"
+    )

--- a/lium/cli/bk/restore_logs/display.py
+++ b/lium/cli/bk/restore_logs/display.py
@@ -3,6 +3,14 @@ from datetime import datetime
 from rich.table import Table
 
 
+_STAGE_LABELS = {
+    "WAITING_FOR_POD": "Waiting for pod",
+    "PREPARING": "Preparing",
+    "RESTORING": "Restoring",
+    "FINALIZING": "Finalizing",
+}
+
+
 def _format_status(status: str) -> str:
     status_upper = status.upper()
     if status_upper == "COMPLETED":
@@ -22,6 +30,46 @@ def _format_datetime(value: str | None) -> str:
         return value
 
 
+def _format_progress(value: float | None) -> str:
+    if value is None:
+        return ""
+    return f"{value:.2f}".rstrip("0").rstrip(".") + "%"
+
+
+def _format_bytes(value: int) -> str:
+    size = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if size < 1024 or unit == "TiB":
+            return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} B"
+        size /= 1024
+    return f"{int(value)} B"
+
+
+def _format_stage(log) -> str:
+    if getattr(log, "status", "").upper() in {"COMPLETED", "FAILED", "CANCELLED"}:
+        return ""
+    stage = getattr(log, "stage", None)
+    return _STAGE_LABELS.get(stage, stage or "")
+
+
+def _format_work(log) -> str:
+    stage = getattr(log, "stage", None)
+    total_files = getattr(log, "total_files", None)
+    processed_files = getattr(log, "processed_files", None)
+    total_bytes = getattr(log, "total_bytes", None)
+    processed_bytes = getattr(log, "processed_bytes", None)
+
+    if stage == "PREPARING" and total_files is not None:
+        return f"{total_files:,} files discovered"
+
+    details = []
+    if processed_files is not None and total_files is not None:
+        details.append(f"{processed_files:,}/{total_files:,} files")
+    if processed_bytes is not None and total_bytes is not None:
+        details.append(f"{_format_bytes(processed_bytes)}/{_format_bytes(total_bytes)}")
+    return ", ".join(details)
+
+
 def format_logs_table(logs: list) -> Table:
     """Format restore logs as a table."""
     table = Table(
@@ -34,7 +82,9 @@ def format_logs_table(logs: list) -> Table:
     table.add_column("#", style="dim")
     table.add_column("Restore ID", style="cyan")
     table.add_column("Status")
+    table.add_column("Stage")
     table.add_column("Progress", justify="right")
+    table.add_column("Work")
     table.add_column("Created")
     table.add_column("Restore Path")
     table.add_column("Error")
@@ -42,8 +92,7 @@ def format_logs_table(logs: list) -> Table:
     for idx, log in enumerate(logs, 1):
         restore_id_full = getattr(log, "id", "unknown")
         status = _format_status(getattr(log, "status", "Unknown"))
-        progress = getattr(log, "progress", None)
-        progress_text = f"{progress:.0f}%" if progress is not None else ""
+        progress_text = _format_progress(getattr(log, "progress", None))
         created = _format_datetime(getattr(log, "created_at", None))
         restore_path = getattr(log, "restore_path", None) or ""
         error = getattr(log, "error_message", None) or ""
@@ -52,7 +101,9 @@ def format_logs_table(logs: list) -> Table:
             str(idx),
             restore_id_full,
             status,
+            _format_stage(log),
             progress_text,
+            _format_work(log),
             created,
             restore_path,
             error,
@@ -68,9 +119,21 @@ def format_single_restore(pod_name: str, log) -> str:
     lines.append(f"Backup ID: {getattr(log, 'backup_id', 'unknown')}")
     lines.append(f"Status: {getattr(log, 'status', 'Unknown')}")
 
+    restore_mode = getattr(log, "restore_mode", None)
+    if restore_mode:
+        lines.append(f"Mode: {restore_mode}")
+
+    stage = _format_stage(log)
+    if stage:
+        lines.append(f"Stage: {stage}")
+
     progress = getattr(log, "progress", None)
     if progress is not None:
-        lines.append(f"Progress: {progress:.0f}%")
+        lines.append(f"Progress: {_format_progress(progress)}")
+
+    work = _format_work(log)
+    if work:
+        lines.append(f"Work: {work}")
 
     restore_path = getattr(log, "restore_path", None)
     if restore_path:

--- a/lium/cli/bk/restore_logs/display.py
+++ b/lium/cli/bk/restore_logs/display.py
@@ -54,6 +54,9 @@ def _format_stage(log) -> str:
 
 
 def _format_work(log) -> str:
+    if getattr(log, "status", "").upper() in {"COMPLETED", "FAILED", "CANCELLED"}:
+        return ""
+
     stage = getattr(log, "stage", None)
     total_files = getattr(log, "total_files", None)
     processed_files = getattr(log, "processed_files", None)

--- a/lium/cli/bk/restore_logs/display.py
+++ b/lium/cli/bk/restore_logs/display.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from rich.table import Table
 
-
 _STAGE_LABELS = {
     "WAITING_FOR_POD": "Waiting for pod",
     "PREPARING": "Preparing",
@@ -17,6 +16,8 @@ def _format_status(status: str) -> str:
         return f"[green]{status}[/green]"
     if status_upper in ["FAILED", "ERROR"]:
         return f"[red]{status}[/red]"
+    if status_upper == "CANCELLED":
+        return f"[dim]{status}[/dim]"
     return f"[yellow]{status}[/yellow]"
 
 
@@ -67,7 +68,23 @@ def _format_work(log) -> str:
         details.append(f"{processed_files:,}/{total_files:,} files")
     if processed_bytes is not None and total_bytes is not None:
         details.append(f"{_format_bytes(processed_bytes)}/{_format_bytes(total_bytes)}")
+    throughput = getattr(log, "throughput_bytes_per_second", None)
+    if throughput:
+        details.append(f"{_format_bytes(throughput)}/s")
+    remaining = getattr(log, "estimated_remaining_seconds", None)
+    if remaining:
+        details.append(f"~{_format_duration(remaining)} left")
     return ", ".join(details)
+
+
+def _format_duration(seconds: int) -> str:
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, remaining_seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m {remaining_seconds}s"
+    hours, remaining_minutes = divmod(minutes, 60)
+    return f"{hours}h {remaining_minutes}m"
 
 
 def format_logs_table(logs: list) -> Table:
@@ -134,6 +151,10 @@ def format_single_restore(pod_name: str, log) -> str:
     work = _format_work(log)
     if work:
         lines.append(f"Work: {work}")
+
+    elapsed = getattr(log, "elapsed_seconds", None)
+    if elapsed is not None:
+        lines.append(f"Elapsed: {_format_duration(elapsed)}")
 
     restore_path = getattr(log, "restore_path", None)
     if restore_path:

--- a/lium/cli/bk/set/command.py
+++ b/lium/cli/bk/set/command.py
@@ -13,6 +13,7 @@ from lium.cli.utils import (
 )
 from . import validation, parsing
 from .actions import SetBackupAction
+from ..path_warning import entire_volume_backup_warning
 
 
 @click.command("set")
@@ -60,6 +61,10 @@ def bk_set_command(pod_id: str, path: str, every: str, keep: str, yes: bool):
     frequency_hours = parsed.get("frequency_hours")
     retention_days = parsed.get("retention_days")
 
+    path_warning = entire_volume_backup_warning(pod, backup_path)
+    if path_warning:
+        ui.warning(path_warning)
+
     # Execute
     ctx = {
         "lium": lium,
@@ -67,7 +72,7 @@ def bk_set_command(pod_id: str, path: str, every: str, keep: str, yes: bool):
         "pod_name": pod_name,
         "path": backup_path,
         "frequency_hours": frequency_hours,
-        "retention_days": retention_days
+        "retention_days": retention_days,
     }
 
     action = SetBackupAction()

--- a/lium/cli/bk/set/command.py
+++ b/lium/cli/bk/set/command.py
@@ -18,7 +18,7 @@ from ..path_warning import entire_volume_backup_warning
 
 @click.command("set")
 @click.argument("pod_id")
-@click.option("--path", default="/root", help="Backup path (default: /root)")
+@click.option("--path", required=True, help="Explicit path inside the pod volume to back up")
 @click.option("--every", help="Backup frequency (e.g., 1h, 6h, 24h)")
 @click.option("--keep", help="Retention period (e.g., 1d, 7d, 30d)")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
@@ -34,7 +34,7 @@ def bk_set_command(pod_id: str, path: str, every: str, keep: str, yes: bool):
     \b
     Examples:
       lium bk set 1 --path /root --every 6h --keep 7d
-      lium bk set eager-wolf-aa --every 1h --keep 1d
+      lium bk set eager-wolf-aa --path /root/checkpoints --every 1h --keep 1d
     """
     ensure_config()
 

--- a/lium/cli/bk/set/command.py
+++ b/lium/cli/bk/set/command.py
@@ -44,7 +44,7 @@ def bk_set_command(pod_id: str, path: str, every: str, keep: str, yes: bool):
         raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
 
     # Load data
-    lium = Lium()
+    lium = Lium(source="cli")
     all_pods = ui.load("Loading pods", lambda: lium.ps())
 
     if not all_pods:

--- a/lium/cli/up/actions.py
+++ b/lium/cli/up/actions.py
@@ -161,6 +161,8 @@ class RentPodAction:
         ports: Optional[int] = ctx.get("ports")
         ssh_name: Optional[str] = ctx.get("ssh_name")
         enable_volume_encryption: bool | None = ctx.get("enable_volume_encryption")
+        backup_id: Optional[str] = ctx.get("backup_id")
+        restore_path: Optional[str] = ctx.get("restore_path")
 
         if not name:
             name = executor.huid
@@ -174,6 +176,8 @@ class RentPodAction:
             ports=ports,
             ssh_name=ssh_name,
             enable_volume_encryption=enable_volume_encryption,
+            backup_id=backup_id,
+            restore_path=restore_path,
         )
 
         pod_id = pod_info.get('id') or pod_info.get('name', '')

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -40,6 +40,8 @@ from .actions import (
 @click.option("--until", help="Auto-terminate at time in local timezone (e.g., 'today 23:00', 'tomorrow 01:00', '2025-10-20 15:30')")
 @click.option("--jupyter", is_flag=True, help="Install Jupyter Notebook (automatically selects available port)")
 @click.option("--no-ssh", "no_ssh", is_flag=True, help="Create the pod and return instead of opening an SSH session")
+@click.option("--restore-backup", "restore_backup_id", help="Backup ID to restore after the pod starts")
+@click.option("--restore-to", "restore_path", help="New or empty subdirectory for the startup restore")
 @click.option("--image", help="Docker image to run (e.g., pytorch/pytorch:2.0, nvidia/cuda:12.0)")
 @click.option("--internal-ports", help="Internal ports to expose (comma-separated, e.g., 22,8000,8080)")
 @click.option("--dockerfile", type=click.Path(exists=True, dir_okay=False, readable=True), help="Path to a Dockerfile to build the pod image from (custom build; mutually exclusive with --image/--template_id)")
@@ -67,6 +69,8 @@ def up_command(
     until: Optional[str],
     jupyter: bool,
     no_ssh: bool,
+    restore_backup_id: Optional[str],
+    restore_path: Optional[str],
     image: Optional[str],
     internal_ports: Optional[str],
     dockerfile: Optional[str],
@@ -98,6 +102,7 @@ def up_command(
       lium up 1 --until "today 23:00"       # Auto-terminate at 23:00 local time today
       lium up 1 --until "tomorrow 01:00"    # Auto-terminate at 01:00 local time tomorrow
       lium up 1 --jupyter                   # Install Jupyter Notebook (auto-selects port)
+      lium up 1 --restore-backup BACKUP_ID --restore-to /root/restored
       LIUM_DEBUG=1 lium up 1 --jupyter      # Show debug information
     \b
     Docker-run style (streams logs instead of SSH):
@@ -122,6 +127,12 @@ def up_command(
     )
     if not valid:
         raise CliFailure("invalid_arguments", error, EXIT_CONFIGURATION_ERROR)
+    if bool(restore_backup_id) != bool(restore_path):
+        raise CliFailure(
+            "invalid_arguments",
+            "--restore-backup and --restore-to must be provided together",
+            EXIT_CONFIGURATION_ERROR,
+        )
 
     # Parse env vars if provided
     env_dict = {}
@@ -280,6 +291,8 @@ def up_command(
             f"({executor.gpu_count}×{executor.gpu_type}) "
             f"at ${executor.price_per_hour:.2f}/h?"
         )
+        if restore_backup_id:
+            confirm_msg += f" Restore backup {restore_backup_id} to {restore_path} after startup."
         if not ui.confirm(confirm_msg):
             return
 
@@ -308,6 +321,8 @@ def up_command(
             "ports": ports,
             "ssh_name": ssh_name,
             "enable_volume_encryption": volume_encryption,
+            "backup_id": restore_backup_id,
+            "restore_path": restore_path,
         })
     )
 
@@ -373,6 +388,11 @@ def up_command(
     # Always state what was created: a caller that only gets an SSH banner or a
     # log stream has no way to name the pod it is now paying for.
     ui.info(f"{pod_label} ready")
+
+    if restore_backup_id:
+        ui.warning(
+            f"Restore is continuing in {restore_path}. Do not modify that directory until the restore completes."
+        )
 
     if no_ssh:
         return

--- a/lium/cli/up/command.py
+++ b/lium/cli/up/command.py
@@ -198,6 +198,10 @@ def up_command(
             )
 
     lium = Lium(source="cli")
+    if restore_backup_id:
+        restore_backup_id = ui.load(
+            "Resolving backup ID", lambda: lium.resolve_backup_id(restore_backup_id)
+        )
 
     action = ResolveExecutorAction()
     result = ui.load(

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -59,8 +59,30 @@ def _response_error_message(response: requests.Response) -> str:
 
     detail = payload.get("detail") if isinstance(payload, dict) else None
     response_message = payload.get("message") if isinstance(payload, dict) else None
-    structured_error = detail if isinstance(detail, dict) else response_message if isinstance(response_message, dict) else None
-    if isinstance(detail, list) and detail:
+    validation_errors = (
+        payload.get("validation_errors") if isinstance(payload, dict) else None
+    )
+    structured_error = (
+        detail
+        if isinstance(detail, dict)
+        else response_message if isinstance(response_message, dict) else None
+    )
+    if isinstance(validation_errors, list) and validation_errors:
+        messages: list[str] = []
+        for error in validation_errors:
+            if not isinstance(error, dict):
+                messages.append(str(error))
+                continue
+            field = error.get("field")
+            reason = error.get("message") or error.get("msg") or "Invalid value"
+            messages.append(f"{field}: {reason}" if field else str(reason))
+        validation_summary = "; ".join(messages)
+        message = (
+            f"{response_message}: {validation_summary}"
+            if isinstance(response_message, str)
+            else validation_summary
+        )
+    elif isinstance(detail, list) and detail:
         message = detail[0].get("msg") if isinstance(detail[0], dict) else str(detail[0])
     elif structured_error:
         message = structured_error.get("message") or "Request failed"
@@ -99,6 +121,7 @@ class Lium:
 
     def __init__(self, config: Optional[Config] = None, source: str = "sdk"):
         self.config = config or Config.load()
+        self.source = source
         self.headers = {
             "X-API-KEY": self.config.api_key,
             "X-Source": source,
@@ -1510,7 +1533,7 @@ class Lium:
         Returns:
             Created :class:`BackupConfig`.
         """
-        if path.rstrip("/") == pod.volume_path.rstrip("/"):
+        if self.source != "cli" and path.rstrip("/") == pod.volume_path.rstrip("/"):
             warnings.warn(
                 "Backing up the entire volume is less reliable when files are actively changing; "
                 "prefer a stable subdirectory when possible.",

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -51,6 +51,24 @@ load_dotenv()
 _PAY_API_KEY = "6RhXQ788J9BdnqeLua8z7ZSkXBDahclxhwjMB17qW1M"
 
 
+def _response_error_message(response: requests.Response) -> str:
+    try:
+        payload = response.json()
+    except Exception:
+        return response.text or "Request failed"
+
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if isinstance(detail, list) and detail:
+        message = detail[0].get("msg") if isinstance(detail[0], dict) else str(detail[0])
+    elif isinstance(detail, dict):
+        message = detail.get("message") or "Request failed"
+        if detail.get("active_operation_id"):
+            message += f" (active operation: {detail['active_operation_id']})"
+    else:
+        message = detail or (payload.get("message") if isinstance(payload, dict) else None)
+    return str(message or "Request failed")
+
+
 def _get_client_version() -> str:
     try:
         return version("lium.io")
@@ -106,14 +124,14 @@ class Lium:
         if resp.status_code == 401:
             raise LiumAuthError("Invalid API key")
         if resp.status_code == 403:
-            raise LiumPermissionError(f"Permission denied: {resp.text}")
+            raise LiumPermissionError(f"Permission denied: {_response_error_message(resp)}")
         if resp.status_code == 404:
-            raise LiumNotFoundError(f"Resource not found: {resp.text}")
+            raise LiumNotFoundError(f"Resource not found: {_response_error_message(resp)}")
         if resp.status_code == 429:
             raise LiumRateLimitError("Rate limit exceeded")
         if 500 <= resp.status_code < 600:
             raise LiumServerError(f"Server error: {resp.status_code}")
-        raise LiumError(f"API error {resp.status_code}: {resp.text}")
+        raise LiumError(f"API error {resp.status_code}: {_response_error_message(resp)}")
 
     def _dict_to_backup_config(self, config_dict: Dict) -> BackupConfig:
         """Convert backup config dict to BackupConfig object."""
@@ -141,7 +159,18 @@ class Lium:
             error_message=log_dict.get("error_message"),
             progress=log_dict.get("progress"),
             backup_volume_id=log_dict.get("backup_volume_id"),
-            created_at=log_dict.get("created_at")
+            created_at=log_dict.get("created_at"),
+            stage=log_dict.get("stage"),
+            total_files=log_dict.get("total_files"),
+            processed_files=log_dict.get("processed_files"),
+            total_bytes=log_dict.get("total_bytes"),
+            processed_bytes=log_dict.get("processed_bytes"),
+            deletion_state=log_dict.get("deletion_state"),
+            physical_cleanup_at=log_dict.get("physical_cleanup_at"),
+            status_message=log_dict.get("status_message"),
+            elapsed_seconds=log_dict.get("elapsed_seconds"),
+            throughput_bytes_per_second=log_dict.get("throughput_bytes_per_second"),
+            estimated_remaining_seconds=log_dict.get("estimated_remaining_seconds"),
         )
 
     def _dict_to_restore_log(self, log_dict: Dict) -> RestoreLog:
@@ -167,6 +196,9 @@ class Lium:
             processed_files=log_dict.get("processed_files"),
             total_bytes=log_dict.get("total_bytes"),
             processed_bytes=log_dict.get("processed_bytes"),
+            elapsed_seconds=log_dict.get("elapsed_seconds"),
+            throughput_bytes_per_second=log_dict.get("throughput_bytes_per_second"),
+            estimated_remaining_seconds=log_dict.get("estimated_remaining_seconds"),
         )
 
     def _dict_to_volume_info(self, volume_dict: Dict) -> VolumeInfo:
@@ -1476,6 +1508,13 @@ class Lium:
         Returns:
             Created :class:`BackupConfig`.
         """
+        if path.rstrip("/") == pod.volume_path.rstrip("/"):
+            warnings.warn(
+                "Backing up the entire volume is less reliable when files are actively changing; "
+                "prefer a stable subdirectory when possible.",
+                UserWarning,
+                stacklevel=2,
+            )
         payload = {
             "pod_id": pod.id,
             "backup_frequency_hours": frequency_hours,
@@ -1570,6 +1609,14 @@ class Lium:
             API response payload.
         """
         return self._request("DELETE", f"/backup-configs/{config_id}").json()
+
+    def backup_cancel(self, backup_id: str) -> Dict[str, Any]:
+        """Request cancellation of an active backup while retaining its history."""
+        return self._request("POST", f"/backup-logs/{backup_id}/cancel").json()
+
+    def backup_log_delete(self, backup_id: str) -> Dict[str, Any]:
+        """Delete the stored data for a completed backup and retain its audit row."""
+        return self._request("DELETE", f"/backup-logs/{backup_id}").json()
     
     def restore(
         self,
@@ -1617,6 +1664,10 @@ class Lium:
             return [self._dict_to_restore_log(log) for log in logs]
         except LiumNotFoundError:
             return []
+
+    def restore_cancel(self, restore_id: str) -> Dict[str, Any]:
+        """Request cancellation of an active restore."""
+        return self._request("POST", f"/restore-logs/{restore_id}/cancel").json()
 
     def get_deployment_estimate(self, executor_id: str, template_id: str) -> dict:
         """Estimate deployment time for a template on a node.

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1648,7 +1648,12 @@ class Lium:
         """Resolve an eight-character backup ID shown by the CLI."""
         if not re.fullmatch(r"[0-9a-fA-F]{8}", backup_id):
             return backup_id
-        matches = {log.id for log in self.backup_logs_all() if log.id.startswith(backup_id)}
+        normalized_backup_id = backup_id.lower()
+        matches = {
+            log.id
+            for log in self.backup_logs_all()
+            if log.id.startswith(normalized_backup_id)
+        }
         return self._resolve_short_id(backup_id, matches, "backup")
 
     def backup_delete(self, config_id: str) -> Dict[str, Any]:
@@ -1721,11 +1726,12 @@ class Lium:
         """Resolve an eight-character restore ID shown by the CLI."""
         if not re.fullmatch(r"[0-9a-fA-F]{8}", restore_id):
             return restore_id
+        normalized_restore_id = restore_id.lower()
         matches = {
             log.id
             for pod in self.ps()
             for log in self.restore_logs(pod)
-            if log.id.startswith(restore_id)
+            if log.id.startswith(normalized_restore_id)
         }
         return self._resolve_short_id(restore_id, matches, "restore")
 

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1495,7 +1495,7 @@ class Lium:
         self,
         pod: PodInfo,
         *,
-        path: str = "/home",
+        path: str,
         frequency_hours: int = 6,
         retention_days: int = 7,
     ) -> BackupConfig:
@@ -1503,7 +1503,7 @@ class Lium:
 
         Args:
             pod: Pod to configure.
-            path: Filesystem path to back up.
+            path: Explicit filesystem path inside the pod volume to back up.
             frequency_hours: Backup interval in hours.
             retention_days: Retention period in days.
 

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -58,14 +58,16 @@ def _response_error_message(response: requests.Response) -> str:
         return response.text or "Request failed"
 
     detail = payload.get("detail") if isinstance(payload, dict) else None
+    response_message = payload.get("message") if isinstance(payload, dict) else None
+    structured_error = detail if isinstance(detail, dict) else response_message if isinstance(response_message, dict) else None
     if isinstance(detail, list) and detail:
         message = detail[0].get("msg") if isinstance(detail[0], dict) else str(detail[0])
-    elif isinstance(detail, dict):
-        message = detail.get("message") or "Request failed"
-        if detail.get("active_operation_id"):
-            message += f" (active operation: {detail['active_operation_id']})"
+    elif structured_error:
+        message = structured_error.get("message") or "Request failed"
+        if structured_error.get("active_operation_id"):
+            message += f" (active operation: {structured_error['active_operation_id']})"
     else:
-        message = detail or (payload.get("message") if isinstance(payload, dict) else None)
+        message = detail or response_message
     return str(message or "Request failed")
 
 
@@ -1599,6 +1601,28 @@ class Lium:
             # No backup logs exist for this pod, return empty list
             return []
 
+    def backup_logs_all(self) -> List[BackupLog]:
+        """Get all backup logs available to the current user."""
+        logs: List[BackupLog] = []
+        page = 1
+        while True:
+            response = self._request(
+                "GET", "/backup-logs/", params={"page": page, "limit": 100}
+            ).json()
+            if not isinstance(response, dict):
+                return logs
+            logs.extend(self._dict_to_backup_log(log) for log in response.get("items", []))
+            if not response.get("has_next"):
+                return logs
+            page += 1
+
+    def resolve_backup_id(self, backup_id: str) -> str:
+        """Resolve an eight-character backup ID shown by the CLI."""
+        if not re.fullmatch(r"[0-9a-fA-F]{8}", backup_id):
+            return backup_id
+        matches = {log.id for log in self.backup_logs_all() if log.id.startswith(backup_id)}
+        return self._resolve_short_id(backup_id, matches, "backup")
+
     def backup_delete(self, config_id: str) -> Dict[str, Any]:
         """Delete a backup configuration by ID.
 
@@ -1664,6 +1688,26 @@ class Lium:
             return [self._dict_to_restore_log(log) for log in logs]
         except LiumNotFoundError:
             return []
+
+    def resolve_restore_id(self, restore_id: str) -> str:
+        """Resolve an eight-character restore ID shown by the CLI."""
+        if not re.fullmatch(r"[0-9a-fA-F]{8}", restore_id):
+            return restore_id
+        matches = {
+            log.id
+            for pod in self.ps()
+            for log in self.restore_logs(pod)
+            if log.id.startswith(restore_id)
+        }
+        return self._resolve_short_id(restore_id, matches, "restore")
+
+    @staticmethod
+    def _resolve_short_id(short_id: str, matches: set[str], resource_name: str) -> str:
+        if not matches:
+            raise LiumNotFoundError(f"No {resource_name} matches ID '{short_id}'")
+        if len(matches) > 1:
+            raise LiumError(f"{resource_name.capitalize()} ID '{short_id}' is ambiguous")
+        return matches.pop()
 
     def restore_cancel(self, restore_id: str) -> Dict[str, Any]:
         """Request cancellation of an active restore."""

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -159,6 +159,14 @@ class Lium:
             logs=log_dict.get("logs"),
             restore_path=log_dict.get("restore_path"),
             created_at=log_dict.get("created_at", ""),
+            backup_engine=log_dict.get("backup_engine"),
+            restore_mode=log_dict.get("restore_mode"),
+            stage=log_dict.get("stage"),
+            last_heartbeat_at=log_dict.get("last_heartbeat_at"),
+            total_files=log_dict.get("total_files"),
+            processed_files=log_dict.get("processed_files"),
+            total_bytes=log_dict.get("total_bytes"),
+            processed_bytes=log_dict.get("processed_bytes"),
         )
 
     def _dict_to_volume_info(self, volume_dict: Dict) -> VolumeInfo:
@@ -322,6 +330,8 @@ class Lium:
         ssh_keys: Optional[List[str]] = None,
         ssh_name: Optional[str] = None,
         enable_volume_encryption: bool | None = True,
+        backup_id: Optional[str] = None,
+        restore_path: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Start a new pod on a specific node.
 
@@ -344,6 +354,9 @@ class Lium:
             enable_volume_encryption: Whether to request encryption for the local
                 pod volume. Enabled by default. The image must support Lium volume
                 encryption.
+            backup_id: Optional backup ID to restore after the pod starts.
+            restore_path: New or empty subdirectory where the backup is restored.
+                Required when ``backup_id`` is provided.
 
         Returns:
             Pod metadata as returned by the rent API (id, name, status, ssh command, etc.).
@@ -352,6 +365,8 @@ class Lium:
             raise ValueError(
                 "Provide either template_id or dockerfile_content, not both"
             )
+        if bool(backup_id) != bool(restore_path):
+            raise ValueError("backup_id and restore_path must be provided together")
 
         executor_info = self.get_executor(executor_id)
         if not executor_info:
@@ -375,6 +390,8 @@ class Lium:
             "user_public_key": ssh_material,
             "initial_port_count": ports,
             "enable_volume_encryption": enable_volume_encryption,
+            "backup_log_id": backup_id,
+            "restore_path": restore_path,
         }
 
         response = self._request("POST", f"/executors/{executor_info.id}/rent", json=payload).json()
@@ -1559,21 +1576,23 @@ class Lium:
         pod: PodInfo,
         *,
         backup_id: str,
-        restore_path: str = "/root",
+        restore_path: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Restore a backup to a pod.
         
         Args:
             pod: Pod to restore to.
             backup_id: ID of the backup to restore.
-            restore_path: Path where to restore the backup (default: /root).
+            restore_path: New or empty subdirectory where the backup is restored.
+                Defaults to ``<pod volume>/restored``.
             
         Returns:
             Response from the restore API.
         """
+        target_path = restore_path or pod.default_restore_path
         payload = {
             "backup_id": backup_id,
-            "restore_path": restore_path
+            "restore_path": target_path,
         }
         
         return self._request("POST", f"/pods/{pod.id}/restore", json=payload).json()

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -1639,6 +1639,11 @@ class Lium:
                 return logs
             page += 1
 
+    def backup_log(self, backup_id: str) -> BackupLog:
+        """Get one backup log owned by the authenticated user."""
+        response = self._request("GET", f"/backup-logs/{backup_id}").json()
+        return self._dict_to_backup_log(response)
+
     def resolve_backup_id(self, backup_id: str) -> str:
         """Resolve an eight-character backup ID shown by the CLI."""
         if not re.fullmatch(r"[0-9a-fA-F]{8}", backup_id):

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -28,13 +28,13 @@ class ExecutorInfo:
     @property
     def driver_version(self) -> str:
         """Extract GPU driver version from specs."""
-        return self.specs.get('gpu', {}).get('driver', '')
+        return self.specs.get("gpu", {}).get("driver", "")
 
     @property
     def gpu_model(self) -> str:
         """Extract GPU model name from specs."""
-        gpu_details = self.specs.get('gpu', {}).get('details', [])
-        return gpu_details[0].get('name', '') if gpu_details else ''
+        gpu_details = self.specs.get("gpu", {}).get("details", [])
+        return gpu_details[0].get("name", "") if gpu_details else ""
 
     @property
     def download_speed(self) -> float:
@@ -67,18 +67,24 @@ class PodInfo:
 
     @property
     def host(self) -> Optional[str]:
-        return (re.findall(r'@(\S+)', self.ssh_cmd) or [None])[0] if self.ssh_cmd else None
+        return (
+            (re.findall(r"@(\S+)", self.ssh_cmd) or [None])[0] if self.ssh_cmd else None
+        )
 
     @property
     def username(self) -> Optional[str]:
-        return (re.findall(r'ssh (\S+)@', self.ssh_cmd) or [None])[0] if self.ssh_cmd else None
+        return (
+            (re.findall(r"ssh (\S+)@", self.ssh_cmd) or [None])[0]
+            if self.ssh_cmd
+            else None
+        )
 
     @property
     def ssh_port(self) -> int:
         """Extract SSH port from command."""
-        if not self.ssh_cmd or '-p ' not in self.ssh_cmd:
+        if not self.ssh_cmd or "-p " not in self.ssh_cmd:
             return 22
-        return int(self.ssh_cmd.split('-p ')[1].split()[0])
+        return int(self.ssh_cmd.split("-p ")[1].split()[0])
 
     @property
     def volume_path(self) -> str:
@@ -95,6 +101,7 @@ class PodInfo:
 @dataclass
 class Template:
     """Template information."""
+
     id: str
     name: str
     huid: str
@@ -107,6 +114,7 @@ class Template:
 @dataclass
 class BackupConfig:
     """Backup configuration information."""
+
     id: str
     huid: str
     pod_executor_id: str
@@ -121,6 +129,7 @@ class BackupConfig:
 @dataclass
 class BackupLog:
     """Backup log information."""
+
     id: str
     huid: str
     backup_config_id: str
@@ -131,11 +140,23 @@ class BackupLog:
     progress: Optional[float] = None
     backup_volume_id: Optional[str] = None
     created_at: Optional[str] = None
+    stage: Optional[str] = None
+    total_files: Optional[int] = None
+    processed_files: Optional[int] = None
+    total_bytes: Optional[int] = None
+    processed_bytes: Optional[int] = None
+    deletion_state: Optional[str] = None
+    physical_cleanup_at: Optional[str] = None
+    status_message: Optional[str] = None
+    elapsed_seconds: Optional[int] = None
+    throughput_bytes_per_second: Optional[int] = None
+    estimated_remaining_seconds: Optional[int] = None
 
 
 @dataclass
 class RestoreLog:
     """Restore log information."""
+
     id: str
     huid: str
     backup_id: str
@@ -156,11 +177,15 @@ class RestoreLog:
     processed_files: Optional[int] = None
     total_bytes: Optional[int] = None
     processed_bytes: Optional[int] = None
+    elapsed_seconds: Optional[int] = None
+    throughput_bytes_per_second: Optional[int] = None
+    estimated_remaining_seconds: Optional[int] = None
 
 
 @dataclass
 class SSHKey:
     """Public SSH key registered for the current user."""
+
     id: str
     name: str
     public_key: str
@@ -170,6 +195,7 @@ class SSHKey:
 @dataclass
 class VolumeInfo:
     """Volume information."""
+
     id: str
     huid: str
     name: str

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -80,6 +80,17 @@ class PodInfo:
             return 22
         return int(self.ssh_cmd.split('-p ')[1].split()[0])
 
+    @property
+    def volume_path(self) -> str:
+        """Return the pod's local volume mount path."""
+        volumes = self.template.get("volumes", []) if self.template else []
+        return volumes[0] if volumes else "/root"
+
+    @property
+    def default_restore_path(self) -> str:
+        """Return a safe restore destination below the local volume mount."""
+        return f"{self.volume_path.rstrip('/')}/restored"
+
 
 @dataclass
 class Template:
@@ -137,6 +148,14 @@ class RestoreLog:
     error_message: Optional[str] = None
     logs: Optional[List[str]] = None
     restore_path: Optional[str] = None
+    backup_engine: Optional[str] = None
+    restore_mode: Optional[str] = None
+    stage: Optional[str] = None
+    last_heartbeat_at: Optional[str] = None
+    total_files: Optional[int] = None
+    processed_files: Optional[int] = None
+    total_bytes: Optional[int] = None
+    processed_bytes: Optional[int] = None
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.32"
+version = "0.0.33"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.34"
+version = "0.0.33"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.33"
+version = "0.0.34"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/test/test_backup_cli.py
+++ b/test/test_backup_cli.py
@@ -159,6 +159,32 @@ def test_bk_restore_prints_success(monkeypatch):
 
     assert result.exit_code == 0
     assert "Restore started for backup-test at /root/restore" in result.output
+    assert "Do not add, modify, or remove files in /root/restore" in result.output
+    assert "lium bk restore-logs backup-test" in result.output
+
+
+def test_bk_restore_uses_safe_default_subdirectory(monkeypatch):
+    pod = _pod()
+    pod.default_restore_path = "/root/restored"
+
+    class FakeLium:
+        def ps(self):
+            return [pod]
+
+        def restore(self, *, pod, backup_id, restore_path):
+            assert backup_id == "backup-123"
+            assert restore_path == "/root/restored"
+            return {"restore_log_id": "restore-123"}
+
+    _patch_backup_command(monkeypatch, restore_command, FakeLium)
+
+    result = CliRunner().invoke(
+        cli,
+        ["bk", "restore", "backup-test", "--id", "backup-123", "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert "Restore started for backup-test at /root/restored" in result.output
 
 
 def test_bk_restore_logs_by_id_prints_status_progress_path_and_error(monkeypatch):
@@ -192,6 +218,41 @@ def test_bk_restore_logs_by_id_prints_status_progress_path_and_error(monkeypatch
     assert "Restore Path: /root/restore" in result.output
     assert "Backup ID: 8fbb30f6-6026-4043-98c7-c4189dc09bef" in result.output
     assert "Error: Restore failed" in result.output
+
+
+def test_bk_restore_logs_show_preparation_progress(monkeypatch):
+    restore_log = SimpleNamespace(
+        id="9b6c8d90-1111-4222-9333-48b031f1f3eb",
+        backup_id="8fbb30f6-6026-4043-98c7-c4189dc09bef",
+        status="IN_PROGRESS",
+        progress=0,
+        restore_mode="STARTUP",
+        stage="PREPARING",
+        total_files=12_345,
+        processed_files=None,
+        total_bytes=None,
+        processed_bytes=None,
+        restore_path="/root/restored",
+        created_at="2026-05-14T12:00:00Z",
+        completed_at=None,
+        error_message=None,
+    )
+
+    class FakeLium:
+        def ps(self):
+            return [_pod()]
+
+        def restore_logs(self, pod):
+            return [restore_log]
+
+    _patch_backup_command(monkeypatch, restore_logs_command, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "restore-logs", "--id", "9b6c8d90"])
+
+    assert result.exit_code == 0
+    assert "Mode: STARTUP" in result.output
+    assert "Stage: Preparing" in result.output
+    assert "Work: 12,345 files discovered" in result.output
 
 
 def test_bk_show_warns_when_config_missing(monkeypatch):

--- a/test/test_backup_cli.py
+++ b/test/test_backup_cli.py
@@ -9,6 +9,7 @@ from lium.cli.bk.restore import command as restore_command
 from lium.cli.bk.rm import command as rm_command
 from lium.cli.bk.set import command as set_command
 from lium.cli.bk.show import command as show_command
+from lium.cli.bk import lifecycle as lifecycle_commands
 from lium.cli.cli import cli
 
 
@@ -55,7 +56,17 @@ def test_bk_set_prints_success(monkeypatch):
 
     result = CliRunner().invoke(
         cli,
-        ["bk", "set", "backup-test", "--path", "/root/data", "--every", "6h", "--keep", "7d"],
+        [
+            "bk",
+            "set",
+            "backup-test",
+            "--path",
+            "/root/data",
+            "--every",
+            "6h",
+            "--keep",
+            "7d",
+        ],
     )
 
     assert result.exit_code == 0
@@ -82,7 +93,15 @@ def test_bk_now_prints_backup_log_id(monkeypatch):
 
     result = CliRunner().invoke(
         cli,
-        ["bk", "now", "backup-test", "--name", "pre-deploy", "--description", "before release"],
+        [
+            "bk",
+            "now",
+            "backup-test",
+            "--name",
+            "pre-deploy",
+            "--description",
+            "before release",
+        ],
     )
 
     assert result.exit_code == 0
@@ -154,7 +173,16 @@ def test_bk_restore_prints_success(monkeypatch):
 
     result = CliRunner().invoke(
         cli,
-        ["bk", "restore", "backup-test", "--id", "backup-123", "--to", "/root/restore", "--yes"],
+        [
+            "bk",
+            "restore",
+            "backup-test",
+            "--id",
+            "backup-123",
+            "--to",
+            "/root/restore",
+            "--yes",
+        ],
     )
 
     assert result.exit_code == 0
@@ -270,3 +298,57 @@ def test_bk_show_warns_when_config_missing(monkeypatch):
 
     assert result.exit_code == 0
     assert "No backup configuration found for backup-test" in result.output
+
+
+def test_bk_cancel_keeps_history(monkeypatch):
+    calls = []
+
+    class FakeLium:
+        def backup_cancel(self, backup_id):
+            calls.append(backup_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "cancel", "--id", "backup-123", "--yes"])
+
+    assert result.exit_code == 0
+    assert calls == ["backup-123"]
+    assert "history and last reported progress" in result.output
+    assert "remain available" in result.output
+
+
+def test_bk_delete_removes_only_completed_backup_data(monkeypatch):
+    calls = []
+
+    class FakeLium:
+        def backup_log_delete(self, backup_id):
+            calls.append(backup_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "delete", "--id", "backup-123", "--yes"])
+
+    assert result.exit_code == 0
+    assert calls == ["backup-123"]
+    assert "Storage usage will update after cleanup finishes" in result.output
+
+
+def test_bk_restore_cancel_warns_about_partial_files(monkeypatch):
+    calls = []
+
+    class FakeLium:
+        def restore_cancel(self, restore_id):
+            calls.append(restore_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(
+        cli, ["bk", "restore-cancel", "--id", "restore-123", "--yes"]
+    )
+
+    assert result.exit_code == 0
+    assert calls == ["restore-123"]
+    assert "Partial files may remain" in result.output

--- a/test/test_backup_cli.py
+++ b/test/test_backup_cli.py
@@ -133,18 +133,22 @@ def test_bk_logs_by_id_prints_status_progress_and_error(monkeypatch):
 
     class FakeLium:
         def ps(self):
-            return [_pod()]
+            raise AssertionError("--id lookup must not depend on an active pod")
 
-        def backup_logs(self, pod):
-            assert pod.id == "pod-123"
-            return [backup_log]
+        def resolve_backup_id(self, backup_id):
+            assert backup_id == "8fbb30f6"
+            return backup_log.id
+
+        def backup_log(self, backup_id):
+            assert backup_id == backup_log.id
+            return backup_log
 
     _patch_backup_command(monkeypatch, logs_command, FakeLium)
 
     result = CliRunner().invoke(cli, ["bk", "logs", "--id", "8fbb30f6"])
 
     assert result.exit_code == 0
-    assert "Pod: backup-test" in result.output
+    assert "Backup ID: 8fbb30f6-6026-4043-98c7-c4189dc09bef" in result.output
     assert "Status: FAILED" in result.output
     assert "Progress: 30%" in result.output
     assert "Error: Backup upload failed" in result.output

--- a/test/test_backup_cli.py
+++ b/test/test_backup_cli.py
@@ -38,6 +38,9 @@ def _patch_backup_command(monkeypatch, command_module, fake_lium_cls):
 
 def test_bk_set_prints_success(monkeypatch):
     class FakeLium:
+        def __init__(self, source="sdk"):
+            assert source == "cli"
+
         def ps(self):
             return [_pod()]
 

--- a/test/test_backup_cli.py
+++ b/test/test_backup_cli.py
@@ -74,6 +74,16 @@ def test_bk_set_prints_success(monkeypatch):
     assert "path=/root/data, every=6h, keep=7d" in result.output
 
 
+def test_bk_set_requires_explicit_backup_path():
+    result = CliRunner().invoke(
+        cli,
+        ["bk", "set", "backup-test", "--every", "6h", "--keep", "7d"],
+    )
+
+    assert result.exit_code == 2
+    assert "Missing option '--path'" in result.output
+
+
 def test_bk_now_prints_backup_log_id(monkeypatch):
     class FakeLium:
         def ps(self):

--- a/test/test_backup_cli.py
+++ b/test/test_backup_cli.py
@@ -159,13 +159,19 @@ def test_bk_rm_prints_success(monkeypatch):
 
 
 def test_bk_restore_prints_success(monkeypatch):
+    full_backup_id = "8fbb30f6-6026-4043-98c7-c4189dc09bef"
+
     class FakeLium:
         def ps(self):
             return [_pod()]
 
+        def resolve_backup_id(self, backup_id):
+            assert backup_id == "8fbb30f6"
+            return full_backup_id
+
         def restore(self, *, pod, backup_id, restore_path):
             assert pod.id == "pod-123"
-            assert backup_id == "backup-123"
+            assert backup_id == full_backup_id
             assert restore_path == "/root/restore"
             return {"restore_log_id": "restore-123"}
 
@@ -178,7 +184,7 @@ def test_bk_restore_prints_success(monkeypatch):
             "restore",
             "backup-test",
             "--id",
-            "backup-123",
+            "8fbb30f6",
             "--to",
             "/root/restore",
             "--yes",
@@ -198,6 +204,9 @@ def test_bk_restore_uses_safe_default_subdirectory(monkeypatch):
     class FakeLium:
         def ps(self):
             return [pod]
+
+        def resolve_backup_id(self, backup_id):
+            return backup_id
 
         def restore(self, *, pod, backup_id, restore_path):
             assert backup_id == "backup-123"
@@ -304,6 +313,9 @@ def test_bk_cancel_keeps_history(monkeypatch):
     calls = []
 
     class FakeLium:
+        def resolve_backup_id(self, backup_id):
+            return backup_id
+
         def backup_cancel(self, backup_id):
             calls.append(backup_id)
             return {"success": True}
@@ -322,6 +334,9 @@ def test_bk_delete_removes_only_completed_backup_data(monkeypatch):
     calls = []
 
     class FakeLium:
+        def resolve_backup_id(self, backup_id):
+            return backup_id
+
         def backup_log_delete(self, backup_id):
             calls.append(backup_id)
             return {"success": True}
@@ -339,6 +354,9 @@ def test_bk_restore_cancel_warns_about_partial_files(monkeypatch):
     calls = []
 
     class FakeLium:
+        def resolve_restore_id(self, restore_id):
+            return restore_id
+
         def restore_cancel(self, restore_id):
             calls.append(restore_id)
             return {"success": True}
@@ -352,3 +370,47 @@ def test_bk_restore_cancel_warns_about_partial_files(monkeypatch):
     assert result.exit_code == 0
     assert calls == ["restore-123"]
     assert "Partial files may remain" in result.output
+
+
+def test_bk_cancel_resolves_displayed_short_id(monkeypatch):
+    calls = []
+    full_id = "8fbb30f6-6026-4043-98c7-c4189dc09bef"
+
+    class FakeLium:
+        def resolve_backup_id(self, backup_id):
+            assert backup_id == "8fbb30f6"
+            return full_id
+
+        def backup_cancel(self, backup_id):
+            calls.append(backup_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "cancel", "--id", "8fbb30f6", "--yes"])
+
+    assert result.exit_code == 0
+    assert calls == [full_id]
+
+
+def test_bk_restore_cancel_resolves_displayed_short_id(monkeypatch):
+    calls = []
+    full_id = "9b6c8d90-1111-4222-9333-48b031f1f3eb"
+
+    class FakeLium:
+        def resolve_restore_id(self, restore_id):
+            assert restore_id == "9b6c8d90"
+            return full_id
+
+        def restore_cancel(self, restore_id):
+            calls.append(restore_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(
+        cli, ["bk", "restore-cancel", "--id", "9b6c8d90", "--yes"]
+    )
+
+    assert result.exit_code == 0
+    assert calls == [full_id]

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -286,6 +286,7 @@ def test_resolve_backup_id_uses_paginated_backup_logs(monkeypatch):
     monkeypatch.setattr(client, "_request", lambda *args, **kwargs: Response())
 
     assert client.resolve_backup_id("8fbb30f6") == backup_id
+    assert client.resolve_backup_id("8FBB30F6") == backup_id
 
 
 def test_backup_log_uses_authenticated_single_log_endpoint(monkeypatch):
@@ -323,3 +324,4 @@ def test_resolve_restore_id_searches_active_pods(monkeypatch):
     )
 
     assert client.resolve_restore_id("9b6c8d90") == restore_id
+    assert client.resolve_restore_id("9B6C8D90") == restore_id

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from lium.sdk import Config, Lium, LiumPermissionError
@@ -41,3 +43,52 @@ def test_logs_403_raises_permission_error(monkeypatch):
 
     with pytest.raises(LiumPermissionError):
         list(client.logs("pod-1"))
+
+
+def test_restore_uses_pod_safe_default_path(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    captured = {}
+    pod = SimpleNamespace(id="pod-1", default_restore_path="/workspace/restored")
+
+    class Response:
+        def json(self):
+            return {"success": True}
+
+    def fake_request(method, endpoint, json=None, **kwargs):
+        captured.update(method=method, endpoint=endpoint, payload=json)
+        return Response()
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    client.restore(pod, backup_id="backup-123")
+
+    assert captured["endpoint"] == "/pods/pod-1/restore"
+    assert captured["payload"]["restore_path"] == "/workspace/restored"
+
+
+def test_restore_log_hydrates_progress_metadata():
+    client = Lium(Config(api_key="test"))
+
+    restore_log = client._dict_to_restore_log(
+        {
+            "id": "restore-1",
+            "backup_id": "backup-1",
+            "pod_id": "pod-1",
+            "status": "IN_PROGRESS",
+            "progress": 12.34,
+            "created_at": "2026-08-12T12:00:00Z",
+            "backup_engine": "RESTIC",
+            "restore_mode": "STARTUP",
+            "stage": "RESTORING",
+            "last_heartbeat_at": "2026-08-12T12:01:00Z",
+            "total_files": 100,
+            "processed_files": 25,
+            "total_bytes": 1_000,
+            "processed_bytes": 250,
+        }
+    )
+
+    assert restore_log.stage == "RESTORING"
+    assert restore_log.restore_mode == "STARTUP"
+    assert restore_log.processed_files == 25
+    assert restore_log.processed_bytes == 250

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from lium.sdk import Config, Lium, LiumPermissionError
+from lium.sdk import Config, Lium, LiumError, LiumPermissionError
 
 
 class _Forbidden:
@@ -30,7 +30,9 @@ def test_client_sets_version_header(monkeypatch):
 
 
 def test_request_403_raises_permission_error(monkeypatch):
-    monkeypatch.setattr("lium.sdk.client.requests.request", lambda *a, **kw: _Forbidden())
+    monkeypatch.setattr(
+        "lium.sdk.client.requests.request", lambda *a, **kw: _Forbidden()
+    )
     client = Lium(Config(api_key="test"))
 
     with pytest.raises(LiumPermissionError):
@@ -85,6 +87,9 @@ def test_restore_log_hydrates_progress_metadata():
             "processed_files": 25,
             "total_bytes": 1_000,
             "processed_bytes": 250,
+            "elapsed_seconds": 12,
+            "throughput_bytes_per_second": 20,
+            "estimated_remaining_seconds": 38,
         }
     )
 
@@ -92,3 +97,56 @@ def test_restore_log_hydrates_progress_metadata():
     assert restore_log.restore_mode == "STARTUP"
     assert restore_log.processed_files == 25
     assert restore_log.processed_bytes == 250
+    assert restore_log.elapsed_seconds == 12
+    assert restore_log.estimated_remaining_seconds == 38
+
+
+def test_backup_and_restore_lifecycle_methods_use_distinct_endpoints(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    calls = []
+
+    class Response:
+        def json(self):
+            return {"success": True}
+
+    def fake_request(method, endpoint, **kwargs):
+        calls.append((method, endpoint))
+        return Response()
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    client.backup_cancel("backup-1")
+    client.backup_log_delete("backup-1")
+    client.restore_cancel("restore-1")
+
+    assert calls == [
+        ("POST", "/backup-logs/backup-1/cancel"),
+        ("DELETE", "/backup-logs/backup-1"),
+        ("POST", "/restore-logs/restore-1/cancel"),
+    ]
+
+
+def test_structured_busy_error_is_readable(monkeypatch):
+    class ConflictResponse:
+        ok = False
+        status_code = 409
+        text = ""
+
+        def json(self):
+            return {
+                "detail": {
+                    "code": "BACKUP_STORAGE_BUSY",
+                    "message": "Another backup or restore is already running",
+                    "active_operation_id": "active-123",
+                }
+            }
+
+    monkeypatch.setattr(
+        "lium.sdk.client.requests.request", lambda *args, **kwargs: ConflictResponse()
+    )
+    client = Lium(Config(api_key="test"))
+
+    with pytest.raises(
+        LiumError, match="Another backup or restore is already running.*active-123"
+    ):
+        client._request("POST", "/pods/pod-1/backup")

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -288,6 +288,29 @@ def test_resolve_backup_id_uses_paginated_backup_logs(monkeypatch):
     assert client.resolve_backup_id("8fbb30f6") == backup_id
 
 
+def test_backup_log_uses_authenticated_single_log_endpoint(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    backup_id = "8fbb30f6-6026-4043-98c7-c4189dc09bef"
+    request = SimpleNamespace()
+
+    class Response:
+        def json(self):
+            return {"id": backup_id, "status": "COMPLETED"}
+
+    def fake_request(method, endpoint, **kwargs):
+        request.method = method
+        request.endpoint = endpoint
+        return Response()
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    backup_log = client.backup_log(backup_id)
+
+    assert request.method == "GET"
+    assert request.endpoint == f"/backup-logs/{backup_id}"
+    assert backup_log.id == backup_id
+
+
 def test_resolve_restore_id_searches_active_pods(monkeypatch):
     client = Lium(Config(api_key="test"))
     restore_id = "9b6c8d90-1111-4222-9333-48b031f1f3eb"

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -68,6 +68,51 @@ def test_restore_uses_pod_safe_default_path(monkeypatch):
     assert captured["payload"]["restore_path"] == "/workspace/restored"
 
 
+def test_backup_create_requires_explicit_path():
+    client = Lium(Config(api_key="test"))
+    pod = SimpleNamespace(id="pod-1", volume_path="/root")
+
+    with pytest.raises(TypeError, match="path"):
+        client.backup_create(pod)
+
+
+def test_backup_create_warns_for_explicit_whole_volume(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    pod = SimpleNamespace(id="pod-1", volume_path="/root")
+    captured = {}
+
+    class Response:
+        def json(self):
+            return {
+                "id": "config-1",
+                "huid": "config-huid",
+                "pod_executor_id": "pod-1",
+                "backup_frequency_hours": 6,
+                "retention_days": 7,
+                "backup_path": "/root",
+            }
+
+    def fake_request(method, endpoint, json=None, **kwargs):
+        captured.update(method=method, endpoint=endpoint, payload=json)
+        return Response()
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    with pytest.warns(UserWarning, match="entire volume"):
+        client.backup_create(pod, path="/root")
+
+    assert captured == {
+        "method": "POST",
+        "endpoint": "/backup-configs",
+        "payload": {
+            "pod_id": "pod-1",
+            "backup_frequency_hours": 6,
+            "retention_days": 7,
+            "backup_path": "/root",
+        },
+    }
+
+
 def test_restore_log_hydrates_progress_metadata():
     client = Lium(Config(api_key="test"))
 

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -1,3 +1,4 @@
+import warnings
 from types import SimpleNamespace
 
 import pytest
@@ -113,6 +114,30 @@ def test_backup_create_warns_for_explicit_whole_volume(monkeypatch):
     }
 
 
+def test_backup_create_skips_sdk_warning_for_cli_callers(monkeypatch):
+    client = Lium(Config(api_key="test"), source="cli")
+    pod = SimpleNamespace(id="pod-1", volume_path="/root")
+
+    class Response:
+        def json(self):
+            return {
+                "id": "config-1",
+                "huid": "config-huid",
+                "pod_executor_id": "pod-1",
+                "backup_frequency_hours": 6,
+                "retention_days": 7,
+                "backup_path": "/root",
+            }
+
+    monkeypatch.setattr(client, "_request", lambda *args, **kwargs: Response())
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        client.backup_create(pod, path="/root")
+
+    assert caught_warnings == []
+
+
 def test_restore_log_hydrates_progress_metadata():
     client = Lium(Config(api_key="test"))
 
@@ -219,6 +244,35 @@ def test_structured_message_error_is_readable(monkeypatch):
 
     with pytest.raises(LiumError, match="This backup is no longer active"):
         client._request("POST", "/backup-logs/8fbb30f6/cancel")
+
+
+def test_validation_error_includes_field_and_reason(monkeypatch):
+    class ValidationResponse:
+        ok = False
+        status_code = 422
+        text = ""
+
+        def json(self):
+            return {
+                "message": "Request validation failed",
+                "validation_errors": [
+                    {
+                        "field": "body -> backup_log_id",
+                        "message": "Input should be a valid UUID",
+                        "type": "uuid_parsing",
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(
+        "lium.sdk.client.requests.request", lambda *args, **kwargs: ValidationResponse()
+    )
+    client = Lium(Config(api_key="test"))
+
+    with pytest.raises(
+        LiumError, match="body -> backup_log_id: Input should be a valid UUID"
+    ):
+        client._request("POST", "/executors/executor-1/rent")
 
 
 def test_resolve_backup_id_uses_paginated_backup_logs(monkeypatch):

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -150,3 +150,54 @@ def test_structured_busy_error_is_readable(monkeypatch):
         LiumError, match="Another backup or restore is already running.*active-123"
     ):
         client._request("POST", "/pods/pod-1/backup")
+
+
+def test_structured_message_error_is_readable(monkeypatch):
+    class ConflictResponse:
+        ok = False
+        status_code = 409
+        text = ""
+
+        def json(self):
+            return {
+                "message": {
+                    "code": "BACKUP_NOT_ACTIVE",
+                    "message": "This backup is no longer active",
+                    "current_status": "COMPLETED",
+                }
+            }
+
+    monkeypatch.setattr(
+        "lium.sdk.client.requests.request", lambda *args, **kwargs: ConflictResponse()
+    )
+    client = Lium(Config(api_key="test"))
+
+    with pytest.raises(LiumError, match="This backup is no longer active"):
+        client._request("POST", "/backup-logs/8fbb30f6/cancel")
+
+
+def test_resolve_backup_id_uses_paginated_backup_logs(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    backup_id = "8fbb30f6-6026-4043-98c7-c4189dc09bef"
+
+    class Response:
+        def json(self):
+            return {"items": [{"id": backup_id}], "has_next": False}
+
+    monkeypatch.setattr(client, "_request", lambda *args, **kwargs: Response())
+
+    assert client.resolve_backup_id("8fbb30f6") == backup_id
+
+
+def test_resolve_restore_id_searches_active_pods(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    restore_id = "9b6c8d90-1111-4222-9333-48b031f1f3eb"
+    pod = SimpleNamespace(id="pod-1")
+    monkeypatch.setattr(client, "ps", lambda: [pod])
+    monkeypatch.setattr(
+        client,
+        "restore_logs",
+        lambda candidate: [SimpleNamespace(id=restore_id)] if candidate is pod else [],
+    )
+
+    assert client.resolve_restore_id("9b6c8d90") == restore_id

--- a/test/test_up_dockerfile.py
+++ b/test/test_up_dockerfile.py
@@ -126,6 +126,42 @@ def test_up_sends_volume_encryption_preference(monkeypatch, enabled, expected):
     assert captured["payload"]["enable_volume_encryption"] is expected
 
 
+def test_up_sends_startup_restore(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    captured: dict = {}
+    _stub_up(monkeypatch, client, captured)
+
+    client.up(
+        executor_id="exec-1",
+        ssh_keys=["ssh-ed25519 AAA"],
+        backup_id="backup-123",
+        restore_path="/root/restored",
+    )
+
+    assert captured["payload"]["backup_log_id"] == "backup-123"
+    assert captured["payload"]["restore_path"] == "/root/restored"
+
+
+@pytest.mark.parametrize(
+    ("backup_id", "restore_path"),
+    [("backup-123", None), (None, "/root/restored")],
+)
+def test_up_requires_complete_startup_restore_pair(monkeypatch, backup_id, restore_path):
+    client = Lium(Config(api_key="test"))
+    captured: dict = {}
+    _stub_up(monkeypatch, client, captured)
+
+    with pytest.raises(ValueError, match="must be provided together"):
+        client.up(
+            executor_id="exec-1",
+            ssh_keys=["ssh-ed25519 AAA"],
+            backup_id=backup_id,
+            restore_path=restore_path,
+        )
+
+    assert "payload" not in captured
+
+
 def test_ps_hydrates_volume_encryption_outcome(monkeypatch):
     client = Lium(Config(api_key="test"))
     response = SimpleNamespace(
@@ -174,6 +210,29 @@ def test_up_command_exposes_volume_encryption_flag():
     assert result.exit_code == 0
     assert "--volume-encryption" in result.output
     assert "--no-volume-encryption" in result.output
+
+
+def test_up_command_exposes_startup_restore_flags():
+    result = CliRunner().invoke(up_command.up_command, ["--help"])
+    assert result.exit_code == 0
+    assert "--restore-backup" in result.output
+    assert "--restore-to" in result.output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["node-1", "--restore-backup", "backup-123"],
+        ["node-1", "--restore-to", "/root/restored"],
+    ],
+)
+def test_up_command_requires_complete_startup_restore_pair(monkeypatch, args):
+    monkeypatch.setattr(up_command, "ensure_config", lambda: None)
+
+    result = CliRunner().invoke(up_command.up_command, args)
+
+    assert result.exit_code == 2
+    assert "--restore-backup and --restore-to must be provided together" in result.output
 
 
 def test_validate_rejects_dockerfile_with_image():
@@ -234,6 +293,30 @@ def test_rent_pod_action_passes_dockerfile_content_and_no_template():
     assert captured["executor_id"] == "exec-1"
 
 
+def test_rent_pod_action_passes_startup_restore():
+    captured: dict = {}
+
+    class FakeLium:
+        def up(self, **kwargs):
+            captured.update(kwargs)
+            return {"id": "pod-1", "name": kwargs["name"]}
+
+    result = RentPodAction().execute(
+        {
+            "lium": FakeLium(),
+            "executor": SimpleNamespace(id="exec-1", huid="brave-fox-3a"),
+            "template": SimpleNamespace(id="template-1"),
+            "name": "restored-pod",
+            "backup_id": "backup-123",
+            "restore_path": "/root/restored",
+        }
+    )
+
+    assert result.ok
+    assert captured["backup_id"] == "backup-123"
+    assert captured["restore_path"] == "/root/restored"
+
+
 # --------------------------------------------------------------------------- #
 # CLI: full `lium up --dockerfile` path reads the file and forwards its content
 # --------------------------------------------------------------------------- #
@@ -285,7 +368,16 @@ def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path)
     # Act
     result = CliRunner().invoke(
         up_command.up_command,
-        ["brave-fox-3a", "--dockerfile", str(dockerfile), "--yes"],
+        [
+            "brave-fox-3a",
+            "--dockerfile",
+            str(dockerfile),
+            "--restore-backup",
+            "backup-123",
+            "--restore-to",
+            "/root/restored",
+            "--yes",
+        ],
     )
 
     # Assert
@@ -293,6 +385,10 @@ def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path)
     assert "ctx" in captured, "RentPodAction was never reached"
     assert captured["ctx"]["dockerfile_content"] == dockerfile_text
     assert captured["ctx"]["template"] is None
+    assert captured["ctx"]["backup_id"] == "backup-123"
+    assert captured["ctx"]["restore_path"] == "/root/restored"
+    assert "Restore is continuing in /root/restored" in result.output
+    assert "Do not modify that directory" in result.output
 
 
 def test_up_command_rejects_dockerfile_with_image(monkeypatch, tmp_path):

--- a/test/test_up_dockerfile.py
+++ b/test/test_up_dockerfile.py
@@ -329,6 +329,8 @@ def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path)
     dockerfile.write_text(dockerfile_text)
 
     captured: dict = {}
+    short_backup_id = "8fbb30f6"
+    full_backup_id = "8fbb30f6-6026-4043-98c7-c4189dc09bef"
     executor = SimpleNamespace(
         id="exec-1",
         huid="brave-fox-3a",
@@ -339,6 +341,11 @@ def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path)
         download_speed=1000,
     )
     pod = SimpleNamespace(id="pod-1", name="custom-pod", huid="brave-fox-3a")
+
+    class _FakeLium:
+        def resolve_backup_id(self, backup_id):
+            assert backup_id == short_backup_id
+            return full_backup_id
 
     class _FakeResolveExecutor:
         def execute(self, ctx):
@@ -358,7 +365,7 @@ def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path)
             return ActionResult(ok=True, data={"ssh_cmd": "ssh root@host -p 22", "pod": pod})
 
     monkeypatch.setattr(up_command, "ensure_config", lambda: None)
-    monkeypatch.setattr(up_command, "Lium", lambda **kwargs: SimpleNamespace())
+    monkeypatch.setattr(up_command, "Lium", lambda **kwargs: _FakeLium())
     monkeypatch.setattr(up_command, "ResolveExecutorAction", _FakeResolveExecutor)
     monkeypatch.setattr(up_command, "RentPodAction", _FakeRentPod)
     monkeypatch.setattr(up_command, "WaitReadyAction", _FakeWaitReady)
@@ -373,7 +380,7 @@ def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path)
             "--dockerfile",
             str(dockerfile),
             "--restore-backup",
-            "backup-123",
+            short_backup_id,
             "--restore-to",
             "/root/restored",
             "--yes",
@@ -385,11 +392,10 @@ def test_up_command_reads_dockerfile_and_forwards_content(monkeypatch, tmp_path)
     assert "ctx" in captured, "RentPodAction was never reached"
     assert captured["ctx"]["dockerfile_content"] == dockerfile_text
     assert captured["ctx"]["template"] is None
-    assert captured["ctx"]["backup_id"] == "backup-123"
+    assert captured["ctx"]["backup_id"] == full_backup_id
     assert captured["ctx"]["restore_path"] == "/root/restored"
     assert "Restore is continuing in /root/restored" in result.output
     assert "Do not modify that directory" in result.output
-
 
 def test_up_command_rejects_dockerfile_with_image(monkeypatch, tmp_path):
     dockerfile = tmp_path / "Dockerfile"

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.32"
+version = "0.0.33"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.34"
+version = "0.0.33"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.33"
+version = "0.0.34"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Complete the CLI/SDK portion of parent task DAH-2640 in one release. This consolidates the restore-alignment and backup-lifecycle client work that was previously split across DAH-2639 and DAH-2641.

- use safe restore subdirectories for online and startup restores
- add backup cancellation, completed-backup deletion, and restore cancellation
- expose backup/restore lifecycle states and useful transfer metrics
- accept the eight-character IDs displayed by CLI history commands
- keep backup history accessible after the source pod is deleted
- require explicit backup paths instead of silently choosing a whole volume
- show readable structured API conflicts and practical path warnings
- bump the CLI/SDK package from `0.0.32` to `0.0.33`

## Background

The backend now requires restores to target a new or empty subdirectory rather than the volume root. Startup restores begin after the pod reaches `RUNNING`, while Backup V2 exposes separate cancellation and deletion operations, skipped scheduled attempts, richer progress data, and structured lifecycle conflicts.

The existing CLI/SDK still defaulted restores to `/root`, could not request startup restores or lifecycle actions, omitted most progress fields, and displayed shortened IDs that could not always be reused. `lium bk logs --id` also searched only currently active pods, making retained backup history inaccessible after its source pod was deleted. Backup configuration silently defaulted to a whole-volume path. This PR aligns the complete client contract in one release.

## CLI changes

- `lium bk restore POD --id BACKUP_ID` defaults to `<pod volume>/restored`; callers can still provide a different new or empty subdirectory with `--to`.
- `lium up` accepts `--restore-backup BACKUP_ID --restore-to PATH` for restore during pod creation.
- Online and startup restore commands warn users not to modify the destination until the restore finishes.
- Add `lium bk cancel --id BACKUP_ID` to cancel an active backup while retaining its history and last progress.
- Add `lium bk delete --id BACKUP_ID` to delete stored data for a completed backup as a separate destructive action.
- Add `lium bk restore-cancel --id RESTORE_ID`, including a warning that already-written files may remain.
- Backup and restore history display lifecycle status, stage, precise percentage, bytes/files, throughput, elapsed time, and backend-provided ETA when applicable.
- `lium bk logs --id` resolves the displayed short ID globally within the authenticated user's history and fetches the owner-checked record directly, so it works after pod deletion.
- Single-backup history output identifies the backup instead of requiring a live pod name.
- Terminal restore output suppresses active-stage and remaining-time information.
- Cancelled, skipped, deleted, failed, and completed outcomes are visually distinct.
- `lium bk set` now requires `--path`; selecting the whole volume remains allowed and produces a reliability warning.
- Structured backend errors render as readable messages rather than raw dictionaries.
- Cancel, delete, restore, restore-cancel, and backup-log lookup accept the eight-character identifiers printed by the CLI, while full UUIDs continue to work.

## SDK changes

- Extend `Lium.up()` with `backup_id` and `restore_path` for startup restore requests.
- Default `Lium.restore()` to `<pod volume>/restored`.
- Require an explicit path in `backup_create()`; selecting the whole volume remains supported with a warning.
- Add `backup_cancel()`, `backup_log_delete()`, `restore_cancel()`, and owner-checked single-backup retrieval.
- Add backup/restore short-ID resolution, including paginated backup history lookup and ambiguity handling.
- Add `PodInfo.volume_path` and `PodInfo.default_restore_path`.
- Hydrate backup and restore models with lifecycle stage, byte/file counters, throughput, elapsed time, ETA, deletion state, cleanup time, status messages, restore mode, and heartbeat data.
- Parse structured errors from both backend response envelopes and include the active operation ID when supplied.

## Compatibility and safety

- Explicit restore requests targeting `/root` remain rejected by the backend rather than being silently redirected.
- Startup restore requires both the backup ID and destination so a partial request cannot create an ambiguous rental.
- Cancellation preserves history; deletion remains a separate action for completed backup data.
- Requiring an explicit backup path prevents new callers from accidentally selecting a whole volume; explicit whole-volume backup remains supported.
- Backup-log lookup remains authenticated and user-scoped by the backend; another user's backup UUID returns 404.
- No database, IAM, secret, or infrastructure changes are included in this PR.

## Validation

- Latest focused backup CLI and SDK client suites: **30 passed**.
- Earlier combined CLI/SDK backup suite: **51 passed**.
- Live staging check: `lium bk logs --id 1530fdcb` returned a retained completed 2.3 GiB/20,003-file backup after its source pod had been deleted.
- `uv lock --check` — passed previously.
- `uv run lium --version` — `lium, version 0.0.33`.
- `git diff --check` — passed.

Staging validation used real encrypted and plain pods and covered online/startup restore, cancellation, deletion, incremental backups, scheduled overlap/catch-up, precise progress, short-ID lifecycle actions, and restored integrity/metadata.

Related API and webapp changes are tracked in:

- Parent task: https://app.notion.com/p/3b8b8bfdbde981259ae5fa1155239ae1
- Backend: https://github.com/Datura-ai/lium-io-backend/pull/908
- Validator/executor: https://github.com/Datura-ai/lium-io/pull/1226
- Frontend: https://github.com/Datura-ai/lium-io-frontend/pull/240
