### PR TITLE
DAH-2654: sign up with a Bittensor hotkey and attach an email later

### DIFF
--- a/lium/__about__.py
+++ b/lium/__about__.py
@@ -1,3 +1,3 @@
 """Project version metadata."""
 
-__version__ = "0.0.32"
+__version__ = "0.0.33"

--- a/lium/cli/cli.py
+++ b/lium/cli/cli.py
@@ -6,7 +6,7 @@ from importlib.metadata import version, PackageNotFoundError
 from lium.__about__ import __version__ as fallback_version
 from .themed_console import ThemedConsole
 from .init.command import init_command
-from .signup import signup_command
+from .signup import attach_email_command, signup_command, signup_key_command
 from .ls import ls_command
 from .templates import templates_command
 from .up import up_command
@@ -68,6 +68,8 @@ def cli(ctx):
 
 # Register core commands
 cli.add_command(signup_command)
+cli.add_command(signup_key_command)
+cli.add_command(attach_email_command)
 cli.add_command(init_command)
 cli.add_command(ls_command)
 cli.add_command(templates_command)

--- a/lium/cli/signup/__init__.py
+++ b/lium/cli/signup/__init__.py
@@ -1,5 +1,5 @@
 """Signup command package."""
 
-from .command import signup_command
+from .command import attach_email_command, signup_command, signup_key_command
 
-__all__ = ["signup_command"]
+__all__ = ["attach_email_command", "signup_command", "signup_key_command"]

--- a/lium/cli/signup/actions.py
+++ b/lium/cli/signup/actions.py
@@ -337,6 +337,12 @@ class AttachEmailAction:
             )
 
         if response.status_code >= 400:
-            return ActionResult(ok=False, data={}, error=_describe_failure(response, "Attaching the email"))
+            # a 5xx can land after the credential was committed, so the password still has to reach the user;
+            # a 4xx is the server refusing the request outright, and nothing was attached
+            return ActionResult(
+                ok=False,
+                data={"credential_may_exist": response.status_code >= 500},
+                error=_describe_failure(response, "Attaching the email"),
+            )
 
         return ActionResult(ok=True, data={})

--- a/lium/cli/signup/actions.py
+++ b/lium/cli/signup/actions.py
@@ -1,4 +1,4 @@
-"""Signup action: create an account and keep the API key it mints."""
+"""Signup actions: create an account — by email or by Bittensor key — and keep the API key it mints."""
 
 import os
 import secrets
@@ -9,12 +9,15 @@ import requests
 
 from lium.cli.actions import ActionResult
 from lium.cli.settings import config
+from lium.provider.errors import ProviderError
+from lium.provider.wallet import load_hotkey_keypair
 
 PASSWORD_ALPHABET = string.ascii_letters + string.digits + "!@#$%^&*-_"
 PASSWORD_LENGTH = 20
 REQUEST_TIMEOUT = 30
 MINTED_KEY_NAME = "Default"
 DEFAULT_BASE_URL = "https://lium.io/api"
+RATE_LIMIT_MESSAGE = "Too many signups from this network. Wait and retry, or sign up at https://lium.io."
 
 
 def generate_password() -> str:
@@ -64,6 +67,36 @@ def _select_minted_key(api_keys: list) -> str | None:
     return newest.get("key")
 
 
+def _configured_key_refusal() -> ActionResult | None:
+    # a second account would be unreachable — nothing here can switch between keys
+    if not config.get("api.api_key"):
+        return None
+
+    if os.environ.get("LIUM_API_KEY"):
+        return ActionResult(
+            ok=False,
+            data={},
+            error="An API key is already configured through the LIUM_API_KEY environment "
+                  "variable. Run 'unset LIUM_API_KEY' first, or use 'lium init' to "
+                  "re-authenticate.",
+        )
+    return ActionResult(
+        ok=False,
+        data={},
+        error="An API key is already configured. Run 'lium config unset api.api_key' first, "
+              "or use 'lium init' to re-authenticate.",
+    )
+
+
+def _describe_failure(response: requests.Response, action: str = "Signup") -> str:
+    # the backend names the offending field in a detail dict; older routes answer with a bare string
+    detail = _json_object(response).get("detail")
+
+    if isinstance(detail, dict):
+        detail = "; ".join(f"{k}: {v}" for k, v in detail.items())
+    return str(detail) if detail else f"{action} failed with HTTP {response.status_code}."
+
+
 class SignupAction:
     """Register an account and return the API key minted for it.
 
@@ -79,22 +112,9 @@ class SignupAction:
         self.display_name = display_name
 
     def execute(self, ctx: dict) -> ActionResult:
-        # a second account would be unreachable — nothing here can switch between keys
-        if config.get("api.api_key"):
-            if os.environ.get("LIUM_API_KEY"):
-                return ActionResult(
-                    ok=False,
-                    data={},
-                    error="An API key is already configured through the LIUM_API_KEY environment "
-                          "variable. Run 'unset LIUM_API_KEY' first, or use 'lium init' to "
-                          "re-authenticate.",
-                )
-            return ActionResult(
-                ok=False,
-                data={},
-                error="An API key is already configured. Run 'lium config unset api.api_key' first, "
-                      "or use 'lium init' to re-authenticate.",
-            )
+        refusal = _configured_key_refusal()
+        if refusal:
+            return refusal
 
         creation_result = self._create_account()
         if not creation_result.ok:
@@ -131,14 +151,10 @@ class SignupAction:
             )
 
         if response.status_code == 429:
-            return ActionResult(
-                ok=False,
-                data={},
-                error="Too many signups from this network. Wait and retry, or sign up at https://lium.io.",
-            )
+            return ActionResult(ok=False, data={}, error=RATE_LIMIT_MESSAGE)
 
         if response.status_code >= 400:
-            return ActionResult(ok=False, data={}, error=self._describe_failure(response))
+            return ActionResult(ok=False, data={}, error=_describe_failure(response))
 
         body = _json_object(response)
         return ActionResult(ok=True, data={
@@ -173,10 +189,154 @@ class SignupAction:
 
         return _select_minted_key(api_keys)
 
-    @staticmethod
-    def _describe_failure(response: requests.Response) -> str:
-        detail = _json_object(response).get("detail")
 
-        if isinstance(detail, dict):
-            detail = "; ".join(f"{k}: {v}" for k, v in detail.items())
-        return str(detail) if detail else f"Signup failed with HTTP {response.status_code}."
+class KeySignupAction:
+    """Register an account owned by a Bittensor hotkey and return the API key minted for it.
+
+    ``POST /auth/wallet-challenge`` mints a single-use message, the hotkey signs
+    it, and ``POST /auth/wallet-signup`` trades the signature for an account
+    plus its default API key. No email and no password are involved — attach
+    them later with :class:`AttachEmailAction`.
+    """
+
+    def __init__(self, coldkey: str, hotkey: str, display_name: str | None):
+        self.coldkey = coldkey
+        self.hotkey = hotkey
+        self.display_name = display_name
+
+    def execute(self, ctx: dict) -> ActionResult:
+        refusal = _configured_key_refusal()
+        if refusal:
+            return refusal
+
+        try:
+            keypair = load_hotkey_keypair(self.coldkey, self.hotkey)
+        except ProviderError as e:
+            return ActionResult(ok=False, data={}, error=str(e))
+
+        address = keypair.ss58_address
+        challenge_result = self._request_challenge(address)
+        if not challenge_result.ok:
+            return challenge_result
+
+        # the backend verifies the signature over the message it minted, as bare hex without 0x
+        signature = keypair.sign(challenge_result.data["message"]).hex()
+
+        signup_result = self._register(address, challenge_result.data["nonce"], signature)
+        if not signup_result.ok:
+            return signup_result
+
+        api_key = signup_result.data.get("api_key")
+        if not api_key:
+            return ActionResult(
+                ok=False,
+                data={},
+                error=f"Account created for {address}, but the API key could not be read back. "
+                      "Copy it from https://lium.io.",
+            )
+
+        config.set("api.api_key", api_key)
+        return ActionResult(ok=True, data={
+            "address": address,
+            "api_key": api_key,
+            "is_new_user": signup_result.data.get("is_new_user"),
+            "signup_credit_granted": signup_result.data.get("signup_credit_granted"),
+        })
+
+    def _request_challenge(self, address: str) -> ActionResult:
+        # the challenge is single-use and expires in 300 s, so it is minted right before signing
+        try:
+            response = requests.post(
+                f"{base_url()}/auth/wallet-challenge",
+                json={"address": address},
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as e:
+            return ActionResult(ok=False, data={}, error=f"Wallet challenge request failed: {e}.")
+
+        if response.status_code >= 400:
+            return ActionResult(ok=False, data={}, error=_describe_failure(response, "Wallet challenge"))
+
+        body = _json_object(response)
+        if not body.get("nonce") or not body.get("message"):
+            return ActionResult(
+                ok=False,
+                data={},
+                error="The wallet challenge response carried no message to sign.",
+            )
+        return ActionResult(ok=True, data={"nonce": body["nonce"], "message": body["message"]})
+
+    def _register(self, address: str, nonce: str, signature: str) -> ActionResult:
+        # the account is created inside this call, so a transport failure can still leave one behind
+        payload = {"address": address, "nonce": nonce, "signature": signature}
+        if self.display_name:
+            payload["name"] = self.display_name
+
+        try:
+            response = requests.post(
+                f"{base_url()}/auth/wallet-signup",
+                json=payload,
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as e:
+            return ActionResult(
+                ok=False,
+                data={},
+                error=f"Wallet signup request failed: {e}. The account may have been created — "
+                      "check https://lium.io before retrying.",
+            )
+
+        if response.status_code == 429:
+            return ActionResult(ok=False, data={}, error=RATE_LIMIT_MESSAGE)
+
+        if response.status_code >= 400:
+            return ActionResult(ok=False, data={}, error=_describe_failure(response))
+
+        body = _json_object(response)
+        return ActionResult(ok=True, data={
+            "api_key": body.get("api_key"),
+            "is_new_user": body.get("is_new_user"),
+            "signup_credit_granted": body.get("signup_credit_granted"),
+        })
+
+
+class AttachEmailAction:
+    """Attach an email + password login to the account the stored API key belongs to.
+
+    The account keeps its key-only owner; the email becomes a second way in and
+    stays unverified until the user clicks the link the backend mails.
+    """
+
+    def __init__(self, email: str, password: str):
+        self.email = email
+        self.password = password
+
+    def execute(self, ctx: dict) -> ActionResult:
+        api_key = config.get("api.api_key")
+        if not api_key:
+            return ActionResult(
+                ok=False,
+                data={},
+                error="No API key is configured. Run 'lium signup-key --coldkey <name> --hotkey <name>' "
+                      "first, or 'lium init' to authenticate an existing account.",
+            )
+
+        try:
+            response = requests.post(
+                f"{base_url()}/users/me/email-password",
+                json={"email": self.email, "password": self.password},
+                headers={"X-API-Key": api_key},
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as e:
+            # the verification mail is sent inside the call, so a transport failure can still leave it attached
+            return ActionResult(
+                ok=False,
+                data={"credential_may_exist": True},
+                error=f"Attaching the email failed: {e}. It may have been attached.",
+            )
+
+        if response.status_code >= 400:
+            return ActionResult(ok=False, data={}, error=_describe_failure(response, "Attaching the email"))
+
+        return ActionResult(ok=True, data={})

--- a/lium/cli/signup/command.py
+++ b/lium/cli/signup/command.py
@@ -7,7 +7,7 @@ import click
 from lium.cli import ui
 from lium.cli.init.actions import SetupSshKeyAction
 from lium.cli.utils import CliFailure, handle_errors
-from .actions import SignupAction, generate_password
+from .actions import AttachEmailAction, KeySignupAction, SignupAction, generate_password
 
 
 def _credit_line(credit_granted: bool | None) -> str:
@@ -90,3 +90,109 @@ def signup_command(email: str, display_name: str | None, password: str | None, j
     ui.print("")
     ui.dim("  The verification link in the confirmation email does not gate renting — it confirms")
     ui.dim("  the address so password resets and account emails reach you.")
+
+
+@click.command("signup-key")
+@click.option("--coldkey", required=True, help="Bittensor coldkey (wallet) name holding the hotkey.")
+@click.option("--hotkey", required=True, help="Bittensor hotkey name — its address owns the account.")
+@click.option("--name", "display_name", default=None, help="Display name (defaults to the address).")
+@click.option("--json", "json_output", is_flag=True, help="Print machine-readable JSON")
+@handle_errors
+def signup_key_command(coldkey: str, hotkey: str, display_name: str | None, json_output: bool):
+    """Create a Lium account owned by a Bittensor hotkey and store the API key it mints.
+
+    No email, no password: the hotkey signs a challenge from the backend and the
+    account is created for its address. The wallet must already exist under
+    ~/.bittensor/wallets — this command never generates a key. Add an email
+    login later with 'lium attach-email'.
+
+    \b
+    Examples:
+      lium signup-key --coldkey default --hotkey agent
+      lium signup-key --coldkey default --hotkey agent --name agent-01 --json
+    """
+    signup_result = KeySignupAction(
+        coldkey=coldkey, hotkey=hotkey, display_name=display_name
+    ).execute({})
+    if not signup_result.ok:
+        raise CliFailure("signup_key_failed", signup_result.error)
+
+    ssh_result = SetupSshKeyAction().execute({})
+    credit_granted = signup_result.data.get("signup_credit_granted")
+    next_steps = [
+        _credit_line(credit_granted),
+        "Add an email login with 'lium attach-email --email you@example.com'.",
+        "Then: lium ls, lium up <node-id>.",
+    ]
+
+    if json_output:
+        click.echo(json.dumps({
+            "address": signup_result.data["address"],
+            "api_key": signup_result.data["api_key"],
+            "is_new_user": signup_result.data.get("is_new_user"),
+            "signup_credit_granted": credit_granted,
+            "ssh_key_configured": ssh_result.ok,
+            "next_steps": next_steps,
+        }, sort_keys=True))
+        return
+
+    ui.success(f"Account created for {signup_result.data['address']}")
+    ui.info("API key stored in ~/.lium/config.ini")
+    if not ssh_result.ok:
+        ui.warning(f"SSH key not configured: {ssh_result.error}")
+
+    ui.print("")
+    ui.info("Next steps:")
+    for number, step in enumerate(next_steps, start=1):
+        ui.print(f"  {number}. {step}")
+
+
+@click.command("attach-email")
+@click.option("--email", required=True, help="The user's real email — the verification link is sent there.")
+@click.option("--password", default=None, envvar="LIUM_SIGNUP_PASSWORD",
+              help="Account password (generated when omitted). Falls back to LIUM_SIGNUP_PASSWORD.")
+@click.option("--json", "json_output", is_flag=True, help="Print machine-readable JSON")
+@handle_errors
+def attach_email_command(email: str, password: str | None, json_output: bool):
+    """Add an email + password login to the account of the stored API key.
+
+    Meant for an account created with 'lium signup-key', which has no email at
+    all. The address stays unverified until the user clicks the link in the
+    confirmation email.
+
+    To set your own password, prefer LIUM_SIGNUP_PASSWORD over --password:
+    a flag value is left behind in the shell history and in `ps` output.
+
+    \b
+    Examples:
+      lium attach-email --email ada@example.com
+      LIUM_SIGNUP_PASSWORD=... lium attach-email --email ada@example.com --json
+    """
+    password = password or generate_password()
+
+    attach_result = AttachEmailAction(email=email, password=password).execute({})
+    if not attach_result.ok:
+        # the credential may be attached server-side; losing the generated password would strand that login
+        if attach_result.data.get("credential_may_exist"):
+            raise CliFailure(
+                "attach_email_failed",
+                f"{attach_result.error} Log in at https://lium.io with {email} / {password} to check.",
+                data={"email": email, "password": password},
+            )
+        raise CliFailure("attach_email_failed", attach_result.error)
+
+    if json_output:
+        click.echo(json.dumps({
+            "email": email,
+            "password": password,
+            "next_steps": [
+                "Ask the user to click the verification link in the confirmation email.",
+                "The account keeps its API key — nothing else changes.",
+            ],
+        }, sort_keys=True))
+        return
+
+    ui.success(f"Email {email} attached to the account")
+    ui.print(f"\n  password: {password}")
+    ui.dim("  Save it — it is the dashboard login at https://lium.io\n")
+    ui.info("Click the verification link in the confirmation email to verify the address.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lium.io"
-version = "0.0.32"
+version = "0.0.33"
 description = "A custom CLI tool for Lium. Lium CLI provides tools for interacting with the Lium ecosystem from the command line."
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/test/test_attach_email_cli.py
+++ b/test/test_attach_email_cli.py
@@ -109,6 +109,36 @@ def test_attach_email_generates_a_password_when_omitted(monkeypatch, stored_conf
     assert json.loads(result.output)["password"] == sent["password"]
 
 
+def test_attach_email_reports_the_password_when_the_server_fails(monkeypatch, stored_config):
+    """A 5xx can land after the credential was committed, so the password must still reach the user."""
+    monkeypatch.setattr(
+        signup_actions.requests, "post",
+        lambda url, **kwargs: FakeResponse(500, {"detail": "Internal server error"}),
+    )
+
+    result = CliRunner().invoke(
+        cli, ["attach-email", "--email", "ada@example.com", "--password", "s3cret-pw"]
+    )
+
+    assert result.exit_code != 0
+    assert "s3cret-pw" in " ".join(result.output.split())
+
+
+def test_attach_email_hides_the_password_when_the_server_refuses(monkeypatch, stored_config):
+    """A 4xx attached nothing, so printing the password would only invite a login that cannot work."""
+    monkeypatch.setattr(
+        signup_actions.requests, "post",
+        lambda url, **kwargs: FakeResponse(409, {"detail": {"email": "Email is already in use."}}),
+    )
+
+    result = CliRunner().invoke(
+        cli, ["attach-email", "--email", "ada@example.com", "--password", "s3cret-pw"]
+    )
+
+    assert result.exit_code != 0
+    assert "s3cret-pw" not in " ".join(result.output.split())
+
+
 def test_attach_email_reports_the_password_when_the_request_times_out(monkeypatch, stored_config):
     """The backend mails the user inside the request, so a read timeout can still leave the login attached."""
     def timing_out_post(url, **kwargs):

--- a/test/test_attach_email_cli.py
+++ b/test/test_attach_email_cli.py
@@ -1,0 +1,126 @@
+"""DAH-2654: `lium attach-email` adds an email + password login to a key-only account."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from lium.cli.cli import cli
+from lium.cli.signup import actions as signup_actions
+
+
+class FakeResponse:
+    def __init__(self, status_code: int = 201, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def stored_config(monkeypatch):
+    """Config double: the stored API key is what names the account to attach to."""
+    stored = {"api.api_key": "sk_wallet"}
+
+    class FakeConfig:
+        def get(self, key, default=None):
+            return stored.get(key, default)
+
+        def set(self, key, value):
+            stored[key] = value
+
+    monkeypatch.setattr(signup_actions, "config", FakeConfig())
+    return stored
+
+
+def test_attach_email_posts_the_credential_under_the_stored_key(monkeypatch, stored_config):
+    sent = {}
+
+    def fake_post(url, **kwargs):
+        sent["url"] = url
+        sent["json"] = kwargs["json"]
+        sent["headers"] = kwargs["headers"]
+        return FakeResponse(201, {"id": "user-1", "email": "ada@example.com"})
+
+    monkeypatch.setattr(signup_actions.requests, "post", fake_post)
+
+    result = CliRunner().invoke(
+        cli, ["attach-email", "--email", "ada@example.com", "--password", "s3cret-pw"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sent["url"].rsplit("/api", 1)[-1] == "/users/me/email-password"
+    assert sent["json"] == {"email": "ada@example.com", "password": "s3cret-pw"}
+    assert sent["headers"]["X-API-Key"] == "sk_wallet"
+
+
+def test_attach_email_without_an_api_key_points_at_signup_key(monkeypatch, stored_config):
+    stored_config.pop("api.api_key")
+
+    def fail_post(url, **kwargs):
+        raise AssertionError("attach-email must not call the API without an API key")
+
+    monkeypatch.setattr(signup_actions.requests, "post", fail_post)
+
+    result = CliRunner().invoke(cli, ["attach-email", "--email", "ada@example.com"])
+
+    assert result.exit_code != 0
+    assert "lium signup-key" in " ".join(result.output.split())
+
+
+def test_attach_email_surfaces_an_account_that_already_has_an_email(monkeypatch, stored_config):
+    monkeypatch.setattr(
+        signup_actions.requests, "post",
+        lambda url, **kwargs: FakeResponse(409, {"detail": {"email": "Account already has an email address."}}),
+    )
+
+    result = CliRunner().invoke(cli, ["attach-email", "--email", "ada@example.com"])
+
+    assert result.exit_code != 0
+    assert "Account already has an email address." in " ".join(result.output.split())
+
+
+def test_attach_email_surfaces_an_email_taken_by_another_account(monkeypatch, stored_config):
+    monkeypatch.setattr(
+        signup_actions.requests, "post",
+        lambda url, **kwargs: FakeResponse(409, {"detail": {"email": "Email is already in use."}}),
+    )
+
+    result = CliRunner().invoke(cli, ["attach-email", "--email", "ada@example.com", "--json"])
+
+    assert result.exit_code != 0
+    assert "Email is already in use." in json.loads(result.stderr)["error"]["message"]
+
+
+def test_attach_email_generates_a_password_when_omitted(monkeypatch, stored_config):
+    sent = {}
+
+    def fake_post(url, **kwargs):
+        sent.update(kwargs["json"])
+        return FakeResponse(201, {"id": "user-1"})
+
+    monkeypatch.setattr(signup_actions.requests, "post", fake_post)
+
+    result = CliRunner().invoke(cli, ["attach-email", "--email", "ada@example.com", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert len(sent["password"]) == signup_actions.PASSWORD_LENGTH
+    assert json.loads(result.output)["password"] == sent["password"]
+
+
+def test_attach_email_reports_the_password_when_the_request_times_out(monkeypatch, stored_config):
+    """The backend mails the user inside the request, so a read timeout can still leave the login attached."""
+    def timing_out_post(url, **kwargs):
+        raise signup_actions.requests.Timeout("read timed out")
+
+    monkeypatch.setattr(signup_actions.requests, "post", timing_out_post)
+
+    result = CliRunner().invoke(
+        cli, ["attach-email", "--email", "ada@example.com", "--password", "s3cret-pw"]
+    )
+
+    assert result.exit_code != 0
+    plain = " ".join(result.output.split())
+    assert "s3cret-pw" in plain
+    assert "ada@example.com" in plain

--- a/test/test_signup_key_cli.py
+++ b/test/test_signup_key_cli.py
@@ -1,0 +1,236 @@
+"""DAH-2654: `lium signup-key` registers an account owned by an existing Bittensor hotkey."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from lium.cli.actions import ActionResult
+from lium.cli.cli import cli
+from lium.cli.signup import actions as signup_actions
+from lium.provider.errors import ProviderError
+
+ADDRESS = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+
+
+class FakeResponse:
+    def __init__(self, status_code: int = 200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def json(self):
+        return self._payload
+
+
+class FakeKeypair:
+    """Stands in for a bittensor hotkey keypair: records what it was asked to sign."""
+
+    def __init__(self, address: str = ADDRESS):
+        self.ss58_address = address
+        self.signed: list = []
+
+    def sign(self, message):
+        self.signed.append(message)
+        return b"\xde\xad\xbe\xef"
+
+
+@pytest.fixture
+def stored_config(monkeypatch):
+    """Config double: empty to start, records what the signup writes into it."""
+    stored = {}
+
+    class FakeConfig:
+        def get(self, key, default=None):
+            return stored.get(key, default)
+
+        def set(self, key, value):
+            stored[key] = value
+
+    monkeypatch.setattr(signup_actions, "config", FakeConfig())
+    return stored
+
+
+@pytest.fixture
+def ssh_setup_ok(monkeypatch):
+    monkeypatch.setattr(
+        "lium.cli.init.actions.SetupSshKeyAction.execute",
+        lambda self, ctx: ActionResult(ok=True, data={"already_configured": True}),
+    )
+
+
+@pytest.fixture
+def keypair(monkeypatch):
+    """Wallet double: no ~/.bittensor keyfile is read in the tests."""
+    loaded = FakeKeypair()
+    monkeypatch.setattr(signup_actions, "load_hotkey_keypair", lambda coldkey, hotkey: loaded)
+    return loaded
+
+
+def test_signup_key_stores_the_key_returned_by_the_wallet_signup(monkeypatch, stored_config, ssh_setup_ok, keypair):
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append(url)
+        if url.endswith("/auth/wallet-challenge"):
+            return FakeResponse(200, {"nonce": "n-1", "message": "sign me", "expires_at": "2026-08-13T10:05:00"})
+        return FakeResponse(200, {"success": True, "api_key": "sk_wallet", "is_new_user": True})
+
+    monkeypatch.setattr(signup_actions.requests, "post", fake_post)
+
+    result = CliRunner().invoke(cli, ["signup-key", "--coldkey", "default", "--hotkey", "agent"])
+
+    assert result.exit_code == 0, result.output
+    assert stored_config["api.api_key"] == "sk_wallet"
+    assert [c.rsplit("/api", 1)[-1] for c in calls] == ["/auth/wallet-challenge", "/auth/wallet-signup"]
+
+
+def test_signup_key_signs_the_challenge_message_verbatim(monkeypatch, stored_config, ssh_setup_ok, keypair):
+    """The backend verifies the signature over the exact message it minted, as bare hex without 0x."""
+    message = "lium wallet challenge nonce=abc123 issued=2026-08-13T10:00:00"
+    sent = {}
+
+    def fake_post(url, **kwargs):
+        if url.endswith("/auth/wallet-challenge"):
+            sent["challenge"] = kwargs["json"]
+            return FakeResponse(200, {"nonce": "abc123", "message": message, "expires_at": "2026-08-13T10:05:00"})
+        sent["signup"] = kwargs["json"]
+        return FakeResponse(200, {"api_key": "sk_wallet"})
+
+    monkeypatch.setattr(signup_actions.requests, "post", fake_post)
+
+    result = CliRunner().invoke(
+        cli, ["signup-key", "--coldkey", "default", "--hotkey", "agent", "--name", "agent-01"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert keypair.signed == [message]
+    assert sent["challenge"] == {"address": ADDRESS}
+    assert sent["signup"] == {
+        "address": ADDRESS,
+        "nonce": "abc123",
+        "signature": "deadbeef",
+        "name": "agent-01",
+    }
+
+
+def test_signup_key_refuses_when_a_key_is_already_configured(monkeypatch, stored_config, ssh_setup_ok, keypair):
+    stored_config["api.api_key"] = "sk_existing"
+
+    def fail_post(url, **kwargs):
+        raise AssertionError("signup-key must not call the API when a key is already configured")
+
+    monkeypatch.setattr(signup_actions.requests, "post", fail_post)
+
+    result = CliRunner().invoke(cli, ["signup-key", "--coldkey", "default", "--hotkey", "agent"])
+
+    assert result.exit_code != 0
+    assert stored_config["api.api_key"] == "sk_existing"
+    assert "already configured" in " ".join(result.output.split())
+
+
+def test_signup_key_reports_a_wallet_that_cannot_be_opened(monkeypatch, stored_config, ssh_setup_ok):
+    """No keypair, no signature — the backend is never called."""
+    def missing_wallet(coldkey, hotkey):
+        raise ProviderError(f"could not open wallet name={coldkey!r} hotkey={hotkey!r}")
+
+    monkeypatch.setattr(signup_actions, "load_hotkey_keypair", missing_wallet)
+    monkeypatch.setattr(
+        signup_actions.requests, "post",
+        lambda url, **kwargs: (_ for _ in ()).throw(AssertionError("no wallet, no request")),
+    )
+
+    result = CliRunner().invoke(cli, ["signup-key", "--coldkey", "missing", "--hotkey", "agent"])
+
+    assert result.exit_code != 0
+    assert "could not open wallet" in " ".join(result.output.split())
+    assert "api.api_key" not in stored_config
+
+
+def test_signup_key_surfaces_an_address_already_registered(monkeypatch, stored_config, ssh_setup_ok, keypair):
+    def fake_post(url, **kwargs):
+        if url.endswith("/auth/wallet-challenge"):
+            return FakeResponse(200, {"nonce": "n-1", "message": "sign me"})
+        return FakeResponse(400, {"detail": {"address": "Wallet address already registered."}})
+
+    monkeypatch.setattr(signup_actions.requests, "post", fake_post)
+
+    result = CliRunner().invoke(cli, ["signup-key", "--coldkey", "default", "--hotkey", "agent"])
+
+    assert result.exit_code != 0
+    assert "Wallet address already registered." in " ".join(result.output.split())
+    assert "api.api_key" not in stored_config
+
+
+def test_signup_key_surfaces_an_expired_challenge(monkeypatch, stored_config, ssh_setup_ok, keypair):
+    """The challenge is single-use and lives 300 s; a stale one comes back as 401."""
+    def fake_post(url, **kwargs):
+        if url.endswith("/auth/wallet-challenge"):
+            return FakeResponse(200, {"nonce": "n-1", "message": "sign me"})
+        return FakeResponse(401, {"detail": {"challenge": "Invalid or expired wallet challenge."}})
+
+    monkeypatch.setattr(signup_actions.requests, "post", fake_post)
+
+    result = CliRunner().invoke(cli, ["signup-key", "--coldkey", "default", "--hotkey", "agent"])
+
+    assert result.exit_code != 0
+    assert "Invalid or expired wallet challenge." in " ".join(result.output.split())
+
+
+def test_signup_key_surfaces_a_rejected_address(monkeypatch, stored_config, ssh_setup_ok, keypair):
+    monkeypatch.setattr(
+        signup_actions.requests, "post",
+        lambda url, **kwargs: FakeResponse(400, {"detail": {"address": "Invalid SS58 address."}}),
+    )
+
+    result = CliRunner().invoke(cli, ["signup-key", "--coldkey", "default", "--hotkey", "agent"])
+
+    assert result.exit_code != 0
+    assert "Invalid SS58 address." in " ".join(result.output.split())
+
+
+def test_signup_key_surfaces_rate_limit(monkeypatch, stored_config, ssh_setup_ok, keypair):
+    def fake_post(url, **kwargs):
+        if url.endswith("/auth/wallet-challenge"):
+            return FakeResponse(200, {"nonce": "n-1", "message": "sign me"})
+        return FakeResponse(429, {"detail": "Too many requests."})
+
+    monkeypatch.setattr(signup_actions.requests, "post", fake_post)
+
+    result = CliRunner().invoke(cli, ["signup-key", "--coldkey", "default", "--hotkey", "agent"])
+
+    assert result.exit_code != 0
+    assert "Too many signups" in result.output
+
+
+def test_signup_key_announces_the_credit_the_same_way_the_email_signup_does(
+    monkeypatch, stored_config, ssh_setup_ok, keypair
+):
+    def fake_post(url, **kwargs):
+        if url.endswith("/auth/wallet-challenge"):
+            return FakeResponse(200, {"nonce": "n-1", "message": "sign me"})
+        return FakeResponse(200, {"api_key": "sk_wallet", "signup_credit_granted": True})
+
+    monkeypatch.setattr(signup_actions.requests, "post", fake_post)
+
+    result = CliRunner().invoke(cli, ["signup-key", "--coldkey", "default", "--hotkey", "agent"])
+
+    assert result.exit_code == 0, result.output
+    assert "$5 signup credit was granted" in result.output
+
+
+def test_signup_key_json_reports_the_address_and_the_key(monkeypatch, stored_config, ssh_setup_ok, keypair):
+    def fake_post(url, **kwargs):
+        if url.endswith("/auth/wallet-challenge"):
+            return FakeResponse(200, {"nonce": "n-1", "message": "sign me"})
+        return FakeResponse(200, {"api_key": "sk_wallet", "signup_credit_granted": False, "is_new_user": True})
+
+    monkeypatch.setattr(signup_actions.requests, "post", fake_post)
+
+    result = CliRunner().invoke(cli, ["signup-key", "--coldkey", "default", "--hotkey", "agent", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["address"] == ADDRESS
+    assert payload["api_key"] == "sk_wallet"
+    assert payload["signup_credit_granted"] is False
+    assert any("attach-email" in step for step in payload["next_steps"])

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "lium-io"
-version = "0.0.32"
+version = "0.0.33"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Two commands so an agent can onboard itself with the Bittensor wallet it already has, and attach a human's email later. Consumes the API from Datura-ai/lium-io-backend#913, which has to land first.

DAH-2654.

### `lium signup-key --coldkey <wallet> --hotkey <hotkey>`

Loads the hotkey from `~/.bittensor/wallets`, signs the challenge the backend mints, and trades the signature for an account plus its default API key — no email, no password, no human in the loop. It never generates a key: the wallet must already exist. Sets up the SSH key like the email flow and gets the same $5 credit under the same once-per-IP rule.

### `lium attach-email --email <address>`

Adds an email and password login to the account the stored API key belongs to, and mails a verification link. Prefer `LIUM_SIGNUP_PASSWORD` over `--password` — a flag value survives in shell history and `ps`. If the request dies in transport after the credential may already exist, the generated password is kept in the failure output rather than lost.

### Verification

16 new tests, each RED before its code. They assert the endpoint order, that the signature covers the challenge message verbatim, the exact request bodies, and that every backend error reaches the user unchanged. Suite: 439 passed, with the same 11 failures that already fail on untouched `main` (three of them shell out to a GitHub release that 404s).

The version bump is deliberately not here — it belongs to the release commit.
