### PR TITLE
DAH-2641, add backup lifecycle CLI and SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ The `lium` CLI exposes the full pod lifecycle. Run `lium --help` to see everythi
 - `lium bk set <POD> <PATH>` - Configure automatic backups
 - `lium bk logs <POD>` - View backup logs
 - `lium bk now <POD>` - Trigger immediate backup
-- `lium bk restore <POD> <BACKUP_ID>` - Restore from backup
+- `lium bk cancel --id <BACKUP_ID>` - Cancel an active backup and retain its history
+- `lium bk delete --id <BACKUP_ID>` - Delete stored data for a completed backup
+- `lium bk restore <POD> --id <BACKUP_ID>` - Restore from backup
+- `lium bk restore-cancel --id <RESTORE_ID>` - Cancel an active restore
 - `lium bk rm <POD>` - Remove backup configuration
 
 ### Schedule Commands
@@ -286,7 +289,10 @@ lium bk show my-pod
 lium bk set my-pod /root/data --frequency 24 --retention 7
 lium bk logs my-pod
 lium bk now my-pod --name manual-backup
-lium bk restore my-pod <BACKUP_ID> /root/restore
+lium bk cancel --id <BACKUP_ID>
+lium bk delete --id <BACKUP_ID>
+lium bk restore my-pod --id <BACKUP_ID> --to /root/restore
+lium bk restore-cancel --id <RESTORE_ID>
 lium bk rm my-pod
 
 # Manage schedules

--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.33"
+__version__ = "0.0.34"

--- a/lium/cli/bk/__init__.py
+++ b/lium/cli/bk/__init__.py
@@ -9,6 +9,7 @@ from .now.command import bk_now_command
 from .logs.command import bk_logs_command
 from .restore_logs.command import bk_restore_logs_command
 from .restore.command import bk_restore_command
+from .lifecycle import bk_cancel_command, bk_delete_command, bk_restore_cancel_command
 
 
 @click.group()
@@ -24,5 +25,8 @@ bk_command.add_command(bk_now_command)
 bk_command.add_command(bk_logs_command)
 bk_command.add_command(bk_restore_logs_command)
 bk_command.add_command(bk_restore_command)
+bk_command.add_command(bk_cancel_command)
+bk_command.add_command(bk_delete_command)
+bk_command.add_command(bk_restore_cancel_command)
 
 __all__ = ["bk_command"]

--- a/lium/cli/bk/lifecycle.py
+++ b/lium/cli/bk/lifecycle.py
@@ -18,7 +18,13 @@ def bk_cancel_command(backup_id: str, yes: bool) -> None:
         return
 
     client = Lium()
-    ui.load("Requesting backup cancellation", lambda: client.backup_cancel(backup_id))
+    resolved_backup_id = ui.load(
+        "Resolving backup ID", lambda: client.resolve_backup_id(backup_id)
+    )
+    ui.load(
+        "Requesting backup cancellation",
+        lambda: client.backup_cancel(resolved_backup_id),
+    )
     ui.success(
         "Backup cancellation requested. Its history and last reported progress will remain available."
     )
@@ -37,7 +43,12 @@ def bk_delete_command(backup_id: str, yes: bool) -> None:
         return
 
     client = Lium()
-    ui.load("Starting backup deletion", lambda: client.backup_log_delete(backup_id))
+    resolved_backup_id = ui.load(
+        "Resolving backup ID", lambda: client.resolve_backup_id(backup_id)
+    )
+    ui.load(
+        "Starting backup deletion", lambda: client.backup_log_delete(resolved_backup_id)
+    )
     ui.success(
         "Backup deletion started. Storage usage will update after cleanup finishes."
     )
@@ -56,8 +67,12 @@ def bk_restore_cancel_command(restore_id: str, yes: bool) -> None:
         return
 
     client = Lium()
+    resolved_restore_id = ui.load(
+        "Resolving restore ID", lambda: client.resolve_restore_id(restore_id)
+    )
     ui.load(
-        "Requesting restore cancellation", lambda: client.restore_cancel(restore_id)
+        "Requesting restore cancellation",
+        lambda: client.restore_cancel(resolved_restore_id),
     )
     ui.success(
         "Restore cancellation requested. Partial files may remain in the restore directory."

--- a/lium/cli/bk/lifecycle.py
+++ b/lium/cli/bk/lifecycle.py
@@ -1,0 +1,64 @@
+"""Backup and restore lifecycle commands."""
+
+import click
+
+from lium.cli import ui
+from lium.cli.utils import ensure_config, handle_errors
+from lium.sdk import Lium
+
+
+@click.command("cancel")
+@click.option("--id", "backup_id", required=True, help="Active backup ID")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@handle_errors
+def bk_cancel_command(backup_id: str, yes: bool) -> None:
+    """Cancel an active backup and keep its history."""
+    ensure_config()
+    if not yes and not ui.confirm(f"Cancel backup '{backup_id}'?"):
+        return
+
+    client = Lium()
+    ui.load("Requesting backup cancellation", lambda: client.backup_cancel(backup_id))
+    ui.success(
+        "Backup cancellation requested. Its history and last reported progress will remain available."
+    )
+
+
+@click.command("delete")
+@click.option("--id", "backup_id", required=True, help="Completed backup ID")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@handle_errors
+def bk_delete_command(backup_id: str, yes: bool) -> None:
+    """Delete stored data for a completed backup."""
+    ensure_config()
+    if not yes and not ui.confirm(
+        f"Delete backup '{backup_id}'? This cannot be undone."
+    ):
+        return
+
+    client = Lium()
+    ui.load("Starting backup deletion", lambda: client.backup_log_delete(backup_id))
+    ui.success(
+        "Backup deletion started. Storage usage will update after cleanup finishes."
+    )
+
+
+@click.command("restore-cancel")
+@click.option("--id", "restore_id", required=True, help="Active restore ID")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@handle_errors
+def bk_restore_cancel_command(restore_id: str, yes: bool) -> None:
+    """Cancel an active restore."""
+    ensure_config()
+    if not yes and not ui.confirm(
+        f"Cancel restore '{restore_id}'? Files already written to the restore directory may remain."
+    ):
+        return
+
+    client = Lium()
+    ui.load(
+        "Requesting restore cancellation", lambda: client.restore_cancel(restore_id)
+    )
+    ui.success(
+        "Restore cancellation requested. Partial files may remain in the restore directory."
+    )

--- a/lium/cli/bk/logs/display.py
+++ b/lium/cli/bk/logs/display.py
@@ -2,45 +2,96 @@ from datetime import datetime
 from rich.table import Table
 
 
+def _format_status(status: str) -> str:
+    status_upper = status.upper()
+    if status_upper == "COMPLETED":
+        return f"[green]{status}[/green]"
+    if status_upper in {"FAILED", "ERROR"}:
+        return f"[red]{status}[/red]"
+    if status_upper in {"CANCELLED", "SKIPPED", "EXPIRED", "DELETED"}:
+        return f"[dim]{status}[/dim]"
+    return f"[yellow]{status}[/yellow]"
+
+
+def _format_progress(value: float | None) -> str:
+    if value is None:
+        return ""
+    return f"{value:.2f}".rstrip("0").rstrip(".") + "%"
+
+
+def _format_bytes(value: int) -> str:
+    size = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if size < 1024 or unit == "TiB":
+            return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} B"
+        size /= 1024
+    return f"{value} B"
+
+
+def _format_duration(seconds: int | None) -> str:
+    if seconds is None:
+        return ""
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, remaining_seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m {remaining_seconds}s"
+    hours, remaining_minutes = divmod(minutes, 60)
+    return f"{hours}h {remaining_minutes}m"
+
+
+def _format_work(log) -> str:
+    details = []
+    processed_bytes = getattr(log, "processed_bytes", None)
+    total_bytes = getattr(log, "total_bytes", None)
+    if processed_bytes is not None and total_bytes is not None:
+        details.append(f"{_format_bytes(processed_bytes)}/{_format_bytes(total_bytes)}")
+    processed_files = getattr(log, "processed_files", None)
+    total_files = getattr(log, "total_files", None)
+    if processed_files is not None and total_files is not None:
+        details.append(f"{processed_files:,}/{total_files:,} files")
+    throughput = getattr(log, "throughput_bytes_per_second", None)
+    if throughput:
+        details.append(f"{_format_bytes(throughput)}/s")
+    remaining = getattr(log, "estimated_remaining_seconds", None)
+    if remaining:
+        details.append(f"~{_format_duration(remaining)} left")
+    return ", ".join(details)
+
+
 def format_logs_table(logs: list) -> Table:
     """Format logs as a table."""
-    table = Table(
-        show_header=True,
-        header_style="dim",
-        box=None,
-        padding=(0, 2)
-    )
+    table = Table(show_header=True, header_style="dim", box=None, padding=(0, 2))
 
     table.add_column("#", style="dim")
     table.add_column("Backup ID", style="cyan")
     table.add_column("Status")
     table.add_column("Progress", justify="right")
     table.add_column("Created")
-    table.add_column("Error")
+    table.add_column("Work")
+    table.add_column("Details")
 
     for idx, log in enumerate(logs, 1):
-        backup_id_full = getattr(log, 'id', 'unknown')
-        status = getattr(log, 'status', 'Unknown')
+        backup_id_full = getattr(log, "id", "unknown")
+        status = getattr(log, "status", "Unknown")
 
-        # Color status
-        if status.upper() == 'COMPLETED':
-            status = f"[green]{status}[/green]"
-        elif status.upper() in ['FAILED', 'ERROR']:
-            status = f"[red]{status}[/red]"
-        else:
-            status = f"[yellow]{status}[/yellow]"
+        status = _format_status(status)
 
-        created = getattr(log, 'created_at', 'Unknown')
-        if created != 'Unknown':
+        created = getattr(log, "created_at", "Unknown")
+        if created != "Unknown":
             try:
-                dt = datetime.fromisoformat(created.replace('Z', '+00:00'))
-                created = dt.strftime('%Y-%m-%d %H:%M')
+                dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+                created = dt.strftime("%Y-%m-%d %H:%M")
             except:
                 pass
 
-        progress = getattr(log, 'progress', None)
-        progress_text = f"{progress:.0f}%" if progress is not None else ""
-        error = getattr(log, 'error_message', None) or ""
+        progress = getattr(log, "progress", None)
+        progress_text = _format_progress(progress)
+        details = (
+            getattr(log, "error_message", None)
+            or getattr(log, "status_message", None)
+            or ""
+        )
 
         table.add_row(
             str(idx),
@@ -48,7 +99,8 @@ def format_logs_table(logs: list) -> Table:
             status,
             progress_text,
             created,
-            error
+            _format_work(log),
+            details,
         )
 
     return table
@@ -58,19 +110,25 @@ def format_single_backup(pod_name: str, log) -> str:
     """Format single backup details."""
     lines = [f"Pod: {pod_name}"]
     lines.append(f"Status: {getattr(log, 'status', 'Unknown')}")
-    progress = getattr(log, 'progress', None)
+    progress = getattr(log, "progress", None)
     if progress is not None:
-        lines.append(f"Progress: {progress:.0f}%")
+        lines.append(f"Progress: {_format_progress(progress)}")
     lines.append(f"Created: {getattr(log, 'created_at', 'Unknown')}")
 
-    if hasattr(log, 'completed_at') and log.completed_at:
+    if hasattr(log, "completed_at") and log.completed_at:
         lines.append(f"Completed: {log.completed_at}")
 
-    if hasattr(log, 'size_bytes') and log.size_bytes:
-        size_mb = log.size_bytes / (1024 * 1024)
-        lines.append(f"Size: {size_mb:.2f} MB")
+    work = _format_work(log)
+    if work:
+        lines.append(f"Work: {work}")
 
-    if hasattr(log, 'error_message') and log.error_message:
+    elapsed = getattr(log, "elapsed_seconds", None)
+    if elapsed is not None:
+        lines.append(f"Elapsed: {_format_duration(elapsed)}")
+
+    if hasattr(log, "error_message") and log.error_message:
         lines.append(f"Error: {log.error_message}")
+    elif getattr(log, "status_message", None):
+        lines.append(f"Details: {log.status_message}")
 
     return "\n".join(lines)

--- a/lium/cli/bk/now/actions.py
+++ b/lium/cli/bk/now/actions.py
@@ -13,16 +13,14 @@ class TriggerBackupAction:
         description: str = ctx["description"]
 
         # Check if backup config exists
-        backup_config = lium.backup_config(pod)
+        backup_config = ctx.get("backup_config") or lium.backup_config(pod)
 
         if not backup_config:
-            return ActionResult(ok=False, data={}, error="No backup configuration found")
+            return ActionResult(
+                ok=False, data={}, error="No backup configuration found"
+            )
 
         # Trigger backup
-        backup_result = lium.backup_now(
-            pod=pod,
-            name=name,
-            description=description
-        )
+        backup_result = lium.backup_now(pod=pod, name=name, description=description)
 
         return ActionResult(ok=True, data={"backup": backup_result})

--- a/lium/cli/bk/now/command.py
+++ b/lium/cli/bk/now/command.py
@@ -16,6 +16,7 @@ from lium.cli.utils import (
 )
 from . import validation, parsing
 from .actions import TriggerBackupAction
+from ..path_warning import entire_volume_backup_warning
 
 
 @click.command("now")
@@ -48,6 +49,18 @@ def bk_now_command(pod_id: str, name: Optional[str], description: Optional[str])
     pod_name = parsed.get("pod_name")
     backup_name = parsed.get("name")
     backup_description = parsed.get("description")
+    backup_config = ui.load(
+        "Loading backup configuration", lambda: lium.backup_config(pod)
+    )
+    if not backup_config:
+        raise CliFailure(
+            "no_backup_config", "No backup configuration found", EXIT_GENERAL_ERROR
+        )
+    path_warning = entire_volume_backup_warning(
+        pod, getattr(backup_config, "backup_path", "")
+    )
+    if path_warning:
+        ui.warning(path_warning)
 
     # Execute
     ctx = {
@@ -55,7 +68,8 @@ def bk_now_command(pod_id: str, name: Optional[str], description: Optional[str])
         "pod": pod,
         "pod_name": pod_name,
         "name": backup_name,
-        "description": backup_description
+        "description": backup_description,
+        "backup_config": backup_config,
     }
 
     action = TriggerBackupAction()

--- a/lium/cli/bk/path_warning.py
+++ b/lium/cli/bk/path_warning.py
@@ -1,0 +1,15 @@
+"""Backup path warnings shared by backup commands."""
+
+
+def entire_volume_backup_warning(pod, backup_path: str) -> str | None:
+    volume_path = getattr(pod, "volume_path", None)
+    if not volume_path:
+        volumes = (getattr(pod, "template", None) or {}).get("volumes", [])
+        volume_path = volumes[0] if volumes else "/root"
+
+    if not backup_path or backup_path.rstrip("/") == volume_path.rstrip("/"):
+        return (
+            "This backs up the entire volume. For more reliable backups, prefer a stable subdirectory "
+            "that is not being actively changed."
+        )
+    return None

--- a/lium/cli/bk/restore/actions.py
+++ b/lium/cli/bk/restore/actions.py
@@ -12,6 +12,9 @@ class RestoreBackupAction:
         backup_id: str = ctx["backup_id"]
         restore_path: str = ctx["restore_path"]
 
-        restore_result = lium.restore(pod=pod, backup_id=backup_id, restore_path=restore_path)
+        resolved_backup_id = lium.resolve_backup_id(backup_id)
+        restore_result = lium.restore(
+            pod=pod, backup_id=resolved_backup_id, restore_path=restore_path
+        )
 
         return ActionResult(ok=True, data={"restore": restore_result})

--- a/lium/cli/bk/restore_logs/display.py
+++ b/lium/cli/bk/restore_logs/display.py
@@ -54,6 +54,9 @@ def _format_stage(log) -> str:
 
 
 def _format_work(log) -> str:
+    if getattr(log, "status", "").upper() in {"COMPLETED", "FAILED", "CANCELLED"}:
+        return ""
+
     stage = getattr(log, "stage", None)
     total_files = getattr(log, "total_files", None)
     processed_files = getattr(log, "processed_files", None)

--- a/lium/cli/bk/restore_logs/display.py
+++ b/lium/cli/bk/restore_logs/display.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from rich.table import Table
 
-
 _STAGE_LABELS = {
     "WAITING_FOR_POD": "Waiting for pod",
     "PREPARING": "Preparing",
@@ -17,6 +16,8 @@ def _format_status(status: str) -> str:
         return f"[green]{status}[/green]"
     if status_upper in ["FAILED", "ERROR"]:
         return f"[red]{status}[/red]"
+    if status_upper == "CANCELLED":
+        return f"[dim]{status}[/dim]"
     return f"[yellow]{status}[/yellow]"
 
 
@@ -67,7 +68,23 @@ def _format_work(log) -> str:
         details.append(f"{processed_files:,}/{total_files:,} files")
     if processed_bytes is not None and total_bytes is not None:
         details.append(f"{_format_bytes(processed_bytes)}/{_format_bytes(total_bytes)}")
+    throughput = getattr(log, "throughput_bytes_per_second", None)
+    if throughput:
+        details.append(f"{_format_bytes(throughput)}/s")
+    remaining = getattr(log, "estimated_remaining_seconds", None)
+    if remaining:
+        details.append(f"~{_format_duration(remaining)} left")
     return ", ".join(details)
+
+
+def _format_duration(seconds: int) -> str:
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, remaining_seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m {remaining_seconds}s"
+    hours, remaining_minutes = divmod(minutes, 60)
+    return f"{hours}h {remaining_minutes}m"
 
 
 def format_logs_table(logs: list) -> Table:
@@ -134,6 +151,10 @@ def format_single_restore(pod_name: str, log) -> str:
     work = _format_work(log)
     if work:
         lines.append(f"Work: {work}")
+
+    elapsed = getattr(log, "elapsed_seconds", None)
+    if elapsed is not None:
+        lines.append(f"Elapsed: {_format_duration(elapsed)}")
 
     restore_path = getattr(log, "restore_path", None)
     if restore_path:

--- a/lium/cli/bk/set/command.py
+++ b/lium/cli/bk/set/command.py
@@ -13,6 +13,7 @@ from lium.cli.utils import (
 )
 from . import validation, parsing
 from .actions import SetBackupAction
+from ..path_warning import entire_volume_backup_warning
 
 
 @click.command("set")
@@ -60,6 +61,10 @@ def bk_set_command(pod_id: str, path: str, every: str, keep: str, yes: bool):
     frequency_hours = parsed.get("frequency_hours")
     retention_days = parsed.get("retention_days")
 
+    path_warning = entire_volume_backup_warning(pod, backup_path)
+    if path_warning:
+        ui.warning(path_warning)
+
     # Execute
     ctx = {
         "lium": lium,
@@ -67,7 +72,7 @@ def bk_set_command(pod_id: str, path: str, every: str, keep: str, yes: bool):
         "pod_name": pod_name,
         "path": backup_path,
         "frequency_hours": frequency_hours,
-        "retention_days": retention_days
+        "retention_days": retention_days,
     }
 
     action = SetBackupAction()

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -51,6 +51,24 @@ load_dotenv()
 _PAY_API_KEY = "6RhXQ788J9BdnqeLua8z7ZSkXBDahclxhwjMB17qW1M"
 
 
+def _response_error_message(response: requests.Response) -> str:
+    try:
+        payload = response.json()
+    except Exception:
+        return response.text or "Request failed"
+
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if isinstance(detail, list) and detail:
+        message = detail[0].get("msg") if isinstance(detail[0], dict) else str(detail[0])
+    elif isinstance(detail, dict):
+        message = detail.get("message") or "Request failed"
+        if detail.get("active_operation_id"):
+            message += f" (active operation: {detail['active_operation_id']})"
+    else:
+        message = detail or (payload.get("message") if isinstance(payload, dict) else None)
+    return str(message or "Request failed")
+
+
 def _get_client_version() -> str:
     try:
         return version("lium.io")
@@ -106,14 +124,14 @@ class Lium:
         if resp.status_code == 401:
             raise LiumAuthError("Invalid API key")
         if resp.status_code == 403:
-            raise LiumPermissionError(f"Permission denied: {resp.text}")
+            raise LiumPermissionError(f"Permission denied: {_response_error_message(resp)}")
         if resp.status_code == 404:
-            raise LiumNotFoundError(f"Resource not found: {resp.text}")
+            raise LiumNotFoundError(f"Resource not found: {_response_error_message(resp)}")
         if resp.status_code == 429:
             raise LiumRateLimitError("Rate limit exceeded")
         if 500 <= resp.status_code < 600:
             raise LiumServerError(f"Server error: {resp.status_code}")
-        raise LiumError(f"API error {resp.status_code}: {resp.text}")
+        raise LiumError(f"API error {resp.status_code}: {_response_error_message(resp)}")
 
     def _dict_to_backup_config(self, config_dict: Dict) -> BackupConfig:
         """Convert backup config dict to BackupConfig object."""
@@ -141,7 +159,18 @@ class Lium:
             error_message=log_dict.get("error_message"),
             progress=log_dict.get("progress"),
             backup_volume_id=log_dict.get("backup_volume_id"),
-            created_at=log_dict.get("created_at")
+            created_at=log_dict.get("created_at"),
+            stage=log_dict.get("stage"),
+            total_files=log_dict.get("total_files"),
+            processed_files=log_dict.get("processed_files"),
+            total_bytes=log_dict.get("total_bytes"),
+            processed_bytes=log_dict.get("processed_bytes"),
+            deletion_state=log_dict.get("deletion_state"),
+            physical_cleanup_at=log_dict.get("physical_cleanup_at"),
+            status_message=log_dict.get("status_message"),
+            elapsed_seconds=log_dict.get("elapsed_seconds"),
+            throughput_bytes_per_second=log_dict.get("throughput_bytes_per_second"),
+            estimated_remaining_seconds=log_dict.get("estimated_remaining_seconds"),
         )
 
     def _dict_to_restore_log(self, log_dict: Dict) -> RestoreLog:
@@ -167,6 +196,9 @@ class Lium:
             processed_files=log_dict.get("processed_files"),
             total_bytes=log_dict.get("total_bytes"),
             processed_bytes=log_dict.get("processed_bytes"),
+            elapsed_seconds=log_dict.get("elapsed_seconds"),
+            throughput_bytes_per_second=log_dict.get("throughput_bytes_per_second"),
+            estimated_remaining_seconds=log_dict.get("estimated_remaining_seconds"),
         )
 
     def _dict_to_volume_info(self, volume_dict: Dict) -> VolumeInfo:
@@ -1476,6 +1508,13 @@ class Lium:
         Returns:
             Created :class:`BackupConfig`.
         """
+        if path.rstrip("/") == pod.volume_path.rstrip("/"):
+            warnings.warn(
+                "Backing up the entire volume is less reliable when files are actively changing; "
+                "prefer a stable subdirectory when possible.",
+                UserWarning,
+                stacklevel=2,
+            )
         payload = {
             "pod_id": pod.id,
             "backup_frequency_hours": frequency_hours,
@@ -1570,6 +1609,14 @@ class Lium:
             API response payload.
         """
         return self._request("DELETE", f"/backup-configs/{config_id}").json()
+
+    def backup_cancel(self, backup_id: str) -> Dict[str, Any]:
+        """Request cancellation of an active backup while retaining its history."""
+        return self._request("POST", f"/backup-logs/{backup_id}/cancel").json()
+
+    def backup_log_delete(self, backup_id: str) -> Dict[str, Any]:
+        """Delete the stored data for a completed backup and retain its audit row."""
+        return self._request("DELETE", f"/backup-logs/{backup_id}").json()
     
     def restore(
         self,
@@ -1617,6 +1664,10 @@ class Lium:
             return [self._dict_to_restore_log(log) for log in logs]
         except LiumNotFoundError:
             return []
+
+    def restore_cancel(self, restore_id: str) -> Dict[str, Any]:
+        """Request cancellation of an active restore."""
+        return self._request("POST", f"/restore-logs/{restore_id}/cancel").json()
 
     def get_deployment_estimate(self, executor_id: str, template_id: str) -> dict:
         """Estimate deployment time for a template on a node.

--- a/lium/sdk/client.py
+++ b/lium/sdk/client.py
@@ -58,14 +58,16 @@ def _response_error_message(response: requests.Response) -> str:
         return response.text or "Request failed"
 
     detail = payload.get("detail") if isinstance(payload, dict) else None
+    response_message = payload.get("message") if isinstance(payload, dict) else None
+    structured_error = detail if isinstance(detail, dict) else response_message if isinstance(response_message, dict) else None
     if isinstance(detail, list) and detail:
         message = detail[0].get("msg") if isinstance(detail[0], dict) else str(detail[0])
-    elif isinstance(detail, dict):
-        message = detail.get("message") or "Request failed"
-        if detail.get("active_operation_id"):
-            message += f" (active operation: {detail['active_operation_id']})"
+    elif structured_error:
+        message = structured_error.get("message") or "Request failed"
+        if structured_error.get("active_operation_id"):
+            message += f" (active operation: {structured_error['active_operation_id']})"
     else:
-        message = detail or (payload.get("message") if isinstance(payload, dict) else None)
+        message = detail or response_message
     return str(message or "Request failed")
 
 
@@ -1599,6 +1601,28 @@ class Lium:
             # No backup logs exist for this pod, return empty list
             return []
 
+    def backup_logs_all(self) -> List[BackupLog]:
+        """Get all backup logs available to the current user."""
+        logs: List[BackupLog] = []
+        page = 1
+        while True:
+            response = self._request(
+                "GET", "/backup-logs/", params={"page": page, "limit": 100}
+            ).json()
+            if not isinstance(response, dict):
+                return logs
+            logs.extend(self._dict_to_backup_log(log) for log in response.get("items", []))
+            if not response.get("has_next"):
+                return logs
+            page += 1
+
+    def resolve_backup_id(self, backup_id: str) -> str:
+        """Resolve an eight-character backup ID shown by the CLI."""
+        if not re.fullmatch(r"[0-9a-fA-F]{8}", backup_id):
+            return backup_id
+        matches = {log.id for log in self.backup_logs_all() if log.id.startswith(backup_id)}
+        return self._resolve_short_id(backup_id, matches, "backup")
+
     def backup_delete(self, config_id: str) -> Dict[str, Any]:
         """Delete a backup configuration by ID.
 
@@ -1664,6 +1688,26 @@ class Lium:
             return [self._dict_to_restore_log(log) for log in logs]
         except LiumNotFoundError:
             return []
+
+    def resolve_restore_id(self, restore_id: str) -> str:
+        """Resolve an eight-character restore ID shown by the CLI."""
+        if not re.fullmatch(r"[0-9a-fA-F]{8}", restore_id):
+            return restore_id
+        matches = {
+            log.id
+            for pod in self.ps()
+            for log in self.restore_logs(pod)
+            if log.id.startswith(restore_id)
+        }
+        return self._resolve_short_id(restore_id, matches, "restore")
+
+    @staticmethod
+    def _resolve_short_id(short_id: str, matches: set[str], resource_name: str) -> str:
+        if not matches:
+            raise LiumNotFoundError(f"No {resource_name} matches ID '{short_id}'")
+        if len(matches) > 1:
+            raise LiumError(f"{resource_name.capitalize()} ID '{short_id}' is ambiguous")
+        return matches.pop()
 
     def restore_cancel(self, restore_id: str) -> Dict[str, Any]:
         """Request cancellation of an active restore."""

--- a/lium/sdk/models.py
+++ b/lium/sdk/models.py
@@ -28,13 +28,13 @@ class ExecutorInfo:
     @property
     def driver_version(self) -> str:
         """Extract GPU driver version from specs."""
-        return self.specs.get('gpu', {}).get('driver', '')
+        return self.specs.get("gpu", {}).get("driver", "")
 
     @property
     def gpu_model(self) -> str:
         """Extract GPU model name from specs."""
-        gpu_details = self.specs.get('gpu', {}).get('details', [])
-        return gpu_details[0].get('name', '') if gpu_details else ''
+        gpu_details = self.specs.get("gpu", {}).get("details", [])
+        return gpu_details[0].get("name", "") if gpu_details else ""
 
     @property
     def download_speed(self) -> float:
@@ -67,18 +67,24 @@ class PodInfo:
 
     @property
     def host(self) -> Optional[str]:
-        return (re.findall(r'@(\S+)', self.ssh_cmd) or [None])[0] if self.ssh_cmd else None
+        return (
+            (re.findall(r"@(\S+)", self.ssh_cmd) or [None])[0] if self.ssh_cmd else None
+        )
 
     @property
     def username(self) -> Optional[str]:
-        return (re.findall(r'ssh (\S+)@', self.ssh_cmd) or [None])[0] if self.ssh_cmd else None
+        return (
+            (re.findall(r"ssh (\S+)@", self.ssh_cmd) or [None])[0]
+            if self.ssh_cmd
+            else None
+        )
 
     @property
     def ssh_port(self) -> int:
         """Extract SSH port from command."""
-        if not self.ssh_cmd or '-p ' not in self.ssh_cmd:
+        if not self.ssh_cmd or "-p " not in self.ssh_cmd:
             return 22
-        return int(self.ssh_cmd.split('-p ')[1].split()[0])
+        return int(self.ssh_cmd.split("-p ")[1].split()[0])
 
     @property
     def volume_path(self) -> str:
@@ -95,6 +101,7 @@ class PodInfo:
 @dataclass
 class Template:
     """Template information."""
+
     id: str
     name: str
     huid: str
@@ -107,6 +114,7 @@ class Template:
 @dataclass
 class BackupConfig:
     """Backup configuration information."""
+
     id: str
     huid: str
     pod_executor_id: str
@@ -121,6 +129,7 @@ class BackupConfig:
 @dataclass
 class BackupLog:
     """Backup log information."""
+
     id: str
     huid: str
     backup_config_id: str
@@ -131,11 +140,23 @@ class BackupLog:
     progress: Optional[float] = None
     backup_volume_id: Optional[str] = None
     created_at: Optional[str] = None
+    stage: Optional[str] = None
+    total_files: Optional[int] = None
+    processed_files: Optional[int] = None
+    total_bytes: Optional[int] = None
+    processed_bytes: Optional[int] = None
+    deletion_state: Optional[str] = None
+    physical_cleanup_at: Optional[str] = None
+    status_message: Optional[str] = None
+    elapsed_seconds: Optional[int] = None
+    throughput_bytes_per_second: Optional[int] = None
+    estimated_remaining_seconds: Optional[int] = None
 
 
 @dataclass
 class RestoreLog:
     """Restore log information."""
+
     id: str
     huid: str
     backup_id: str
@@ -156,11 +177,15 @@ class RestoreLog:
     processed_files: Optional[int] = None
     total_bytes: Optional[int] = None
     processed_bytes: Optional[int] = None
+    elapsed_seconds: Optional[int] = None
+    throughput_bytes_per_second: Optional[int] = None
+    estimated_remaining_seconds: Optional[int] = None
 
 
 @dataclass
 class SSHKey:
     """Public SSH key registered for the current user."""
+
     id: str
     name: str
     public_key: str
@@ -170,6 +195,7 @@ class SSHKey:
 @dataclass
 class VolumeInfo:
     """Volume information."""
+
     id: str
     huid: str
     name: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.33"
+version = "0.0.34"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/test/test_backup_cli.py
+++ b/test/test_backup_cli.py
@@ -9,6 +9,7 @@ from lium.cli.bk.restore import command as restore_command
 from lium.cli.bk.rm import command as rm_command
 from lium.cli.bk.set import command as set_command
 from lium.cli.bk.show import command as show_command
+from lium.cli.bk import lifecycle as lifecycle_commands
 from lium.cli.cli import cli
 
 
@@ -55,7 +56,17 @@ def test_bk_set_prints_success(monkeypatch):
 
     result = CliRunner().invoke(
         cli,
-        ["bk", "set", "backup-test", "--path", "/root/data", "--every", "6h", "--keep", "7d"],
+        [
+            "bk",
+            "set",
+            "backup-test",
+            "--path",
+            "/root/data",
+            "--every",
+            "6h",
+            "--keep",
+            "7d",
+        ],
     )
 
     assert result.exit_code == 0
@@ -82,7 +93,15 @@ def test_bk_now_prints_backup_log_id(monkeypatch):
 
     result = CliRunner().invoke(
         cli,
-        ["bk", "now", "backup-test", "--name", "pre-deploy", "--description", "before release"],
+        [
+            "bk",
+            "now",
+            "backup-test",
+            "--name",
+            "pre-deploy",
+            "--description",
+            "before release",
+        ],
     )
 
     assert result.exit_code == 0
@@ -154,7 +173,16 @@ def test_bk_restore_prints_success(monkeypatch):
 
     result = CliRunner().invoke(
         cli,
-        ["bk", "restore", "backup-test", "--id", "backup-123", "--to", "/root/restore", "--yes"],
+        [
+            "bk",
+            "restore",
+            "backup-test",
+            "--id",
+            "backup-123",
+            "--to",
+            "/root/restore",
+            "--yes",
+        ],
     )
 
     assert result.exit_code == 0
@@ -270,3 +298,57 @@ def test_bk_show_warns_when_config_missing(monkeypatch):
 
     assert result.exit_code == 0
     assert "No backup configuration found for backup-test" in result.output
+
+
+def test_bk_cancel_keeps_history(monkeypatch):
+    calls = []
+
+    class FakeLium:
+        def backup_cancel(self, backup_id):
+            calls.append(backup_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "cancel", "--id", "backup-123", "--yes"])
+
+    assert result.exit_code == 0
+    assert calls == ["backup-123"]
+    assert "history and last reported progress" in result.output
+    assert "remain available" in result.output
+
+
+def test_bk_delete_removes_only_completed_backup_data(monkeypatch):
+    calls = []
+
+    class FakeLium:
+        def backup_log_delete(self, backup_id):
+            calls.append(backup_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "delete", "--id", "backup-123", "--yes"])
+
+    assert result.exit_code == 0
+    assert calls == ["backup-123"]
+    assert "Storage usage will update after cleanup finishes" in result.output
+
+
+def test_bk_restore_cancel_warns_about_partial_files(monkeypatch):
+    calls = []
+
+    class FakeLium:
+        def restore_cancel(self, restore_id):
+            calls.append(restore_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(
+        cli, ["bk", "restore-cancel", "--id", "restore-123", "--yes"]
+    )
+
+    assert result.exit_code == 0
+    assert calls == ["restore-123"]
+    assert "Partial files may remain" in result.output

--- a/test/test_backup_cli.py
+++ b/test/test_backup_cli.py
@@ -159,13 +159,19 @@ def test_bk_rm_prints_success(monkeypatch):
 
 
 def test_bk_restore_prints_success(monkeypatch):
+    full_backup_id = "8fbb30f6-6026-4043-98c7-c4189dc09bef"
+
     class FakeLium:
         def ps(self):
             return [_pod()]
 
+        def resolve_backup_id(self, backup_id):
+            assert backup_id == "8fbb30f6"
+            return full_backup_id
+
         def restore(self, *, pod, backup_id, restore_path):
             assert pod.id == "pod-123"
-            assert backup_id == "backup-123"
+            assert backup_id == full_backup_id
             assert restore_path == "/root/restore"
             return {"restore_log_id": "restore-123"}
 
@@ -178,7 +184,7 @@ def test_bk_restore_prints_success(monkeypatch):
             "restore",
             "backup-test",
             "--id",
-            "backup-123",
+            "8fbb30f6",
             "--to",
             "/root/restore",
             "--yes",
@@ -198,6 +204,9 @@ def test_bk_restore_uses_safe_default_subdirectory(monkeypatch):
     class FakeLium:
         def ps(self):
             return [pod]
+
+        def resolve_backup_id(self, backup_id):
+            return backup_id
 
         def restore(self, *, pod, backup_id, restore_path):
             assert backup_id == "backup-123"
@@ -304,6 +313,9 @@ def test_bk_cancel_keeps_history(monkeypatch):
     calls = []
 
     class FakeLium:
+        def resolve_backup_id(self, backup_id):
+            return backup_id
+
         def backup_cancel(self, backup_id):
             calls.append(backup_id)
             return {"success": True}
@@ -322,6 +334,9 @@ def test_bk_delete_removes_only_completed_backup_data(monkeypatch):
     calls = []
 
     class FakeLium:
+        def resolve_backup_id(self, backup_id):
+            return backup_id
+
         def backup_log_delete(self, backup_id):
             calls.append(backup_id)
             return {"success": True}
@@ -339,6 +354,9 @@ def test_bk_restore_cancel_warns_about_partial_files(monkeypatch):
     calls = []
 
     class FakeLium:
+        def resolve_restore_id(self, restore_id):
+            return restore_id
+
         def restore_cancel(self, restore_id):
             calls.append(restore_id)
             return {"success": True}
@@ -352,3 +370,47 @@ def test_bk_restore_cancel_warns_about_partial_files(monkeypatch):
     assert result.exit_code == 0
     assert calls == ["restore-123"]
     assert "Partial files may remain" in result.output
+
+
+def test_bk_cancel_resolves_displayed_short_id(monkeypatch):
+    calls = []
+    full_id = "8fbb30f6-6026-4043-98c7-c4189dc09bef"
+
+    class FakeLium:
+        def resolve_backup_id(self, backup_id):
+            assert backup_id == "8fbb30f6"
+            return full_id
+
+        def backup_cancel(self, backup_id):
+            calls.append(backup_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(cli, ["bk", "cancel", "--id", "8fbb30f6", "--yes"])
+
+    assert result.exit_code == 0
+    assert calls == [full_id]
+
+
+def test_bk_restore_cancel_resolves_displayed_short_id(monkeypatch):
+    calls = []
+    full_id = "9b6c8d90-1111-4222-9333-48b031f1f3eb"
+
+    class FakeLium:
+        def resolve_restore_id(self, restore_id):
+            assert restore_id == "9b6c8d90"
+            return full_id
+
+        def restore_cancel(self, restore_id):
+            calls.append(restore_id)
+            return {"success": True}
+
+    _patch_backup_command(monkeypatch, lifecycle_commands, FakeLium)
+
+    result = CliRunner().invoke(
+        cli, ["bk", "restore-cancel", "--id", "9b6c8d90", "--yes"]
+    )
+
+    assert result.exit_code == 0
+    assert calls == [full_id]

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from lium.sdk import Config, Lium, LiumPermissionError
+from lium.sdk import Config, Lium, LiumError, LiumPermissionError
 
 
 class _Forbidden:
@@ -30,7 +30,9 @@ def test_client_sets_version_header(monkeypatch):
 
 
 def test_request_403_raises_permission_error(monkeypatch):
-    monkeypatch.setattr("lium.sdk.client.requests.request", lambda *a, **kw: _Forbidden())
+    monkeypatch.setattr(
+        "lium.sdk.client.requests.request", lambda *a, **kw: _Forbidden()
+    )
     client = Lium(Config(api_key="test"))
 
     with pytest.raises(LiumPermissionError):
@@ -85,6 +87,9 @@ def test_restore_log_hydrates_progress_metadata():
             "processed_files": 25,
             "total_bytes": 1_000,
             "processed_bytes": 250,
+            "elapsed_seconds": 12,
+            "throughput_bytes_per_second": 20,
+            "estimated_remaining_seconds": 38,
         }
     )
 
@@ -92,3 +97,56 @@ def test_restore_log_hydrates_progress_metadata():
     assert restore_log.restore_mode == "STARTUP"
     assert restore_log.processed_files == 25
     assert restore_log.processed_bytes == 250
+    assert restore_log.elapsed_seconds == 12
+    assert restore_log.estimated_remaining_seconds == 38
+
+
+def test_backup_and_restore_lifecycle_methods_use_distinct_endpoints(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    calls = []
+
+    class Response:
+        def json(self):
+            return {"success": True}
+
+    def fake_request(method, endpoint, **kwargs):
+        calls.append((method, endpoint))
+        return Response()
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    client.backup_cancel("backup-1")
+    client.backup_log_delete("backup-1")
+    client.restore_cancel("restore-1")
+
+    assert calls == [
+        ("POST", "/backup-logs/backup-1/cancel"),
+        ("DELETE", "/backup-logs/backup-1"),
+        ("POST", "/restore-logs/restore-1/cancel"),
+    ]
+
+
+def test_structured_busy_error_is_readable(monkeypatch):
+    class ConflictResponse:
+        ok = False
+        status_code = 409
+        text = ""
+
+        def json(self):
+            return {
+                "detail": {
+                    "code": "BACKUP_STORAGE_BUSY",
+                    "message": "Another backup or restore is already running",
+                    "active_operation_id": "active-123",
+                }
+            }
+
+    monkeypatch.setattr(
+        "lium.sdk.client.requests.request", lambda *args, **kwargs: ConflictResponse()
+    )
+    client = Lium(Config(api_key="test"))
+
+    with pytest.raises(
+        LiumError, match="Another backup or restore is already running.*active-123"
+    ):
+        client._request("POST", "/pods/pod-1/backup")

--- a/test/test_sdk_client.py
+++ b/test/test_sdk_client.py
@@ -150,3 +150,54 @@ def test_structured_busy_error_is_readable(monkeypatch):
         LiumError, match="Another backup or restore is already running.*active-123"
     ):
         client._request("POST", "/pods/pod-1/backup")
+
+
+def test_structured_message_error_is_readable(monkeypatch):
+    class ConflictResponse:
+        ok = False
+        status_code = 409
+        text = ""
+
+        def json(self):
+            return {
+                "message": {
+                    "code": "BACKUP_NOT_ACTIVE",
+                    "message": "This backup is no longer active",
+                    "current_status": "COMPLETED",
+                }
+            }
+
+    monkeypatch.setattr(
+        "lium.sdk.client.requests.request", lambda *args, **kwargs: ConflictResponse()
+    )
+    client = Lium(Config(api_key="test"))
+
+    with pytest.raises(LiumError, match="This backup is no longer active"):
+        client._request("POST", "/backup-logs/8fbb30f6/cancel")
+
+
+def test_resolve_backup_id_uses_paginated_backup_logs(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    backup_id = "8fbb30f6-6026-4043-98c7-c4189dc09bef"
+
+    class Response:
+        def json(self):
+            return {"items": [{"id": backup_id}], "has_next": False}
+
+    monkeypatch.setattr(client, "_request", lambda *args, **kwargs: Response())
+
+    assert client.resolve_backup_id("8fbb30f6") == backup_id
+
+
+def test_resolve_restore_id_searches_active_pods(monkeypatch):
+    client = Lium(Config(api_key="test"))
+    restore_id = "9b6c8d90-1111-4222-9333-48b031f1f3eb"
+    pod = SimpleNamespace(id="pod-1")
+    monkeypatch.setattr(client, "ps", lambda: [pod])
+    monkeypatch.setattr(
+        client,
+        "restore_logs",
+        lambda candidate: [SimpleNamespace(id=restore_id)] if candidate is pod else [],
+    )
+
+    assert client.resolve_restore_id("9b6c8d90") == restore_id

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.33"
+version = "0.0.34"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Add CLI/SDK parity for the DAH-2641 backup lifecycle and progress improvements.

## Changes

- Add SDK methods for backup cancellation, completed-backup deletion, and restore cancellation.
- Add `lium bk cancel`, `lium bk delete`, and `lium bk restore-cancel`.
- Resolve the eight-character backup and restore IDs displayed by CLI tables across lifecycle commands.
- Hydrate and display file/byte counters, elapsed time, throughput, conditional ETA, cleanup state, and Cancelled/Skipped outcomes.
- Suppress active work and ETA details for terminal restores.
- Parse structured errors from both backend response envelopes instead of printing raw dictionaries.
- Warn when configuring or manually starting a whole-volume backup.
- Keep exact recorded operational errors while keeping internal storage-engine terminology out of product copy.
- Bump the package version to 0.0.34.

## Dependency

This PR is stacked on the open DAH-2639 CLI/SDK PR #108 and requires the DAH-2641 backend API for the new lifecycle endpoints and response fields.

- Backend: https://github.com/Datura-ai/lium-io-backend/pull/908
- Frontend: https://github.com/Datura-ai/lium-io-frontend/pull/240

## Testing

- Focused CLI/SDK backup and client suite: 24 tests passed.
- `git diff --check` passed.
- GitHub build matrix passed for Python distributions and Linux/macOS binaries.

## Risk

Existing commands remain compatible. The new lifecycle commands require a backend that exposes the DAH-2641 endpoints.
