### PR TITLE
Stop lium signup from claiming email verification blocks renting

### DIFF
--- a/lium/cli/signup/command.py
+++ b/lium/cli/signup/command.py
@@ -68,9 +68,10 @@ def signup_command(email: str, display_name: str | None, password: str | None, j
             "ssh_key_configured": ssh_result.ok,
             "signup_credit_granted": credit_granted,
             "next_steps": [
-                "Ask the user to click the verification link in the confirmation email — renting is blocked until then.",
                 _credit_line(credit_granted),
                 "Then: lium ls, lium up <node-id>.",
+                "The verification link in the confirmation email does not gate renting — it confirms "
+                "the address so password resets and account emails reach the user.",
             ],
         }, sort_keys=True))
         return
@@ -84,6 +85,8 @@ def signup_command(email: str, display_name: str | None, password: str | None, j
 
     ui.print("")
     ui.info("Before the first rental:")
-    ui.print("  1. Click the verification link in the confirmation email — renting is blocked until then.")
-    ui.print(f"  2. {_credit_line(credit_granted)}")
-    ui.print("  3. Then 'lium ls' and 'lium up <node-id>'.")
+    ui.print(f"  1. {_credit_line(credit_granted)}")
+    ui.print("  2. Then 'lium ls' and 'lium up <node-id>'.")
+    ui.print("")
+    ui.dim("  The verification link in the confirmation email does not gate renting — it confirms")
+    ui.dim("  the address so password resets and account emails reach you.")

--- a/test/test_signup_cli.py
+++ b/test/test_signup_cli.py
@@ -146,6 +146,8 @@ def test_signup_json_reports_credentials_and_next_steps(monkeypatch, stored_conf
     assert payload["email"] == "ada@example.com"
     assert payload["password"]
     assert any("verification link" in step for step in payload["next_steps"])
+    # DAH-2587 dropped the email_verified gate from the rent endpoints — balance is the only gate now
+    assert not any("renting is blocked" in step for step in payload["next_steps"])
 
 
 def test_signup_reports_credentials_when_the_key_cannot_be_read_back(monkeypatch, stored_config, ssh_setup_ok):


### PR DESCRIPTION
Follow-up to [DAH-2587](https://app.notion.com/p/Make-lium-io-signup-fully-agent-completable-no-manual-form-email-verification-3b3b8bfdbde981d6bdb3d99d414aa9bb), which removed the gate from the backend but left this copy describing it.

## Problem

A successful `lium signup` ends by telling the caller, in both the human output and `--json`:

> Click the verification link in the confirmation email — renting is blocked until then.

It is not blocked. In compute-app both rent endpoints — `POST /executors/{executor_uuid}/rent` and `POST /executors/cluster/rent` — depend on `checkUserBalanceApiKeyDeps` → `check_user_balance_api_key`, which carries the DAH-2587 comment "balance rules without the email_verified gate, so an agent can rent straight after a programmatic signup" and checks the balance and nothing else. The verification-carrying variants (`check_user_balance_and_verification`, `check_user_balance_and_verification_api_key`) still exist, but no route references either, so `403 "User is not verified"` is unreachable on rent.

The cost lands on exactly the caller DAH-2587 was for: an agent that just signed up non-interactively reads step 1 and stops to wait on a human, for a gate that is not there. The `signup-key` command on the DAH-2654 branch already words this correctly, so the two commands currently contradict each other.

## Fix

Balance is the only gate, so it becomes step 1, and verification moves out of the "before the first rental" list into a note saying what it is actually for:

```
Before the first rental:
  1. Check the balance with 'lium balance' and fund the account before renting.
  2. Then 'lium ls' and 'lium up <node-id>'.

  The verification link in the confirmation email does not gate renting — it confirms
  the address so password resets and account emails reach you.
```

`next_steps` in `--json` carries the same three entries in the same order.

`--email`'s help ("the verification link is sent there") is left alone: still true, and it claims no gate.

## Checked against compute-app `origin/master` @ `07e50bd1`

| Check | Result |
|---|---|
| `POST /executors/{executor_uuid}/rent` dependency | `checkUserBalanceApiKeyDeps` — `apps/server/src/routes/executor.py:207` |
| `POST /executors/cluster/rent` dependency | `checkUserBalanceApiKeyDeps` — `apps/server/src/routes/executor.py:114` |
| `check_user_balance_api_key` body | balance only: `"Invalid account balance. Please contact support."`, `"Insufficient balance"` |
| Routes referencing `check_user_balance_and_verification*` | none — `git grep` over `origin/master` finds only the definitions and the two `Depends(...)` aliases |
| What `email_verified` still does | set on confirm, cleared when the email changes; gates no route, not even `/users/request-reset-password` |

## Tests

```
pytest test/test_signup_cli.py -q   # 22 passed
pytest test/ -q                     # 423 passed, 11 failed — the same 11 fail on origin/main
```

`test_signup_json_reports_credentials_and_next_steps` gains one assertion so the claim cannot come back unnoticed.

## Other PRs

- Datura-ai/lium-skill#8 — the same stale claim in `SKILL.md` and `references/cli-commands.md`, plus the regenerated `llms-full.txt`.

## Risks

Copy only, no behaviour change. `lium/cli/signup/command.py` is also rewritten on the DAH-2654 branch (`signup-key` / `attach-email`), which still carries the old two lines — that branch will hit a small conflict here and should take this version.

A user who reads the new text and never confirms the address keeps renting fine, but password resets and account mail go to an address nobody proved is reachable. The note is there to say so.
